### PR TITLE
[TASK]: allow container execution with non root user

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,4 +19,6 @@ if [ "$(id -u)" -eq "0" ]; then
   chmod a+x /usr/local/bin/invocation.sh
 
   su - typo3 -c "/usr/local/bin/invocation.sh"
+else
+  sh -c "$@"
 fi


### PR DESCRIPTION
The container will switch by default to a non root user. When the user flag is used, we do need this logic. We can just execute as the provided user id.