### PR TITLE
[TASK] add first documentation setup

### DIFF
--- a/Documentation/Developer/Building.rst
+++ b/Documentation/Developer/Building.rst
@@ -1,0 +1,53 @@
+..  include:: ../Includes.rst.txt
+
+..  _Building:
+
+========
+Building
+========
+
+While the components of this repository are split into separate packages, it can
+be build as a stand alone application. We do provide 2 ways to use this project
+on your own device.
+
+Using Docker
+------------
+
+A docker image is available on github packages. If you want to build your own
+image you can use the following command, in the root of this repository.
+
+::
+
+    docker build -t typo3-docs:local .
+
+once the build is finished you can execute your fresh image using::
+
+  docker run --rm -v $(pwd):/project typo3-docs:local --progress
+
+Using PHP
+---------
+
+We do ship a phar_ binary with this repository. In short a phar file is an
+executable PHP file. You can run it like any other executable.
+
+To build the phar file we use box_, with some wrapper script. To build the phar
+file you can run the following command.
+
+::
+    composer run build:phar
+
+This will create a file called guides.phar in the build directory. You can execute
+the phar file like a php file using::
+
+    php build/guides.phar
+
+.. warning::
+
+    Currently box is not able to build a phar file for projects containing
+    composer plugins as it will only install production dependencies. This
+    means that the composer.json is modified during the build process. You shall
+    not commit this change to the repository.
+
+.. _phar: https://www.php.net/manual/en/intro.phar.php
+.. _box: https://box-project.github.io/box/
+.. _`github packages page`: https://github.com/TYPO3-Documentation/render-guides/pkgs/container/render-guides

--- a/Documentation/Developer/Building.rst
+++ b/Documentation/Developer/Building.rst
@@ -7,27 +7,27 @@ Building
 ========
 
 While the components of this repository are split into separate packages, it can
-be build as a stand alone application. We do provide 2 ways to use this project
+be build as a standalone application. Two ways are provided to use this project
 on your own device.
 
 Using Docker
 ------------
 
-A docker image is available on github packages. If you want to build your own
+A docker image is available on GitHub packages. If you want to build your own
 image you can use the following command, in the root of this repository.
 
 ::
 
     docker build -t typo3-docs:local .
 
-once the build is finished you can execute your fresh image using::
+Once the build is finished you can execute your fresh image using::
 
   docker run --rm -v $(pwd):/project typo3-docs:local --progress
 
 Using PHP
 ---------
 
-We do ship a phar_ binary with this repository. In short a phar file is an
+We do ship a phar_ binary with this repository. In short, a phar file is an
 executable PHP file. You can run it like any other executable.
 
 To build the phar file we use box_, with some wrapper script. To build the phar
@@ -37,7 +37,7 @@ file you can run the following command.
     composer run build:phar
 
 This will create a file called guides.phar in the build directory. You can execute
-the phar file like a php file using::
+the phar file like a PHP file using::
 
     php build/guides.phar
 

--- a/Documentation/Developer/Building.rst
+++ b/Documentation/Developer/Building.rst
@@ -27,7 +27,7 @@ Once the build is finished you can execute your fresh image using::
 Using PHP
 ---------
 
-We do ship a phar_ binary with this repository. In short, a phar file is an
+A phar_ binary is shipped with this repository. In short, a phar file is an
 executable PHP file. You can run it like any other executable.
 
 To build the phar file we use box_, with some wrapper script. To build the phar

--- a/Documentation/Developer/Directory-structure.rst
+++ b/Documentation/Developer/Directory-structure.rst
@@ -29,17 +29,17 @@ The ``.ddev`` directory contains the configuration for the local development env
 for people using DDEV.
 
 The ``.github`` directory contains the configuration for the GitHub workflows.
-Triggered by pull requests and pushes to the main branch. The main workflow
+They are triggered by pull requests and pushes to the main branch. The main workflow
 contains the quality assurance steps. The phar workflow builds the phar file on
 release and nightly builds. Same applies for the docker workflow on the docker side.
 
 The ``bin`` directory contains the executable scripts for the project. The file
 in there is needed for the phar build.
 
-The ``fixtures`` directory contains the fixtures for local developement tests.
+The ``fixtures`` directory contains the fixtures for local development tests.
 
-The ``packages`` directory contains the TYPO3 extensions. The ``typo3-docs-theme``
-extension contains the theme for the documentation, and typo3 specific directives.
+The ``packages`` directory contains the TYPO3-specific extensions. The ``typo3-docs-theme``
+extension contains the theme for the documentation, and TYPO3-specific directives.
 The ``typo3-guides-extension`` extension contains extensions on the base tool.
 This are customizations to make the tool fit the TYPO3 documentation needs.
 

--- a/Documentation/Developer/Directory-structure.rst
+++ b/Documentation/Developer/Directory-structure.rst
@@ -1,0 +1,51 @@
+..  include:: /Includes.rst.txt
+
+..  _directory_structure:
+
+===================
+Directory structure
+===================
+
+The directory structure of the project is as follows::
+
+    .
+    ├── .ddev
+    ├── .github
+    │   ├── workflows
+    │   │   ├── main.yml
+    │   │   ├── phar.yml
+    │   │   ├── docker.yml
+    ├── bin
+    ├── fixtures
+    ├── packages
+    │   ├── typo3-docs-theme
+    │   ├── typo3-guides-extension
+    ├── tests
+    │   ├── Integration
+    ├── tools
+
+
+The ``.ddev`` directory contains the configuration for the local development environment.
+for people using DDEV.
+
+The ``.github`` directory contains the configuration for the GitHub workflows.
+Triggered by pull requests and pushes to the main branch. The main workflow
+contains the quality assurance steps. The phar workflow builds the phar file on
+release and nightly builds. Same applies for the docker workflow on the docker side.
+
+The ``bin`` directory contains the executable scripts for the project. The file
+in there is needed for the phar build.
+
+The ``fixtures`` directory contains the fixtures for local developement tests.
+
+The ``packages`` directory contains the TYPO3 extensions. The ``typo3-docs-theme``
+extension contains the theme for the documentation, and typo3 specific directives.
+The ``typo3-guides-extension`` extension contains extensions on the base tool.
+This are customizations to make the tool fit the TYPO3 documentation needs.
+
+The ``tests`` directory contains the tests for the project. The integration tests
+are located in the ``Integration`` directory. During the integration tests the
+tool is executed as it was run by the user.
+
+The ``tools`` directory contains the tools needed for the project. Like scripts
+to build the phar file, or the docker image.

--- a/Documentation/Developer/Index.rst
+++ b/Documentation/Developer/Index.rst
@@ -1,0 +1,22 @@
+..  include:: ../Includes.rst.txt
+
+..  _Developers:
+
+==========
+Developers
+==========
+
+This part of the documentation is meant for developers working on the render-guides
+project. You will find information about the setup of the project and the release
+process.
+
+Under the hood this tool is based on `phpDocumentor/guides`_
+
+..  toctree::
+    :maxdepth: 2
+    :titlesonly:
+
+    Mono-repository
+    Directory-structure
+    Building
+    Theme-customization

--- a/Documentation/Developer/Index.rst
+++ b/Documentation/Developer/Index.rst
@@ -1,4 +1,4 @@
-..  include:: ../Includes.rst.txt
+..  include:: /Includes.rst.txt
 
 ..  _Developers:
 

--- a/Documentation/Developer/Mono-repository.rst
+++ b/Documentation/Developer/Mono-repository.rst
@@ -1,0 +1,34 @@
+..  include:: /Includes.rst.txt
+
+..  _mono-repository:
+
+===============
+Mono-repo setup
+===============
+
+This repository is following a mono-repo setup. This means all code and
+configuration to render documentation is in this repository. This includes
+scripts to build the documentation, the configuration for the CI/CD pipeline.
+
+Some packages in this repository can be used as stand-alone packages when not
+rendering documentation for typo3 but for internal company documentation.
+
+To ensure the mono-repo setup works, and also works in separate repositories,
+we are using a tool called `monorepo-builder`_. This tool will help us to keep the
+dependencies over packages in sync.
+
+If you add a new dependency to a package, you can run
+
+::
+
+    composer run monorepo:merge
+
+This will update the root composer.json file with the new dependency.
+
+We do recommend to run the validation check before you commit.
+
+::
+
+    composer run monorepo:validate
+
+.. _`monorepo-builder`: https://github.com/symplify/monorepo-builder

--- a/Documentation/Developer/Mono-repository.rst
+++ b/Documentation/Developer/Mono-repository.rst
@@ -8,10 +8,10 @@ Mono-repo setup
 
 This repository is following a mono-repo setup. This means all code and
 configuration to render documentation is in this repository. This includes
-scripts to build the documentation, the configuration for the CI/CD pipeline.
+scripts to build the documentation and the configuration for the CI/CD pipeline.
 
-Some packages in this repository can be used as stand-alone packages when not
-rendering documentation for typo3 but for internal company documentation.
+Some packages in this repository can be used as standalone packages when not
+rendering documentation for TYPO3 but for internal company documentation.
 
 To ensure the mono-repo setup works, and also works in separate repositories,
 we are using a tool called `monorepo-builder`_. This tool will help us to keep the

--- a/Documentation/Developer/Mono-repository.rst
+++ b/Documentation/Developer/Mono-repository.rst
@@ -25,7 +25,7 @@ If you add a new dependency to a package, you can run
 
 This will update the root composer.json file with the new dependency.
 
-We do recommend to run the validation check before you commit.
+It is recommended to run the validation check before you commit.
 
 ::
 

--- a/Documentation/Developer/Theme-customization.rst
+++ b/Documentation/Developer/Theme-customization.rst
@@ -6,7 +6,7 @@
 Theme Customization
 ===================
 
-The theme provided by this package is prepared to be integrated into the typo3
+The theme provided by this package is prepared to be integrated into the TYPO3 documentation
 website. Templates are written in twig_ and uses components provided by
 `phpDocumentor/guides`_. The theme is using bootstrap_ as a base framework.
 

--- a/Documentation/Developer/Theme-customization.rst
+++ b/Documentation/Developer/Theme-customization.rst
@@ -1,0 +1,27 @@
+..  include:: /Includes.rst.txt
+
+..  _theme-customization:
+
+===================
+Theme Customization
+===================
+
+The theme provided by this package is prepared to be integrated into the typo3
+website. Templates are written in twig_ and uses components provided by
+`phpDocumentor/guides`_. The theme is using bootstrap_ as a base framework.
+
+To customize the components provided by `phpDocumentor/guides`_ you have to follow
+the directory structure of the templates provided by this package. Every template
+can be overwritten by creating a new template with the same name in the same
+directory. The template engine will automatically use the new template.
+
+In the template you always have the current ``node`` available. This node is the
+element that is currently rendered. The node is an instance of
+``phpDocumentor\Guides\Nodes\Node``. Every template has a different specialized
+node. Consult the template of the node to see which properties are available.
+
+When you are creating a template for a node that is a container (like a chapter)
+you can access the children of the node by using ``node.children``. This is an
+array of nodes. You can iterate over this array to render the children using the
+``render_node`` function. This function will render the node using the correct
+template.

--- a/Documentation/Developer/Theme-customization.rst
+++ b/Documentation/Developer/Theme-customization.rst
@@ -6,9 +6,11 @@
 Theme Customization
 ===================
 
-The theme provided by this package is prepared to be integrated into the TYPO3 documentation
-website. Templates are written in twig_ and uses components provided by
-`phpDocumentor/guides`_. The theme is using bootstrap_ as a base framework.
+The theme provided by this package is prepared to be integrated into the TYPO3
+documentation website. Templates are written in twig_ and uses components
+provided by `phpDocumentor/guides`_. The theme is using bootstrap_ as a
+base framework. You can find the theme in ``packages/typo3-docs-theme``. Templates
+can be found in ``packages/typo3-docs-theme/resource/template``.
 
 To customize the components provided by `phpDocumentor/guides`_ you have to follow
 the directory structure of the templates provided by this package. Every template

--- a/Documentation/Includes.rst.txt
+++ b/Documentation/Includes.rst.txt
@@ -1,0 +1,4 @@
+
+.. _`phpDocumentor/guides`: https://github.com/phpDocumentor/guides/
+..  _twig: https://twig.symfony.com/
+.. _bootstrap: https://getbootstrap.com/

--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -2,9 +2,9 @@
 
 .. _start:
 
-=========
-<project>
-=========
+=============
+Render guides
+=============
 
 :Package name:
     render-guides

--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -1,69 +1,55 @@
+..  include:: /Includes.rst.txt
 
-=============
-render-guides
-=============
+.. _start:
 
-Mono-repo setup
-===============
+=========
+<project>
+=========
 
-This repository is following a mono-repo setup. This means all code and
-configuration to render documentation is in this repository. This includes
-scripts to build the documentation, the configuration for the CI/CD pipeline.
+:Package name:
+    render-guides
 
-To ensure the mono-repo setup works, and also works in separate repositories,
-we are using a tool called monorepo-builder_. This tool will help us to keep the
-dependencies over packages in sync.
+:Version:
+    |release|
 
-If you add a new dependency to a package, you can run
+:Language:
+    en
 
-::
-    composer run monorepo:merge
+:Author:
+    TYPO3 contributors
 
-This will update the root composer.json file with the new dependency.
+:License:
+    This document is published under the
+    `Creative Commons BY 4.0 <https://creativecommons.org/licenses/by/4.0/>`__
+    license.
 
-We do recommend to run the validation check before you commit.
+:Rendered:
+    |today|
 
-::
-    composer run monorepo:validate
+----
 
-.. _monorepo-builder: https://github.com/symplify/monorepo-builder
+This guide contains information about the render-guides tool and how to use it
+as a documentation writer. It also contains information for developers who want
+to extend the tool.
 
-Building
-========
+----
 
-While the components of this repository are split into separate packages, it can
-be build as a stand alone application. We do provide 2 ways to use this project
-on your own device.
+**Table of Contents:**
 
-Using Docker
-------------
+..  toctree::
+    :maxdepth: 2
+    :titlesonly:
 
-A docker image is available on github packages. If you want to build your own
-image you can use the following command, in the root of this repository.
+    Introduction/Index
+    Installation/Index
+    Configuration/Index
+    Developer/Index
+    KnownProblems/Index
 
-::
-    docker build -t render-guides:local .
+..  Meta Menu
 
-Using PHP
----------
+..  toctree::
+    :hidden:
 
-We do ship a phar_ binary with this repository. In short a phar file is an
-executable PHP file. You can run it like any other executable.
-
-To build the phar file we use box_, with some wrapper script. To build the phar
-file you can run the following command.
-
-::
-    composer run build:phar
-
-This will create a file called guides.phar in the build directory.
-
-.. warning::
-
-    Currently box is not able to build a phar file for projects containing
-    composer plugins as it will only install production dependencies. This
-    means that the composer.json is modified during the build process. You shall
-    not commit this change to the repository.
-
-.. _phar: https://www.php.net/manual/en/intro.phar.php
-.. _box: https://box-project.github.io/box/
+    Sitemap
+    genindex

--- a/Documentation/Installation/Index.rst
+++ b/Documentation/Installation/Index.rst
@@ -8,9 +8,7 @@ Installation
 
 This project is not a TYPO3 extension, but a standalone application
 used to render documentation. If you want to learn more about how to write
-documentation, please check the TYPO3 documentation website.
-
-.. add a link to the typo3 website using interlinking?
+documentation, please check the :ref:`Contributing Guide - How to Document <2document:contribute>`.
 
 Two methods are provided to install the project on your local machine.
 

--- a/Documentation/Installation/Index.rst
+++ b/Documentation/Installation/Index.rst
@@ -8,7 +8,7 @@ Installation
 
 This project is not a TYPO3 extension, but a standalone application
 used to render documentation. If you want to learn more about how to write
-documentation, please check the :ref:`Contributing Guide - How to Document <2document:contribute>`.
+documentation, please check the :ref:`Contributing Guide - How to Document <h2document:contribute>`.
 
 Two methods are provided to install the project on your local machine.
 

--- a/Documentation/Installation/Index.rst
+++ b/Documentation/Installation/Index.rst
@@ -1,4 +1,4 @@
-..  include:: ../Includes.rst.txt
+..  include:: /Includes.rst.txt
 
 ..  _installation:
 
@@ -6,13 +6,13 @@
 Installation
 =============
 
-This project is not an typo3 extension, but a stand alone application.
+This project is not a TYPO3 extension, but a standalone application
 used to render documentation. If you want to learn more about how to write
-documentation, please check the typo3 website.
+documentation, please check the TYPO3 documentation website.
 
 .. add a link to the typo3 website using interlinking?
 
-We provide 2 methods to install the project on your local machine.
+Two methods are provided to install the project on your local machine.
 
 - Using Docker
 - Using PHP
@@ -26,7 +26,7 @@ We provide 2 methods to install the project on your local machine.
 Docker
 ------
 
-The docker image is available on github packages. You can pull the image with
+The docker image is available on GitHub packages. You can pull the image with
 the following command.
 
 ::
@@ -34,7 +34,7 @@ the following command.
     docker pull ghcr.io/typo3-documentation/render-guides:main
 
 For all available tags, please check the `github packages page`_.
-Once you have pulled the image, you can run the image to render your projects documentation.
+Once you have pulled the image, you can run the image to render your project's documentation.
 
 ::
 

--- a/Documentation/Installation/Index.rst
+++ b/Documentation/Installation/Index.rst
@@ -1,0 +1,52 @@
+..  include:: ../Includes.rst.txt
+
+..  _installation:
+
+=============
+Installation
+=============
+
+This project is not an typo3 extension, but a stand alone application.
+used to render documentation. If you want to learn more about how to write
+documentation, please check the typo3 website.
+
+.. add a link to the typo3 website using interlinking?
+
+We provide 2 methods to install the project on your local machine.
+
+- Using Docker
+- Using PHP
+
+.. note::
+
+    The docker image is the recommended way to use this project. It will
+    automatically install all dependencies and will not interfere with your
+    local PHP installation.
+
+Docker
+------
+
+The docker image is available on github packages. You can pull the image with
+the following command.
+
+::
+
+    docker pull ghcr.io/typo3-documentation/render-guides:main
+
+For all available tags, please check the `github packages page`_.
+Once you have pulled the image, you can run the image to render your projects documentation.
+
+::
+
+    docker run --rm -v $(pwd):/project ghcr.io/typo3-documentation/render-guides:main --progress
+
+Unlike other docker images this image will detect the owner-user of the mounted
+project. This means that the files created by the docker image will have the
+same owner as the files in your project. No more permission issues.
+
+PHP
+---
+
+<TBD>
+
+.. _`github packages page`: https://github.com/TYPO3-Documentation/render-guides/pkgs/container/render-guides

--- a/Documentation/Introduction/Index.rst
+++ b/Documentation/Introduction/Index.rst
@@ -1,0 +1,17 @@
+..  include:: ../Includes.rst.txt
+
+..  _introduction:
+
+============
+Introduction
+============
+
+This is the documentation rendering tool for Typo3 projects. It is based on
+`phpDocumentor/guides`_ and can be used as a drop-in replacement for sphinx.
+The tool is used by the auotmated documentation rendering system of the
+TYPO3 project. And can be used by documentation authors to validate their
+documentation.
+
+.. Note::
+
+    This tool is still in development, there will be bugs and missing features.

--- a/Documentation/Introduction/Index.rst
+++ b/Documentation/Introduction/Index.rst
@@ -6,9 +6,9 @@
 Introduction
 ============
 
-This is the documentation rendering tool for Typo3 projects. It is based on
-`phpDocumentor/guides`_ and can be used as a drop-in replacement for sphinx.
-The tool is used by the auotmated documentation rendering system of the
+This is the documentation rendering tool for TYPO3 projects. It is based on
+`phpDocumentor/guides`_ and can be used as a drop-in replacement for Sphinx.
+The tool is used by the automated documentation rendering system of the
 TYPO3 project. And can be used by documentation authors to validate their
 documentation.
 

--- a/Documentation/KnownProblems/Index.rst
+++ b/Documentation/KnownProblems/Index.rst
@@ -6,9 +6,5 @@
 Known problems
 ==============
 
-Use this section for informing about any type of of problem.
-
-This extension does not offer anything ... and it is not in the scope of intended usage..
-
 Find a list of `open issues on Github
 <https://github.com/TYPO3-Documentation/render-guides/issues>`__.

--- a/Documentation/KnownProblems/Index.rst
+++ b/Documentation/KnownProblems/Index.rst
@@ -1,0 +1,14 @@
+..  include:: ../Includes.rst.txt
+
+..  _known-problems:
+
+==============
+Known problems
+==============
+
+Use this section for informing about any type of of problem.
+
+This extension does not offer anything ... and it is not in the scope of intended usage..
+
+Find a list of `open issues on Github
+<https://github.com/TYPO3-Documentation/render-guides/issues>`__.

--- a/Makefile
+++ b/Makefile
@@ -62,5 +62,9 @@ vendor: composer.json composer.lock
 	composer validate --no-check-publish
 	composer install --no-interaction --no-progress  --ignore-platform-reqs
 
+.PHONY: docs
+docs: ## Generate projects docs
+	$(PHP_BIN) vendor/bin/guides -vvv --no-progress Documentation
+
 .PHONY: pre-commit-test
 pre-commit-test: fix-code-style test code-style static-code-analysis test-monorepo

--- a/composer.lock
+++ b/composer.lock
@@ -1172,12 +1172,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/guides-core.git",
-                "reference": "f22d9beb6f5705b53978ca6537d0322cf70033ed"
+                "reference": "9cd66cb23bb2697f34c7e47245255ed2ce002891"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/guides-core/zipball/f22d9beb6f5705b53978ca6537d0322cf70033ed",
-                "reference": "f22d9beb6f5705b53978ca6537d0322cf70033ed",
+                "url": "https://api.github.com/repos/phpDocumentor/guides-core/zipball/9cd66cb23bb2697f34c7e47245255ed2ce002891",
+                "reference": "9cd66cb23bb2697f34c7e47245255ed2ce002891",
                 "shasum": ""
             },
             "require": {
@@ -1214,7 +1214,7 @@
                 "issues": "https://github.com/phpDocumentor/guides-core/issues",
                 "source": "https://github.com/phpDocumentor/guides-core/tree/main"
             },
-            "time": "2023-11-07T21:16:22+00:00"
+            "time": "2023-11-09T16:28:28+00:00"
         },
         {
             "name": "phpdocumentor/guides-cli",
@@ -1222,12 +1222,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/guides-cli.git",
-                "reference": "79b315de6f0fba94619a49a7d909779486d9fc11"
+                "reference": "5bdb46c43d7ab8999614ea4ad0c8c01c8e6cf44a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/guides-cli/zipball/79b315de6f0fba94619a49a7d909779486d9fc11",
-                "reference": "79b315de6f0fba94619a49a7d909779486d9fc11",
+                "url": "https://api.github.com/repos/phpDocumentor/guides-cli/zipball/5bdb46c43d7ab8999614ea4ad0c8c01c8e6cf44a",
+                "reference": "5bdb46c43d7ab8999614ea4ad0c8c01c8e6cf44a",
                 "shasum": ""
             },
             "require": {
@@ -1264,7 +1264,7 @@
             "support": {
                 "source": "https://github.com/phpDocumentor/guides-cli/tree/main"
             },
-            "time": "2023-11-07T19:39:53+00:00"
+            "time": "2023-11-09T14:52:19+00:00"
         },
         {
             "name": "phpdocumentor/guides-graphs",
@@ -6355,5 +6355,5 @@
         "php": "^8.1"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/guides.xml
+++ b/guides.xml
@@ -20,6 +20,8 @@
             <class>\T3Docs\PhpDomain\DependencyInjection\PhpDomainExtension</class>
         </phpdomain>
     </extensions>
-    <inventory id="h2document" url="https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/" />
+    <inventories>
+        <inventory id="h2document" url="https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/" />
+    </inventories>
     <theme>typo3docs</theme>
 </guides>

--- a/guides.xml
+++ b/guides.xml
@@ -20,5 +20,6 @@
             <class>\T3Docs\PhpDomain\DependencyInjection\PhpDomainExtension</class>
         </phpdomain>
     </extensions>
+    <inventory id="h2document" url="https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/" />
     <theme>typo3docs</theme>
 </guides>


### PR DESCRIPTION
Following the default setup of other documentation projects this patch adss a first set of documentation to help future developer to maintain and improve the project.

More documentation is needed. But we should also link to the guides documentation. That needs to be written and published.