### PR TITLE
[DOCS] Fix docker command in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ Usage with Docker
 
 ::
     mkdir Documentation-GENERATED-temp
-    docker run --rm --pull always -v $(pwd):/project -it ghcr.io/typo3-documentation/render-guides:main Documentation Documentation-GENERATED-temp
+    docker run --rm --pull always -v $(pwd):/project -it ghcr.io/typo3-documentation/render-guides:main --output Documentation-GENERATED-temp Documentation
 
 Contributing
 ============


### PR DESCRIPTION
Currently, running the command fails with the error:

    Too many arguments, expected arguments "input".