### PR TITLE
[TASK] relocate config to Documentation

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,13 @@ description: 'Documentation render tool for typo3 documentation'
 inputs:
   input:
     description: 'Input directory'
+    required: false
+    default: null
+
+  config:
+    description: 'Configuration file location'
     default: 'Documentation'
+
   output:
     description: 'Output directory'
     default: 'RenderedDocumentation'
@@ -13,8 +19,9 @@ runs:
   using: 'docker'
   image: 'docker://ghcr.io/typo3-documentation/render-guides:main'
   args:
-    - '${{ inputs.input }}'
+    - '--config=${{ inputs.config }}'
     - '--output=${{ inputs.output }}'
+    - '${{ inputs.input }}'
 
 branding:
   icon: 'book-open'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,19 +6,25 @@ if [ "$(id -u)" -eq "0" ]; then
   UID=$(stat -c "%u" $(pwd))
   GID=$(stat -c "%g" $(pwd))
 
-  addgroup typo3 --gid=$GID;
-  adduser -h $(pwd) -D -G typo3 --uid=$UID typo3;
+  if [ "$UID" -eq "0" ]; then
+        echo "Could not detect the owner of $(pwd) did you mount your project?."
+        echo "Run this container with \"docker run --rm  --volume \${PWD}:/project ghcr.io/typo3-documentation/render-guides:main\""
+        exit 1
+  else
+      addgroup typo3 --gid=$GID;
+      adduser -h $(pwd) -D -G typo3 --uid=$UID typo3;
 
-  # su behaves inconsistently with -c followed by flags
-  # Workaround: run the entrypoint and commands as a standalone script
-  echo "#!/usr/bin/env sh" >> /usr/local/bin/invocation.sh
-  echo >> /usr/local/bin/invocation.sh
-  for ARG in "$@"; do
-      printf "\"${ARG}\" " >> /usr/local/bin/invocation.sh
-  done
-  chmod a+x /usr/local/bin/invocation.sh
+      # su behaves inconsistently with -c followed by flags
+      # Workaround: run the entrypoint and commands as a standalone script
+      echo "#!/usr/bin/env sh" >> /usr/local/bin/invocation.sh
+      echo >> /usr/local/bin/invocation.sh
+      for ARG in "$@"; do
+          printf "${ARG} " >> /usr/local/bin/invocation.sh
+      done
+      chmod a+x /usr/local/bin/invocation.sh
 
-  su - typo3 -c "/usr/local/bin/invocation.sh"
+      su - typo3 -c "/usr/local/bin/invocation.sh"
+  fi
 else
   sh -c "$@"
 fi


### PR DESCRIPTION
The default location for guides.xml is Documentation, people might decide to do it different, so make it configurable.

I update the entrypoint to fix an issue when the input argument was omitted. The previous implementation did quote all arguments. But that broke the optional input argument as it would always be `""` when left empty. 

While testing this behavior I found another issue, that was giving some odd errors when a user does not specify a volume, we to now exit with an error message. 