### PR TITLE
[DOCS] Fix codeblock

### DIFF
--- a/Documentation/Developer/Building.rst
+++ b/Documentation/Developer/Building.rst
@@ -34,6 +34,7 @@ To build the phar file we use box_, with some wrapper script. To build the phar
 file you can run the following command.
 
 ::
+
     composer run build:phar
 
 This will create a file called guides.phar in the build directory. You can execute


### PR DESCRIPTION
There always has to be an empty line after the two collons