### PR TITLE
[TASK] Add guides.xml in the documentation dir

### DIFF
--- a/Documentation/guides.xml
+++ b/Documentation/guides.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<guides
+    xmlns="https://www.phpdoc.org/guides"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://www.phpdoc.org/guides ../vendor/phpdocumentor/guides-cli/resources/schema/guides.xsd"
+>
+    <project title="Render guides" />
+</guides>

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ vendor: composer.json composer.lock
 
 .PHONY: docs
 docs: ## Generate projects docs
-	$(PHP_BIN) vendor/bin/guides -vvv --no-progress Documentation
+	$(PHP_BIN) vendor/bin/guides -vvv --no-progress --config=Documentation
 
 .PHONY: pre-commit-test
 pre-commit-test: fix-code-style test code-style static-code-analysis test-monorepo

--- a/guides.xml
+++ b/guides.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<guides links-are-relative="true">
+<guides
+    xmlns="https://www.phpdoc.org/guides"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://www.phpdoc.org/guides vendor/phpdocumentor/guides-cli/resources/schema/guides.xsd"
+    links-are-relative="true"
+>
     <extensions>
         <bootstrap>
             <class>\phpDocumentor\Guides\Bootstrap\DependencyInjection\BootstrapExtension</class>


### PR DESCRIPTION
Guides.xml at root level is used as default for all projects, our specific config is in Documentation.