### PR TITLE
[TASK] set mem limit in docker to 1G

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ COPY . /opt/guides
 WORKDIR /opt/guides
 
 COPY --from=Builder /opt/guides/vendor /opt/guides/vendor
+RUN echo "memory_limit=1G" >> /usr/local/etc/php/conf.d/typo3.ini
 
 WORKDIR /project
 ENTRYPOINT [ "/opt/guides/entrypoint.sh", "/opt/guides/vendor/bin/guides"]

--- a/Makefile
+++ b/Makefile
@@ -67,5 +67,8 @@ vendor: composer.json composer.lock
 docs: ## Generate projects docs
 	$(PHP_BIN) vendor/bin/guides -vvv --no-progress Documentation
 
+docker-build: ## Build docker image for local debugging
+	docker build -t typo3-docs:local .
+
 .PHONY: pre-commit-test
 pre-commit-test: fix-code-style test code-style static-code-analysis test-monorepo


### PR DESCRIPTION
The single page format requires a bit more memory because all html is kept in memory during rendering.