### PR TITLE
[TASK] Enforce regex validation link

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
         "phpstan/phpstan-strict-rules": "^1.5",
         "phpunit/phpunit": "^10.4",
         "symplify/monorepo-builder": "^11.2",
+        "symplify/phpstan-rules": "^12.4",
         "typo3/coding-standards": "^0.7.1"
     },
     "replace": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f38ba322d2655be2583c8339dce77a9f",
+    "content-hash": "e9b44c69780943569e8d89432562a530",
     "packages": [
         {
             "name": "dflydev/dot-access-data",
@@ -6206,6 +6206,61 @@
                 }
             ],
             "time": "2023-10-20T06:31:52+00:00"
+        },
+        {
+            "name": "symplify/phpstan-rules",
+            "version": "12.4.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symplify/phpstan-rules.git",
+                "reference": "54def05dea85612c8c7729933ba5457dbd3eed64"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symplify/phpstan-rules/zipball/54def05dea85612c8c7729933ba5457dbd3eed64",
+                "reference": "54def05dea85612c8c7729933ba5457dbd3eed64",
+                "shasum": ""
+            },
+            "require": {
+                "nette/utils": "^3.2 || ^4.0",
+                "nikic/php-parser": "^4.17.1",
+                "php": "^7.2|^8.0",
+                "phpstan/phpstan": "^1.10.30",
+                "webmozart/assert": "^1.11"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "config/services/services.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symplify\\PHPStanRules\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Set of Symplify rules for PHPStan",
+            "support": {
+                "issues": "https://github.com/symplify/phpstan-rules/issues",
+                "source": "https://github.com/symplify/phpstan-rules/tree/12.4.3"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.me/rectorphp",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/tomasvotruba",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-10-19T08:45:51+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/packages/php-domain/src/PhpDomain/FullyQualifiedNameService.php
+++ b/packages/php-domain/src/PhpDomain/FullyQualifiedNameService.php
@@ -9,8 +9,15 @@ use T3Docs\PhpDomain\Nodes\PhpNamespaceNode;
 
 class FullyQualifiedNameService
 {
-    private const BASE_NAME_PATTERN = '/^[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*$/';
-    public const FULL_NAME_PATTERN = '/^(.+\\\\)([^\\\\]+)$/';
+    /**
+     * @see https://regex101.com/r/j89USB/1
+     */
+    private const BASE_NAME_PATTERN_REGEX = '/^[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*$/';
+
+    /**
+     * @see https://regex101.com/r/bt7r5S/1
+     */
+    public const FULL_NAME_PATTERN_REGEX = '/^(.+\\\\)([^\\\\]+)$/';
 
     public function __construct(
         private readonly NamespaceRepository $namespaceRepository
@@ -21,11 +28,11 @@ class FullyQualifiedNameService
      */
     public function isFullyQualifiedName(string $name, array &$matches): bool
     {
-        return (bool)preg_match(self::FULL_NAME_PATTERN, $name, $matches);
+        return (bool)preg_match(self::FULL_NAME_PATTERN_REGEX, $name, $matches);
     }
     public function isBaseName(string $name): bool
     {
-        return (bool)preg_match(self::BASE_NAME_PATTERN, $name);
+        return (bool)preg_match(self::BASE_NAME_PATTERN_REGEX, $name);
     }
 
     public function getFullyQualifiedName(string $name, bool $useCurrentNamespace = false): FullyQualifiedNameNode

--- a/packages/php-domain/src/TextRoles/InterfaceTextRole.php
+++ b/packages/php-domain/src/TextRoles/InterfaceTextRole.php
@@ -14,7 +14,13 @@ use Psr\Log\LoggerInterface;
 
 final class InterfaceTextRole implements TextRole
 {
+    /**
+     * @see https://regex101.com/r/OyN05v/1
+     */
+    private const INTERFACE_NAME_REGEX = '/^([a-zA-Z0-9]+):(.*$)/';
+
     private readonly InlineLexer $lexer;
+
     public function __construct(
         private readonly LoggerInterface $logger,
         private readonly AnchorReducer $anchorReducer,
@@ -95,8 +101,7 @@ final class InterfaceTextRole implements TextRole
     /** @return ReferenceNode */
     protected function createNode(string $referenceTarget, string|null $referenceName, string $role): AbstractLinkInlineNode
     {
-        $pattern = '/^([a-zA-Z0-9]+):(.*$)/';
-        if (preg_match($pattern, $referenceTarget, $matches)) {
+        if (preg_match(self::INTERFACE_NAME_REGEX, $referenceTarget, $matches)) {
             $interlinkDomain = $matches[1];
             $id = $this->anchorReducer->reduceAnchor($matches[2]);
         } else {

--- a/packages/typo3-docs-theme/src/Directives/YoutubeDirective.php
+++ b/packages/typo3-docs-theme/src/Directives/YoutubeDirective.php
@@ -24,6 +24,12 @@ use T3Docs\Typo3DocsTheme\Nodes\YoutubeNode;
 
 class YoutubeDirective extends BaseDirective
 {
+    /**
+     * @see https://www.wikidata.org/wiki/Property:P1651#P8966
+     * @see https://regex101.com/r/aKvAce/1
+     */
+    private const YOUTUBE_IDENTIFIER_REGEX = '/^[a-zA-Z0-9_-]{11}$/';
+
     public function __construct(
         private readonly LoggerInterface $logger
     ) {}
@@ -38,7 +44,7 @@ class YoutubeDirective extends BaseDirective
         Directive $directive,
     ): Node {
         $videoId = trim($directive->getData());
-        if (!preg_match('/^[a-zA-Z0-9_-]{11}$/', $videoId)) {
+        if (!preg_match(self::YOUTUBE_IDENTIFIER_REGEX, $videoId)) {
             $this->logger->warning(sprintf('The following youtube id is not valid: %s', $videoId), $blockContext->getLoggerInformation());
             return new ParagraphNode([InlineCompoundNode::getPlainTextInlineNode('Video cannot be displayed')]);
         }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,8 @@
 includes:
   - phpstan-baseline.neon
+rules:
+  - Symplify\PHPStanRules\Rules\AnnotateRegexClassConstWithRegexLinkRule
+  - Symplify\PHPStanRules\Rules\RegexSuffixInRegexConstantRule
 parameters:
   phpVersion: 80100
   level: max


### PR DESCRIPTION
With the help of the phpstan rule "AnnotateRegexClassConstWithRegexLinkRule" a link is necessary for easy access what a regex does and which strings are validated or not. This makes is easier to grasp a regex syntax and to avoid errors.

Regexes have to be a constant with the suffix _REGEX.