### PR TITLE
[BUGFIX] Fix failing regex validation

### DIFF
--- a/packages/php-domain/src/PhpDomain/MethodNameService.php
+++ b/packages/php-domain/src/PhpDomain/MethodNameService.php
@@ -9,7 +9,9 @@ use T3Docs\PhpDomain\Nodes\MethodNameNode;
 
 class MethodNameService
 {
-    /** https://regex101.com/r/QrrSXk/1 */
+    /**
+     * @see https://regex101.com/r/QrrSXk/1
+     */
     private const METHOD_SIGNATURE_REGEX = '/^\s*(\w+)\s*\(\s*(.*?)\s*\)\s*(?::\s*(\w+))?\s*$/';
 
     public function __construct(


### PR DESCRIPTION
This fixes the phpstan error:

    ------ -----------------------------------------------------------------------
     Line   php-domain/src/PhpDomain/MethodNameService.php
    ------ -----------------------------------------------------------------------
     13     Add regex101.com link to that shows the regex in practise, so it will
            be easier to maintain in case of bug/extension in the future
    ------ -----------------------------------------------------------------------

Related: #66 
Related: #68 