### PR TITLE
[DOCS] Document "docker run" issues with macOS, where "--user" is required

### DIFF
--- a/Documentation/Developer/Building.rst
+++ b/Documentation/Developer/Building.rst
@@ -24,6 +24,10 @@ Once the build is finished you can execute your own image using::
 
   docker run --rm -v $(pwd):/project typo3-docs:local --progress
 
+For macOS you also need to specify the argument ``user``::
+
+  docker run --rm -v $(pwd):/project --user=$(id -u):$(id -g) typo3-docs:local --progress
+
 Using PHP
 ---------
 

--- a/Documentation/Installation/Index.rst
+++ b/Documentation/Installation/Index.rst
@@ -48,6 +48,12 @@ project. This means that the files created by the Docker image will have the
 same owner as the files in your project. No more permission issues should occur,
 when files are getting generated inside the image.
 
+This may fail on macOS, in which case you need to specify the `user` argument:
+
+::
+
+    docker run --rm --user=$(id -u):$(id -g) -v $(pwd):/project ghcr.io/typo3-documentation/render-guides:main --progress --config ./Documentation
+
 Another way to utilize Docker is to create your own image/container. This is aimed at people
 who want to contribute to the underlying Documentation tool. Please see :ref:`_Building`
 for those steps.

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ PHP_PROJECT_BIN ?= docker run -i --rm --user $$(id -u):$$(id -g) -v${PWD}:/proje
 PHP_COMPOSER_BIN ?= docker run -i --rm --user $$(id -u):$$(id -g) -v${PWD}:/app composer:2
 
 ## These variables can be overriden by other tasks, i.e. by `make PHP_ARGS=-d memory_limit=2G pre-commit-tests`.
+## The "--user" argument is required for macOS to pass along ownership of /project
 
 ## NOTE: Dependencies listed here (PHP 8.1, composer 2) need to be kept
 ##       in sync with those inside the Dockerfile and composer.json

--- a/README.rst
+++ b/README.rst
@@ -22,6 +22,7 @@ Usage with Docker (via supplied container)
 
     # Execute the Docker container that is provided remotely.
     # Renders all files in the `Documentation` and store in `Documentation-GENERATED-temp`.
+    # On macOS you need to specify the parameter "--user=$(id -u):$(id -g)"
     docker run --rm --pull always -v $(pwd):/project -it ghcr.io/typo3-documentation/render-guides:main --progress
 
 (see :ref:`_Setup_Docker:Docker containers` for complete documentation)
@@ -35,7 +36,8 @@ Usage with Docker (via custom container)
     docker build --file Dockerfile --tag typo3-docs:local .
 
     # Execute the Docker container that is provided locally, build Documentation
-    docker run --rm --user=$(id -u):$(id -g) --volume ${PWD}:/project typo3-docs:local --progress
+    # On macOS you need to specify the parameter "--user=$(id -u):$(id -g)"
+    docker run --rm -v ${PWD}:/project -it typo3-docs:local --progress
 
 (see :ref:`_Setup_Docker:Docker containers` for complete documentation)
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,8 +7,14 @@ if [ "$(id -u)" -eq "0" ]; then
   GID=$(stat -c "%g" $(pwd))
 
   if [ "$UID" -eq "0" ]; then
-        echo "Could not detect the owner of $(pwd) did you mount your project?."
-        echo "Run this container with \"docker run --rm  --volume \${PWD}:/project ghcr.io/typo3-documentation/render-guides:main\""
+        echo "ERROR: Could not detect the owner of $(pwd) - did you mount your project?"
+        echo ""
+        echo "Run this container with:"
+        echo "\"docker run --rm --volume \${PWD}:/project ghcr.io/typo3-documentation/render-guides:main\""
+        echo ""
+        echo "On macOS you might need to specify the user:"
+        echo "\"docker run --rm --volume --user=\$(id -u):\$(id -g) \${PWD}:/project ghcr.io/typo3-documentation/render-guides:main\""
+        echo ""
         exit 1
   else
       addgroup typo3 --gid=$GID;

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env sh
 
-
+# TODO: This detection seems to fail on macOS. If no "--user" argument is specified to make Docker run
+#       as that user, it cannot deduce ownership properly. Probably the Dockerfile needs to be adapted
+#       so that a user-switch to the "typo3" user is done? This can have side-effects though.
 if [ "$(id -u)" -eq "0" ]; then
 
   UID=$(stat -c "%u" $(pwd))
@@ -22,7 +24,7 @@ if [ "$(id -u)" -eq "0" ]; then
 
       # su behaves inconsistently with -c followed by flags
       # Workaround: run the entrypoint and commands as a standalone script
-      echo "#!/usr/bin/env sh" >> /usr/local/bin/invocation.sh
+      echo "#!/usr/bin/env sh" > /usr/local/bin/invocation.sh
       echo >> /usr/local/bin/invocation.sh
       for ARG in "$@"; do
           printf "${ARG} " >> /usr/local/bin/invocation.sh


### PR DESCRIPTION
Docker on macOS runs as root. If the entrypoint.sh is then executed, it sees that the `/project` directory is also mounted as root.

In that case, the script fails because it seems to expect that `/project` should belong to a specific user. However, the `Dockerfile` does currently NOT fix the workspace to a user like `typo3`.

Thus, the script only works if either:
* --user is specified or
* docker is automatically run with the current user (seems to be the case in Linux+Windows)

This PR addresses to document this behaviour.