### PR TITLE
[DOCS] Link to "How to document" from docs

### DIFF
--- a/Documentation/Introduction/Index.rst
+++ b/Documentation/Introduction/Index.rst
@@ -12,6 +12,8 @@ The tool is used by the automated documentation rendering system of the
 TYPO3 project. And can be used by documentation authors to validate their
 documentation.
 
-.. Note::
+..  note::
 
     This tool is still in development, there will be bugs and missing features.
+    If you are looking for the current way to render documentation head over to
+    :ref:`How to document <h2document:start>`.

--- a/Documentation/guides.xml
+++ b/Documentation/guides.xml
@@ -10,4 +10,5 @@
         edit-on-github="TYPO3-Documentation/render-guides"
         edit-on-github-branch="main"
     />
+    <inventory id="h2document" url="https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/" />
 </guides>


### PR DESCRIPTION
This also introduces an interlink into our documentation as example