### PR TITLE
[BUGFIX] Fix the metadata

### DIFF
--- a/packages/typo3-docs-theme/resources/template/structure/layout.html.twig
+++ b/packages/typo3-docs-theme/resources/template/structure/layout.html.twig
@@ -3,17 +3,17 @@
 <head>
     <meta charset="utf-8"/>
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-    <meta content="{{ title }}" name="docsearch:name"/>
+    <meta content="{{ env.projectNode.title }}" name="docsearch:name"/>
     <meta content="" name="docsearch:package_type"/>
-    <meta content="master" name="docsearch:release"/>
-    <meta content="2.0" name="docsearch:version"/>
+    <meta content="{{ env.projectNode.version }}" name="docsearch:release"/>
+    <meta content="{{ env.projectNode.version }}" name="docsearch:version"/>
     <meta content="2020-10-30T07:03:47+00:00" name="docsearch:modified"/>
     <link href="http://purl.org/dc/elements/1.1/" rel="schema.dc"/>
     <meta content="2020-10-30T07:03:47+00:00" name="dc.modified"/>
     <meta content="2020-10-30T07:03:47+00:00" property="article:modified_time"/>
     <title>{{ title }}
-        {%- if title!=null and env.projectNode.title!=null %} - {% endif -%}
-        {%- if env.projectNode.title -%}{{ env.projectNode.title }}{%- endif -%} documentation {{ env.projectNode.version }}</title>
+        {%- if title!=null and env.projectNode.title!=null %} — {% endif -%}
+        {%- if env.projectNode.title -%}{{ env.projectNode.title }} {% endif -%} {{ env.projectNode.version }} documentation</title>
 
     <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/fontawesome.css" rel="stylesheet" type="text/css"/>
     <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/webfonts.css" rel="stylesheet" type="text/css"/>
@@ -150,7 +150,7 @@
 <script type="text/javascript">
     var DOCUMENTATION_OPTIONS = {
         URL_ROOT: './',
-        VERSION: 'main',
+        VERSION: '{{ env.projectNode.version }}',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         HAS_SOURCE: true

--- a/tests/Integration/tests-full/edit-on-github/expected/index.html
+++ b/tests/Integration/tests-full/edit-on-github/expected/index.html
@@ -3,15 +3,15 @@
 <head>
     <meta charset="utf-8"/>
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-    <meta content="Document Title" name="docsearch:name"/>
+    <meta content="" name="docsearch:name"/>
     <meta content="" name="docsearch:package_type"/>
-    <meta content="master" name="docsearch:release"/>
-    <meta content="2.0" name="docsearch:version"/>
+    <meta content="" name="docsearch:release"/>
+    <meta content="" name="docsearch:version"/>
     <meta content="2020-10-30T07:03:47+00:00" name="docsearch:modified"/>
     <link href="http://purl.org/dc/elements/1.1/" rel="schema.dc"/>
     <meta content="2020-10-30T07:03:47+00:00" name="dc.modified"/>
     <meta content="2020-10-30T07:03:47+00:00" property="article:modified_time"/>
-    <title>Document Titledocumentation </title>
+    <title>Document Title documentation</title>
 
     <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/fontawesome.css" rel="stylesheet" type="text/css"/>
     <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/webfonts.css" rel="stylesheet" type="text/css"/>
@@ -103,7 +103,7 @@
                         <div itemprop="articleBody">
                             <!-- body -->
                                 <!-- content start -->
-    <div class="section" id="document-title">
+        <div class="section" id="document-title">
     <h1>Document Title</h1>
 
             <p>Lorem Ipsum Dolor.</p>
@@ -114,7 +114,7 @@
 
     </div>
 
-<!-- content end -->
+    <!-- content end -->
                             <!-- /body -->
                         </div>
                     </div>
@@ -165,7 +165,7 @@
 <script type="text/javascript">
     var DOCUMENTATION_OPTIONS = {
         URL_ROOT: './',
-        VERSION: 'main',
+        VERSION: '',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         HAS_SOURCE: true

--- a/tests/Integration/tests-full/edit-on-github/expected/page1.html
+++ b/tests/Integration/tests-full/edit-on-github/expected/page1.html
@@ -3,15 +3,15 @@
 <head>
     <meta charset="utf-8"/>
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-    <meta content="Page 1" name="docsearch:name"/>
+    <meta content="" name="docsearch:name"/>
     <meta content="" name="docsearch:package_type"/>
-    <meta content="master" name="docsearch:release"/>
-    <meta content="2.0" name="docsearch:version"/>
+    <meta content="" name="docsearch:release"/>
+    <meta content="" name="docsearch:version"/>
     <meta content="2020-10-30T07:03:47+00:00" name="docsearch:modified"/>
     <link href="http://purl.org/dc/elements/1.1/" rel="schema.dc"/>
     <meta content="2020-10-30T07:03:47+00:00" name="dc.modified"/>
     <meta content="2020-10-30T07:03:47+00:00" property="article:modified_time"/>
-    <title>Page 1documentation </title>
+    <title>Page 1 documentation</title>
 
     <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/fontawesome.css" rel="stylesheet" type="text/css"/>
     <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/webfonts.css" rel="stylesheet" type="text/css"/>
@@ -105,13 +105,13 @@
                         <div itemprop="articleBody">
                             <!-- body -->
                                 <!-- content start -->
-    <div class="section" id="page-1">
+        <div class="section" id="page-1">
     <h1>Page 1</h1>
 
             <p>Lorem Ipsum Dolor.</p>
     </div>
 
-<!-- content end -->
+    <!-- content end -->
                             <!-- /body -->
                         </div>
                     </div>
@@ -168,7 +168,7 @@
 <script type="text/javascript">
     var DOCUMENTATION_OPTIONS = {
         URL_ROOT: './',
-        VERSION: 'main',
+        VERSION: '',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         HAS_SOURCE: true

--- a/tests/Integration/tests-full/edit-on-github/expected/subpages/index.html
+++ b/tests/Integration/tests-full/edit-on-github/expected/subpages/index.html
@@ -3,15 +3,15 @@
 <head>
     <meta charset="utf-8"/>
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-    <meta content="Subpages" name="docsearch:name"/>
+    <meta content="" name="docsearch:name"/>
     <meta content="" name="docsearch:package_type"/>
-    <meta content="master" name="docsearch:release"/>
-    <meta content="2.0" name="docsearch:version"/>
+    <meta content="" name="docsearch:release"/>
+    <meta content="" name="docsearch:version"/>
     <meta content="2020-10-30T07:03:47+00:00" name="docsearch:modified"/>
     <link href="http://purl.org/dc/elements/1.1/" rel="schema.dc"/>
     <meta content="2020-10-30T07:03:47+00:00" name="dc.modified"/>
     <meta content="2020-10-30T07:03:47+00:00" property="article:modified_time"/>
-    <title>Subpagesdocumentation </title>
+    <title>Subpages documentation</title>
 
     <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/fontawesome.css" rel="stylesheet" type="text/css"/>
     <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/webfonts.css" rel="stylesheet" type="text/css"/>
@@ -66,7 +66,7 @@
                     <div class="toc-collapse">
                                                 <div aria-label="main navigation" class="toc" role="navigation">
                             <!-- menu -->
-
+                                        
 <div aria-label="main navigation" class="toc" role="navigation">
     <!-- menu -->
     <ul>
@@ -81,7 +81,7 @@
             </div>
             <div class="page-main-content">
                 <div class="rst-content">                        <div aria-label="breadcrumbs navigation" class="breadcrumb-bar" role="navigation">
-
+        
 <ol class="breadcrumb">
     <li class="breadcrumb-item"><a href="../index.html">Document Title</a></li>
                     <li aria-current="page"  class="breadcrumb-item  active">Subpages</li>
@@ -105,17 +105,17 @@
                         <div itemprop="articleBody">
                             <!-- body -->
                                 <!-- content start -->
-    <div class="section" id="subpages">
+        <div class="section" id="subpages">
     <h1>Subpages</h1>
 
             <p>Lorem Ipsum Dolor.</p>
     </div>
 
-<!-- content end -->
+    <!-- content end -->
                             <!-- /body -->
                         </div>
                     </div>
-
+                        
             <nav aria-label="Page navigation">
             <ul class="pagination justify-content-center"><li class="page-item">
                             <a class="page-link" href="../page1.html"
@@ -168,7 +168,7 @@
 <script type="text/javascript">
     var DOCUMENTATION_OPTIONS = {
         URL_ROOT: './',
-        VERSION: 'main',
+        VERSION: '',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         HAS_SOURCE: true

--- a/tests/Integration/tests-full/index/expected/index.html
+++ b/tests/Integration/tests-full/index/expected/index.html
@@ -3,15 +3,15 @@
 <head>
     <meta charset="utf-8"/>
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-    <meta content="Document Title" name="docsearch:name"/>
+    <meta content="Example Project" name="docsearch:name"/>
     <meta content="" name="docsearch:package_type"/>
-    <meta content="master" name="docsearch:release"/>
-    <meta content="2.0" name="docsearch:version"/>
+    <meta content="12.4" name="docsearch:release"/>
+    <meta content="12.4" name="docsearch:version"/>
     <meta content="2020-10-30T07:03:47+00:00" name="docsearch:modified"/>
     <link href="http://purl.org/dc/elements/1.1/" rel="schema.dc"/>
     <meta content="2020-10-30T07:03:47+00:00" name="dc.modified"/>
     <meta content="2020-10-30T07:03:47+00:00" property="article:modified_time"/>
-    <title>Document Titledocumentation </title>
+    <title>Document Title — Example Project 12.4 documentation</title>
 
     <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/fontawesome.css" rel="stylesheet" type="text/css"/>
     <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/webfonts.css" rel="stylesheet" type="text/css"/>
@@ -53,8 +53,16 @@
                     <input class="toc-checkbox" id="toggleToc" type="checkbox"/>
                     <div class="toc-header">
                         <div class="toc-title">
-                            <a class="toc-title-project" href="/"></a>
-                            </div>
+                            <a class="toc-title-project" href="/">Example Project</a>
+                            <div class="toc-version-wrapper" id="toc-version-wrapper">
+                                    <div id="toc-version" class="toc-version">
+                                        <span class="toc-version-prefix">Release:</span>
+                                        <span class="toc-version-number">12.4</span>
+                                    </div>
+                                    <div id="toc-version-options" class="toc-version-options">
+                                        <p><span class="fa fa-spinner fa-spin"></span> Loading data.</p>
+                                    </div>
+                                </div></div>
                         <div class="toc-actions">
                             <label class="toc-toggle" for="toggleToc">
                                 Menu
@@ -86,19 +94,23 @@
         <span class="btn-icon"><span class="fas fa-info-circle"></span></span>
         <span class="btn-text">How to edit</span>
     </a>
+        <a class="btn btn-sm btn-primary" href="https://github.com/TYPO3-Documentation/render-guides/edit/main/Documentation/index.rst" id="btnEditOnGitHub" rel="nofollow noopener" target="_blank">
+        <span class="btn-icon"><span class="fab fa-github"></span></span>
+        <span class="btn-text">Edit on GitHub</span>
+    </a>
     </div>
     </div>
                     <div class="document" itemscope="itemscope" itemtype="http://schema.org/Article" role="main">
                         <div itemprop="articleBody">
                             <!-- body -->
                                 <!-- content start -->
-    <div class="section" id="document-title">
+        <div class="section" id="document-title">
     <h1>Document Title</h1>
 
             <p>Lorem Ipsum Dolor.</p>
     </div>
 
-<!-- content end -->
+    <!-- content end -->
                             <!-- /body -->
                         </div>
                     </div>
@@ -140,7 +152,7 @@
 <script type="text/javascript">
     var DOCUMENTATION_OPTIONS = {
         URL_ROOT: './',
-        VERSION: 'main',
+        VERSION: '12.4',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         HAS_SOURCE: true

--- a/tests/Integration/tests-full/index/expected/objects.inv.json
+++ b/tests/Integration/tests-full/index/expected/objects.inv.json
@@ -1,16 +1,16 @@
 {
     "std:doc": {
         "index": [
-            null,
-            null,
+            "Example Project",
+            "12.4",
             "index.html",
             "Document Title"
         ]
     },
     "std:label": {
         "document-title": [
-            null,
-            null,
+            "Example Project",
+            "12.4",
             "index.html#document-title",
             "Document Title"
         ]

--- a/tests/Integration/tests-full/index/input/guides.xml
+++ b/tests/Integration/tests-full/index/input/guides.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<guides
+    xmlns="https://www.phpdoc.org/guides"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://www.phpdoc.org/guides vendor/phpdocumentor/guides-cli/resources/schema/guides.xsd"
+>
+    <project title="Example Project" version="12.4"/>
+    <extension
+        class="\T3Docs\Typo3DocsTheme\DependencyInjection\Typo3DocsThemeExtension"
+        edit-on-github="TYPO3-Documentation/render-guides"
+        edit-on-github-branch="main"
+    />
+</guides>

--- a/tests/Integration/tests-full/next-prev/expected/index.html
+++ b/tests/Integration/tests-full/next-prev/expected/index.html
@@ -3,15 +3,15 @@
 <head>
     <meta charset="utf-8"/>
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-    <meta content="Document Title" name="docsearch:name"/>
+    <meta content="" name="docsearch:name"/>
     <meta content="" name="docsearch:package_type"/>
-    <meta content="master" name="docsearch:release"/>
-    <meta content="2.0" name="docsearch:version"/>
+    <meta content="" name="docsearch:release"/>
+    <meta content="" name="docsearch:version"/>
     <meta content="2020-10-30T07:03:47+00:00" name="docsearch:modified"/>
     <link href="http://purl.org/dc/elements/1.1/" rel="schema.dc"/>
     <meta content="2020-10-30T07:03:47+00:00" name="dc.modified"/>
     <meta content="2020-10-30T07:03:47+00:00" property="article:modified_time"/>
-    <title>Document Titledocumentation </title>
+    <title>Document Title documentation</title>
 
     <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/fontawesome.css" rel="stylesheet" type="text/css"/>
     <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/webfonts.css" rel="stylesheet" type="text/css"/>
@@ -93,13 +93,13 @@
                         <div itemprop="articleBody">
                             <!-- body -->
                                 <!-- content start -->
-    <div class="section" id="document-title">
+        <div class="section" id="document-title">
     <h1>Document Title</h1>
 
             <p>Lorem Ipsum Dolor.</p>
     </div>
 
-<!-- content end -->
+    <!-- content end -->
                             <!-- /body -->
                         </div>
                     </div>
@@ -150,7 +150,7 @@
 <script type="text/javascript">
     var DOCUMENTATION_OPTIONS = {
         URL_ROOT: './',
-        VERSION: 'main',
+        VERSION: '',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         HAS_SOURCE: true

--- a/tests/Integration/tests-full/next-prev/expected/page.html
+++ b/tests/Integration/tests-full/next-prev/expected/page.html
@@ -3,15 +3,15 @@
 <head>
     <meta charset="utf-8"/>
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-    <meta content="Page" name="docsearch:name"/>
+    <meta content="" name="docsearch:name"/>
     <meta content="" name="docsearch:package_type"/>
-    <meta content="master" name="docsearch:release"/>
-    <meta content="2.0" name="docsearch:version"/>
+    <meta content="" name="docsearch:release"/>
+    <meta content="" name="docsearch:version"/>
     <meta content="2020-10-30T07:03:47+00:00" name="docsearch:modified"/>
     <link href="http://purl.org/dc/elements/1.1/" rel="schema.dc"/>
     <meta content="2020-10-30T07:03:47+00:00" name="dc.modified"/>
     <meta content="2020-10-30T07:03:47+00:00" property="article:modified_time"/>
-    <title>Pagedocumentation </title>
+    <title>Page documentation</title>
 
     <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/fontawesome.css" rel="stylesheet" type="text/css"/>
     <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/webfonts.css" rel="stylesheet" type="text/css"/>
@@ -95,13 +95,13 @@
                         <div itemprop="articleBody">
                             <!-- body -->
                                 <!-- content start -->
-    <div class="section" id="page">
+        <div class="section" id="page">
     <h1>Page</h1>
 
             <p>Lorem Ipsum Dolor.</p>
     </div>
 
-<!-- content end -->
+    <!-- content end -->
                             <!-- /body -->
                         </div>
                     </div>
@@ -158,7 +158,7 @@
 <script type="text/javascript">
     var DOCUMENTATION_OPTIONS = {
         URL_ROOT: './',
-        VERSION: 'main',
+        VERSION: '',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         HAS_SOURCE: true

--- a/tests/Integration/tests-full/next-prev/expected/yetAnotherPage.html
+++ b/tests/Integration/tests-full/next-prev/expected/yetAnotherPage.html
@@ -3,15 +3,15 @@
 <head>
     <meta charset="utf-8"/>
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-    <meta content="Another Page" name="docsearch:name"/>
+    <meta content="" name="docsearch:name"/>
     <meta content="" name="docsearch:package_type"/>
-    <meta content="master" name="docsearch:release"/>
-    <meta content="2.0" name="docsearch:version"/>
+    <meta content="" name="docsearch:release"/>
+    <meta content="" name="docsearch:version"/>
     <meta content="2020-10-30T07:03:47+00:00" name="docsearch:modified"/>
     <link href="http://purl.org/dc/elements/1.1/" rel="schema.dc"/>
     <meta content="2020-10-30T07:03:47+00:00" name="dc.modified"/>
     <meta content="2020-10-30T07:03:47+00:00" property="article:modified_time"/>
-    <title>Another Pagedocumentation </title>
+    <title>Another Page documentation</title>
 
     <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/fontawesome.css" rel="stylesheet" type="text/css"/>
     <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/webfonts.css" rel="stylesheet" type="text/css"/>
@@ -94,13 +94,13 @@
                         <div itemprop="articleBody">
                             <!-- body -->
                                 <!-- content start -->
-    <div class="section" id="another-page">
+        <div class="section" id="another-page">
     <h1>Another Page</h1>
 
             <p>Lorem Ipsum Dolor.</p>
     </div>
 
-<!-- content end -->
+    <!-- content end -->
                             <!-- /body -->
                         </div>
                     </div>
@@ -151,7 +151,7 @@
 <script type="text/javascript">
     var DOCUMENTATION_OPTIONS = {
         URL_ROOT: './',
-        VERSION: 'main',
+        VERSION: '',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         HAS_SOURCE: true

--- a/tests/Integration/tests-full/page-with-subpages/expected/index.html
+++ b/tests/Integration/tests-full/page-with-subpages/expected/index.html
@@ -3,15 +3,15 @@
 <head>
     <meta charset="utf-8"/>
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-    <meta content="Root index" name="docsearch:name"/>
+    <meta content="" name="docsearch:name"/>
     <meta content="" name="docsearch:package_type"/>
-    <meta content="master" name="docsearch:release"/>
-    <meta content="2.0" name="docsearch:version"/>
+    <meta content="" name="docsearch:release"/>
+    <meta content="" name="docsearch:version"/>
     <meta content="2020-10-30T07:03:47+00:00" name="docsearch:modified"/>
     <link href="http://purl.org/dc/elements/1.1/" rel="schema.dc"/>
     <meta content="2020-10-30T07:03:47+00:00" name="dc.modified"/>
     <meta content="2020-10-30T07:03:47+00:00" property="article:modified_time"/>
-    <title>Root indexdocumentation </title>
+    <title>Root index documentation</title>
 
     <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/fontawesome.css" rel="stylesheet" type="text/css"/>
     <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/webfonts.css" rel="stylesheet" type="text/css"/>
@@ -99,7 +99,7 @@
                         <div itemprop="articleBody">
                             <!-- body -->
                                 <!-- content start -->
-    <div class="section" id="root-index">
+        <div class="section" id="root-index">
     <h1>Root index</h1>
 
             <p>Lorem Ipsum Dolor. See <a href="sub/index.html#sub-index">Sub index</a>
@@ -111,7 +111,7 @@
 
     </div>
 
-<!-- content end -->
+    <!-- content end -->
                             <!-- /body -->
                         </div>
                     </div>
@@ -162,7 +162,7 @@
 <script type="text/javascript">
     var DOCUMENTATION_OPTIONS = {
         URL_ROOT: './',
-        VERSION: 'main',
+        VERSION: '',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         HAS_SOURCE: true

--- a/tests/Integration/tests-full/page-with-subpages/expected/sub/index.html
+++ b/tests/Integration/tests-full/page-with-subpages/expected/sub/index.html
@@ -3,15 +3,15 @@
 <head>
     <meta charset="utf-8"/>
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-    <meta content="Sub index" name="docsearch:name"/>
+    <meta content="" name="docsearch:name"/>
     <meta content="" name="docsearch:package_type"/>
-    <meta content="master" name="docsearch:release"/>
-    <meta content="2.0" name="docsearch:version"/>
+    <meta content="" name="docsearch:release"/>
+    <meta content="" name="docsearch:version"/>
     <meta content="2020-10-30T07:03:47+00:00" name="docsearch:modified"/>
     <link href="http://purl.org/dc/elements/1.1/" rel="schema.dc"/>
     <meta content="2020-10-30T07:03:47+00:00" name="dc.modified"/>
     <meta content="2020-10-30T07:03:47+00:00" property="article:modified_time"/>
-    <title>Sub indexdocumentation </title>
+    <title>Sub index documentation</title>
 
     <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/fontawesome.css" rel="stylesheet" type="text/css"/>
     <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/webfonts.css" rel="stylesheet" type="text/css"/>
@@ -100,14 +100,14 @@
                         <div itemprop="articleBody">
                             <!-- body -->
                                 <!-- content start -->
-    <div class="section" id="sub-index">
+        <div class="section" id="sub-index">
     <h1>Sub index</h1>
 
             <p>Lorem Ipsum Dolor.  See <a href="../index.html#root-index">Root index</a>
 .</p>
     </div>
 
-<!-- content end -->
+    <!-- content end -->
                             <!-- /body -->
                         </div>
                     </div>
@@ -158,7 +158,7 @@
 <script type="text/javascript">
     var DOCUMENTATION_OPTIONS = {
         URL_ROOT: './',
-        VERSION: 'main',
+        VERSION: '',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         HAS_SOURCE: true

--- a/tests/Integration/tests-full/sitemap/expected/Sitemap.html
+++ b/tests/Integration/tests-full/sitemap/expected/Sitemap.html
@@ -3,15 +3,15 @@
 <head>
     <meta charset="utf-8"/>
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-    <meta content="Sitemap" name="docsearch:name"/>
+    <meta content="" name="docsearch:name"/>
     <meta content="" name="docsearch:package_type"/>
-    <meta content="master" name="docsearch:release"/>
-    <meta content="2.0" name="docsearch:version"/>
+    <meta content="" name="docsearch:release"/>
+    <meta content="" name="docsearch:version"/>
     <meta content="2020-10-30T07:03:47+00:00" name="docsearch:modified"/>
     <link href="http://purl.org/dc/elements/1.1/" rel="schema.dc"/>
     <meta content="2020-10-30T07:03:47+00:00" name="dc.modified"/>
     <meta content="2020-10-30T07:03:47+00:00" property="article:modified_time"/>
-    <title>Sitemapdocumentation </title>
+    <title>Sitemap documentation</title>
 
     <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/fontawesome.css" rel="stylesheet" type="text/css"/>
     <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/webfonts.css" rel="stylesheet" type="text/css"/>
@@ -222,7 +222,7 @@
 <script type="text/javascript">
     var DOCUMENTATION_OPTIONS = {
         URL_ROOT: './',
-        VERSION: 'main',
+        VERSION: '',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         HAS_SOURCE: true

--- a/tests/Integration/tests-full/sitemap/expected/index.html
+++ b/tests/Integration/tests-full/sitemap/expected/index.html
@@ -3,15 +3,15 @@
 <head>
     <meta charset="utf-8"/>
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-    <meta content="Document Title" name="docsearch:name"/>
+    <meta content="" name="docsearch:name"/>
     <meta content="" name="docsearch:package_type"/>
-    <meta content="master" name="docsearch:release"/>
-    <meta content="2.0" name="docsearch:version"/>
+    <meta content="" name="docsearch:release"/>
+    <meta content="" name="docsearch:version"/>
     <meta content="2020-10-30T07:03:47+00:00" name="docsearch:modified"/>
     <link href="http://purl.org/dc/elements/1.1/" rel="schema.dc"/>
     <meta content="2020-10-30T07:03:47+00:00" name="dc.modified"/>
     <meta content="2020-10-30T07:03:47+00:00" property="article:modified_time"/>
-    <title>Document Titledocumentation </title>
+    <title>Document Title documentation</title>
 
     <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/fontawesome.css" rel="stylesheet" type="text/css"/>
     <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/webfonts.css" rel="stylesheet" type="text/css"/>
@@ -197,7 +197,7 @@
 <script type="text/javascript">
     var DOCUMENTATION_OPTIONS = {
         URL_ROOT: './',
-        VERSION: 'main',
+        VERSION: '',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         HAS_SOURCE: true


### PR DESCRIPTION
The metadata title missed the - sign and a whitespace, order was wrong docsearch:release and docsearch:version should contain the configured version - if any docsearch:name should contain the name of the project, not of the current document

Also output the version in DOCUMENTATION_OPTIONS