### PR TITLE
[TASK] Remove skip of emphasize-lines from code-block

### DIFF
--- a/tests/Integration/tests/code-block/with-emphasize-lines/input/skip
+++ b/tests/Integration/tests/code-block/with-emphasize-lines/input/skip
@@ -1,1 +1,0 @@
-Line highlighting is not implemented by now


### PR DESCRIPTION
This issue was resolved by https://github.com/phpDocumentor/guides/pull/690.