### PR TITLE
[BUGFIX] Remove superfluous reference to TabsDirective class

### DIFF
--- a/packages/typo3-docs-theme/resources/config/typo3-docs-theme.php
+++ b/packages/typo3-docs-theme/resources/config/typo3-docs-theme.php
@@ -13,7 +13,6 @@ use T3Docs\Typo3DocsTheme\Directives\GroupTabDirective;
 
 use T3Docs\Typo3DocsTheme\Directives\T3FieldListTableDirective;
 
-use T3Docs\Typo3DocsTheme\Directives\TabsDirective;
 use T3Docs\Typo3DocsTheme\Directives\YoutubeDirective;
 use T3Docs\Typo3DocsTheme\TextRoles\IssueReferenceTextRole;
 use T3Docs\Typo3DocsTheme\Twig\TwigExtension;
@@ -35,6 +34,5 @@ return static function (ContainerConfigurator $container): void {
 
         ->set(GroupTabDirective::class)
         ->set(T3FieldListTableDirective::class)
-        ->set(TabsDirective::class)
         ->set(YoutubeDirective::class);
 };


### PR DESCRIPTION
This is now part of the phpDocumentor/guides package.