### PR TITLE
[TASK] Adjust docroot of ddev configuration

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -1,6 +1,6 @@
 name: render-guides
 type: php
-docroot: output
+docroot: Documentation-GENERATED-temp
 php_version: "8.1"
 webserver_type: nginx-fpm
 router_http_port: "80"

--- a/.ddev/nginx/index.conf
+++ b/.ddev/nginx/index.conf
@@ -1,0 +1,1 @@
+index Index.html index.html;


### PR DESCRIPTION
As the generated documentation folder is named "Documentation-GENERATED-temp" this is set as docroot.
Additionally, add Index.html (with capitalized I) as index file.