### PR TITLE
[TASK] Cleanup layout template

### DIFF
--- a/packages/typo3-docs-theme/resources/template/structure/layout.html.twig
+++ b/packages/typo3-docs-theme/resources/template/structure/layout.html.twig
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
 <html class="no-js" lang="en">
 <head>
-    <meta charset="utf-8"/>
-    <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-    <meta content="{{ env.projectNode.title }}" name="docsearch:name"/>
-    <meta content="" name="docsearch:package_type"/>
-    <meta content="{{ env.projectNode.version }}" name="docsearch:release"/>
-    <meta content="{{ env.projectNode.version }}" name="docsearch:version"/>
-    <meta content="{{ env.projectNode.lastRendered|date("Y-m-d\\TH:i:sP") }}" name="docsearch:modified"/>
-    <link href="http://purl.org/dc/elements/1.1/" rel="schema.dc"/>
-    <meta content="{{ env.projectNode.lastRendered|date("Y-m-d\\TH:i:sP") }}" name="dc.modified"/>
-    <meta content="{{ env.projectNode.lastRendered|date("Y-m-d\\TH:i:sP") }}" property="article:modified_time"/>
+    <meta charset="utf-8">
+    <meta content="width=device-width, initial-scale=1.0" name="viewport">
+    <meta content="{{ env.projectNode.title }}" name="docsearch:name">
+    <meta content="" name="docsearch:package_type">
+    <meta content="{{ env.projectNode.version }}" name="docsearch:release">
+    <meta content="{{ env.projectNode.version }}" name="docsearch:version">
+    <meta content="{{ env.projectNode.lastRendered|date("Y-m-d\\TH:i:sP") }}" name="docsearch:modified">
+    <link href="http://purl.org/dc/elements/1.1/" rel="schema.dc">
+    <meta content="{{ env.projectNode.lastRendered|date("Y-m-d\\TH:i:sP") }}" name="dc.modified">
+    <meta content="{{ env.projectNode.lastRendered|date("Y-m-d\\TH:i:sP") }}" property="article:modified_time">
     <title>{{ title }}
         {%- if title!=null and env.projectNode.title!=null %} — {% endif -%}
         {%- if env.projectNode.title -%}{{ env.projectNode.title }} {% endif -%} {{ env.projectNode.version }} documentation</title>
 
-    <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/fontawesome.css" rel="stylesheet" type="text/css"/>
-    <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/webfonts.css" rel="stylesheet" type="text/css"/>
-    <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/theme.css" rel="stylesheet" type="text/css"/>
-    <link href="https://docs.typo3.org/search/" rel="search" title="Search"/>
+    <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/fontawesome.css" rel="stylesheet">
+    <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/webfonts.css" rel="stylesheet">
+    <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/theme.css" rel="stylesheet">
+    <link href="https://docs.typo3.org/search/" rel="search" title="Search">
     {% block headerLinks %}
     {% endblock %}
     <!-- extrahead --><!-- /extrahead -->
@@ -43,7 +43,7 @@
         <div class="page-header-inner">
             <!-- pageheader -->
             <a class="logo" href="https://docs.typo3.org/" title="TYPO3 Documentation">
-                <img alt="TYPO3 Logo" class="logo-image" height="130" src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.4.3/img/typo3-logo.svg" width="484"/>
+                <img alt="TYPO3 Logo" class="logo-image" src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.4.3/img/typo3-logo.svg" width="484" height="130">
             </a>
             <!-- /pageheader -->
         </div>
@@ -53,7 +53,7 @@
         <div class="page-main-inner">
             <div class="page-main-navigation">
                 <nav>
-                    <input class="toc-checkbox" id="toggleToc" type="checkbox"/>
+                    <input class="toc-checkbox" id="toggleToc" type="checkbox">
                     <div class="toc-header">
                         <div class="toc-title">
                             <a class="toc-title-project" href="/{{ env.projectNode.homeLink }}">{{ env.projectNode.title }}</a>
@@ -155,7 +155,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     </div>
 </div>
 
-<script type="text/javascript">
+<script>
     var DOCUMENTATION_OPTIONS = {
         URL_ROOT: './',
         VERSION: '{{ env.projectNode.version }}',
@@ -164,20 +164,20 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         HAS_SOURCE: true
     };
 </script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/jquery.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/underscore.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/doctools.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/popper.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/bootstrap.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/theme.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/searchtools.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/autocomplete.min.js" type="text/javascript"></script>
-<script type="text/javascript">
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/jquery.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/underscore.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/doctools.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/popper.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/bootstrap.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/theme.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/searchtools.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/autocomplete.min.js"></script>
+<script>
     jQuery(function() { Search.loadIndex("searchindex.js"); });
 </script>
-<script id="searchindexloader" type="text/javascript"></script>
+<script id="searchindexloader"></script>
 
-<script id="R9wBKTwzv" src="https://app.usercentrics.eu/latest/main.js" type="application/javascript"></script>
+<script id="R9wBKTwzv" src="https://app.usercentrics.eu/latest/main.js"></script>
 <script data-usercentrics="Matomo" src="/js/piwik.js" type="text/plain"></script>
 </body>
 </html>

--- a/tests/Integration/tests-full/edit-on-github/expected/index.html
+++ b/tests/Integration/tests-full/edit-on-github/expected/index.html
@@ -1,22 +1,22 @@
 <!DOCTYPE html>
 <html class="no-js" lang="en">
 <head>
-    <meta charset="utf-8"/>
-    <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-    <meta content="" name="docsearch:name"/>
-    <meta content="" name="docsearch:package_type"/>
-    <meta content="" name="docsearch:release"/>
-    <meta content="" name="docsearch:version"/>
-    <meta content="2023-01-01T12:00:00+00:00" name="docsearch:modified"/>
-    <link href="http://purl.org/dc/elements/1.1/" rel="schema.dc"/>
-    <meta content="2023-01-01T12:00:00+00:00" name="dc.modified"/>
-    <meta content="2023-01-01T12:00:00+00:00" property="article:modified_time"/>
+    <meta charset="utf-8">
+    <meta content="width=device-width, initial-scale=1.0" name="viewport">
+    <meta content="" name="docsearch:name">
+    <meta content="" name="docsearch:package_type">
+    <meta content="" name="docsearch:release">
+    <meta content="" name="docsearch:version">
+    <meta content="2023-01-01T12:00:00+00:00" name="docsearch:modified">
+    <link href="http://purl.org/dc/elements/1.1/" rel="schema.dc">
+    <meta content="2023-01-01T12:00:00+00:00" name="dc.modified">
+    <meta content="2023-01-01T12:00:00+00:00" property="article:modified_time">
     <title>Document Title documentation</title>
 
-    <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/fontawesome.css" rel="stylesheet" type="text/css"/>
-    <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/webfonts.css" rel="stylesheet" type="text/css"/>
-    <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/theme.css" rel="stylesheet" type="text/css"/>
-    <link href="https://docs.typo3.org/search/" rel="search" title="Search"/>
+    <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/fontawesome.css" rel="stylesheet">
+    <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/webfonts.css" rel="stylesheet">
+    <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/theme.css" rel="stylesheet">
+    <link href="https://docs.typo3.org/search/" rel="search" title="Search">
                 <link href="page1.html" rel="next" title="Page 1"/>
             <link href="#" rel="top" title="Document Title"/>
         <!-- extrahead --><!-- /extrahead -->
@@ -41,7 +41,7 @@
         <div class="page-header-inner">
             <!-- pageheader -->
             <a class="logo" href="https://docs.typo3.org/" title="TYPO3 Documentation">
-                <img alt="TYPO3 Logo" class="logo-image" height="130" src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.4.3/img/typo3-logo.svg" width="484"/>
+                <img alt="TYPO3 Logo" class="logo-image" src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.4.3/img/typo3-logo.svg" width="484" height="130">
             </a>
             <!-- /pageheader -->
         </div>
@@ -51,7 +51,7 @@
         <div class="page-main-inner">
             <div class="page-main-navigation">
                 <nav>
-                    <input class="toc-checkbox" id="toggleToc" type="checkbox"/>
+                    <input class="toc-checkbox" id="toggleToc" type="checkbox">
                     <div class="toc-header">
                         <div class="toc-title">
                             <a class="toc-title-project" href="/"></a>
@@ -169,7 +169,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     </div>
 </div>
 
-<script type="text/javascript">
+<script>
     var DOCUMENTATION_OPTIONS = {
         URL_ROOT: './',
         VERSION: '',
@@ -178,20 +178,20 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         HAS_SOURCE: true
     };
 </script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/jquery.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/underscore.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/doctools.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/popper.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/bootstrap.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/theme.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/searchtools.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/autocomplete.min.js" type="text/javascript"></script>
-<script type="text/javascript">
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/jquery.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/underscore.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/doctools.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/popper.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/bootstrap.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/theme.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/searchtools.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/autocomplete.min.js"></script>
+<script>
     jQuery(function() { Search.loadIndex("searchindex.js"); });
 </script>
-<script id="searchindexloader" type="text/javascript"></script>
+<script id="searchindexloader"></script>
 
-<script id="R9wBKTwzv" src="https://app.usercentrics.eu/latest/main.js" type="application/javascript"></script>
+<script id="R9wBKTwzv" src="https://app.usercentrics.eu/latest/main.js"></script>
 <script data-usercentrics="Matomo" src="/js/piwik.js" type="text/plain"></script>
 </body>
 </html>

--- a/tests/Integration/tests-full/edit-on-github/expected/page1.html
+++ b/tests/Integration/tests-full/edit-on-github/expected/page1.html
@@ -1,22 +1,22 @@
 <!DOCTYPE html>
 <html class="no-js" lang="en">
 <head>
-    <meta charset="utf-8"/>
-    <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-    <meta content="" name="docsearch:name"/>
-    <meta content="" name="docsearch:package_type"/>
-    <meta content="" name="docsearch:release"/>
-    <meta content="" name="docsearch:version"/>
-    <meta content="2023-01-01T12:00:00+00:00" name="docsearch:modified"/>
-    <link href="http://purl.org/dc/elements/1.1/" rel="schema.dc"/>
-    <meta content="2023-01-01T12:00:00+00:00" name="dc.modified"/>
-    <meta content="2023-01-01T12:00:00+00:00" property="article:modified_time"/>
+    <meta charset="utf-8">
+    <meta content="width=device-width, initial-scale=1.0" name="viewport">
+    <meta content="" name="docsearch:name">
+    <meta content="" name="docsearch:package_type">
+    <meta content="" name="docsearch:release">
+    <meta content="" name="docsearch:version">
+    <meta content="2023-01-01T12:00:00+00:00" name="docsearch:modified">
+    <link href="http://purl.org/dc/elements/1.1/" rel="schema.dc">
+    <meta content="2023-01-01T12:00:00+00:00" name="dc.modified">
+    <meta content="2023-01-01T12:00:00+00:00" property="article:modified_time">
     <title>Page 1 documentation</title>
 
-    <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/fontawesome.css" rel="stylesheet" type="text/css"/>
-    <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/webfonts.css" rel="stylesheet" type="text/css"/>
-    <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/theme.css" rel="stylesheet" type="text/css"/>
-    <link href="https://docs.typo3.org/search/" rel="search" title="Search"/>
+    <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/fontawesome.css" rel="stylesheet">
+    <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/webfonts.css" rel="stylesheet">
+    <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/theme.css" rel="stylesheet">
+    <link href="https://docs.typo3.org/search/" rel="search" title="Search">
                 <link href="index.html" rel="prev" title="Document Title"/>
             <link href="subpages/index.html" rel="next" title="Subpages"/>
             <link href="index.html" rel="top" title="Document Title"/>
@@ -42,7 +42,7 @@
         <div class="page-header-inner">
             <!-- pageheader -->
             <a class="logo" href="https://docs.typo3.org/" title="TYPO3 Documentation">
-                <img alt="TYPO3 Logo" class="logo-image" height="130" src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.4.3/img/typo3-logo.svg" width="484"/>
+                <img alt="TYPO3 Logo" class="logo-image" src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.4.3/img/typo3-logo.svg" width="484" height="130">
             </a>
             <!-- /pageheader -->
         </div>
@@ -52,7 +52,7 @@
         <div class="page-main-inner">
             <div class="page-main-navigation">
                 <nav>
-                    <input class="toc-checkbox" id="toggleToc" type="checkbox"/>
+                    <input class="toc-checkbox" id="toggleToc" type="checkbox">
                     <div class="toc-header">
                         <div class="toc-title">
                             <a class="toc-title-project" href="/"></a>
@@ -172,7 +172,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     </div>
 </div>
 
-<script type="text/javascript">
+<script>
     var DOCUMENTATION_OPTIONS = {
         URL_ROOT: './',
         VERSION: '',
@@ -181,20 +181,20 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         HAS_SOURCE: true
     };
 </script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/jquery.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/underscore.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/doctools.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/popper.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/bootstrap.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/theme.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/searchtools.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/autocomplete.min.js" type="text/javascript"></script>
-<script type="text/javascript">
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/jquery.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/underscore.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/doctools.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/popper.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/bootstrap.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/theme.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/searchtools.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/autocomplete.min.js"></script>
+<script>
     jQuery(function() { Search.loadIndex("searchindex.js"); });
 </script>
-<script id="searchindexloader" type="text/javascript"></script>
+<script id="searchindexloader"></script>
 
-<script id="R9wBKTwzv" src="https://app.usercentrics.eu/latest/main.js" type="application/javascript"></script>
+<script id="R9wBKTwzv" src="https://app.usercentrics.eu/latest/main.js"></script>
 <script data-usercentrics="Matomo" src="/js/piwik.js" type="text/plain"></script>
 </body>
 </html>

--- a/tests/Integration/tests-full/edit-on-github/expected/subpages/index.html
+++ b/tests/Integration/tests-full/edit-on-github/expected/subpages/index.html
@@ -1,22 +1,22 @@
 <!DOCTYPE html>
 <html class="no-js" lang="en">
 <head>
-    <meta charset="utf-8"/>
-    <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-    <meta content="" name="docsearch:name"/>
-    <meta content="" name="docsearch:package_type"/>
-    <meta content="" name="docsearch:release"/>
-    <meta content="" name="docsearch:version"/>
-    <meta content="2023-01-01T12:00:00+00:00" name="docsearch:modified"/>
-    <link href="http://purl.org/dc/elements/1.1/" rel="schema.dc"/>
-    <meta content="2023-01-01T12:00:00+00:00" name="dc.modified"/>
-    <meta content="2023-01-01T12:00:00+00:00" property="article:modified_time"/>
+    <meta charset="utf-8">
+    <meta content="width=device-width, initial-scale=1.0" name="viewport">
+    <meta content="" name="docsearch:name">
+    <meta content="" name="docsearch:package_type">
+    <meta content="" name="docsearch:release">
+    <meta content="" name="docsearch:version">
+    <meta content="2023-01-01T12:00:00+00:00" name="docsearch:modified">
+    <link href="http://purl.org/dc/elements/1.1/" rel="schema.dc">
+    <meta content="2023-01-01T12:00:00+00:00" name="dc.modified">
+    <meta content="2023-01-01T12:00:00+00:00" property="article:modified_time">
     <title>Subpages documentation</title>
 
-    <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/fontawesome.css" rel="stylesheet" type="text/css"/>
-    <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/webfonts.css" rel="stylesheet" type="text/css"/>
-    <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/theme.css" rel="stylesheet" type="text/css"/>
-    <link href="https://docs.typo3.org/search/" rel="search" title="Search"/>
+    <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/fontawesome.css" rel="stylesheet">
+    <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/webfonts.css" rel="stylesheet">
+    <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/theme.css" rel="stylesheet">
+    <link href="https://docs.typo3.org/search/" rel="search" title="Search">
                 <link href="../page1.html" rel="prev" title="Page 1"/>
             <link href="subpage1.html" rel="next" title="Subpage 1"/>
             <link href="../index.html" rel="top" title="Document Title"/>
@@ -42,7 +42,7 @@
         <div class="page-header-inner">
             <!-- pageheader -->
             <a class="logo" href="https://docs.typo3.org/" title="TYPO3 Documentation">
-                <img alt="TYPO3 Logo" class="logo-image" height="130" src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.4.3/img/typo3-logo.svg" width="484"/>
+                <img alt="TYPO3 Logo" class="logo-image" src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.4.3/img/typo3-logo.svg" width="484" height="130">
             </a>
             <!-- /pageheader -->
         </div>
@@ -52,7 +52,7 @@
         <div class="page-main-inner">
             <div class="page-main-navigation">
                 <nav>
-                    <input class="toc-checkbox" id="toggleToc" type="checkbox"/>
+                    <input class="toc-checkbox" id="toggleToc" type="checkbox">
                     <div class="toc-header">
                         <div class="toc-title">
                             <a class="toc-title-project" href="/"></a>
@@ -172,7 +172,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     </div>
 </div>
 
-<script type="text/javascript">
+<script>
     var DOCUMENTATION_OPTIONS = {
         URL_ROOT: './',
         VERSION: '',
@@ -181,20 +181,20 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         HAS_SOURCE: true
     };
 </script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/jquery.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/underscore.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/doctools.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/popper.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/bootstrap.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/theme.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/searchtools.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/autocomplete.min.js" type="text/javascript"></script>
-<script type="text/javascript">
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/jquery.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/underscore.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/doctools.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/popper.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/bootstrap.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/theme.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/searchtools.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/autocomplete.min.js"></script>
+<script>
     jQuery(function() { Search.loadIndex("searchindex.js"); });
 </script>
-<script id="searchindexloader" type="text/javascript"></script>
+<script id="searchindexloader"></script>
 
-<script id="R9wBKTwzv" src="https://app.usercentrics.eu/latest/main.js" type="application/javascript"></script>
+<script id="R9wBKTwzv" src="https://app.usercentrics.eu/latest/main.js"></script>
 <script data-usercentrics="Matomo" src="/js/piwik.js" type="text/plain"></script>
 </body>
 </html>

--- a/tests/Integration/tests-full/index/expected/index.html
+++ b/tests/Integration/tests-full/index/expected/index.html
@@ -1,22 +1,22 @@
 <!DOCTYPE html>
 <html class="no-js" lang="en">
 <head>
-    <meta charset="utf-8"/>
-    <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-    <meta content="Example Project" name="docsearch:name"/>
-    <meta content="" name="docsearch:package_type"/>
-    <meta content="12.4" name="docsearch:release"/>
-    <meta content="12.4" name="docsearch:version"/>
-    <meta content="2023-01-01T12:00:00+00:00" name="docsearch:modified"/>
-    <link href="http://purl.org/dc/elements/1.1/" rel="schema.dc"/>
-    <meta content="2023-01-01T12:00:00+00:00" name="dc.modified"/>
-    <meta content="2023-01-01T12:00:00+00:00" property="article:modified_time"/>
+    <meta charset="utf-8">
+    <meta content="width=device-width, initial-scale=1.0" name="viewport">
+    <meta content="Example Project" name="docsearch:name">
+    <meta content="" name="docsearch:package_type">
+    <meta content="12.4" name="docsearch:release">
+    <meta content="12.4" name="docsearch:version">
+    <meta content="2023-01-01T12:00:00+00:00" name="docsearch:modified">
+    <link href="http://purl.org/dc/elements/1.1/" rel="schema.dc">
+    <meta content="2023-01-01T12:00:00+00:00" name="dc.modified">
+    <meta content="2023-01-01T12:00:00+00:00" property="article:modified_time">
     <title>Document Title — Example Project 12.4 documentation</title>
 
-    <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/fontawesome.css" rel="stylesheet" type="text/css"/>
-    <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/webfonts.css" rel="stylesheet" type="text/css"/>
-    <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/theme.css" rel="stylesheet" type="text/css"/>
-    <link href="https://docs.typo3.org/search/" rel="search" title="Search"/>
+    <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/fontawesome.css" rel="stylesheet">
+    <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/webfonts.css" rel="stylesheet">
+    <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/theme.css" rel="stylesheet">
+    <link href="https://docs.typo3.org/search/" rel="search" title="Search">
                 <link href="/index.html" rel="top" title="Document Title"/>
         <!-- extrahead --><!-- /extrahead -->
     <script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/modernizr.min.js"></script>
@@ -40,7 +40,7 @@
         <div class="page-header-inner">
             <!-- pageheader -->
             <a class="logo" href="https://docs.typo3.org/" title="TYPO3 Documentation">
-                <img alt="TYPO3 Logo" class="logo-image" height="130" src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.4.3/img/typo3-logo.svg" width="484"/>
+                <img alt="TYPO3 Logo" class="logo-image" src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.4.3/img/typo3-logo.svg" width="484" height="130">
             </a>
             <!-- /pageheader -->
         </div>
@@ -50,7 +50,7 @@
         <div class="page-main-inner">
             <div class="page-main-navigation">
                 <nav>
-                    <input class="toc-checkbox" id="toggleToc" type="checkbox"/>
+                    <input class="toc-checkbox" id="toggleToc" type="checkbox">
                     <div class="toc-header">
                         <div class="toc-title">
                             <a class="toc-title-project" href="/">Example Project</a>
@@ -160,7 +160,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     </div>
 </div>
 
-<script type="text/javascript">
+<script>
     var DOCUMENTATION_OPTIONS = {
         URL_ROOT: './',
         VERSION: '12.4',
@@ -169,20 +169,20 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         HAS_SOURCE: true
     };
 </script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/jquery.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/underscore.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/doctools.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/popper.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/bootstrap.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/theme.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/searchtools.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/autocomplete.min.js" type="text/javascript"></script>
-<script type="text/javascript">
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/jquery.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/underscore.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/doctools.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/popper.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/bootstrap.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/theme.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/searchtools.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/autocomplete.min.js"></script>
+<script>
     jQuery(function() { Search.loadIndex("searchindex.js"); });
 </script>
-<script id="searchindexloader" type="text/javascript"></script>
+<script id="searchindexloader"></script>
 
-<script id="R9wBKTwzv" src="https://app.usercentrics.eu/latest/main.js" type="application/javascript"></script>
+<script id="R9wBKTwzv" src="https://app.usercentrics.eu/latest/main.js"></script>
 <script data-usercentrics="Matomo" src="/js/piwik.js" type="text/plain"></script>
 </body>
 </html>

--- a/tests/Integration/tests-full/next-prev/expected/index.html
+++ b/tests/Integration/tests-full/next-prev/expected/index.html
@@ -1,22 +1,22 @@
 <!DOCTYPE html>
 <html class="no-js" lang="en">
 <head>
-    <meta charset="utf-8"/>
-    <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-    <meta content="" name="docsearch:name"/>
-    <meta content="" name="docsearch:package_type"/>
-    <meta content="" name="docsearch:release"/>
-    <meta content="" name="docsearch:version"/>
-    <meta content="2023-01-01T12:00:00+00:00" name="docsearch:modified"/>
-    <link href="http://purl.org/dc/elements/1.1/" rel="schema.dc"/>
-    <meta content="2023-01-01T12:00:00+00:00" name="dc.modified"/>
-    <meta content="2023-01-01T12:00:00+00:00" property="article:modified_time"/>
+    <meta charset="utf-8">
+    <meta content="width=device-width, initial-scale=1.0" name="viewport">
+    <meta content="" name="docsearch:name">
+    <meta content="" name="docsearch:package_type">
+    <meta content="" name="docsearch:release">
+    <meta content="" name="docsearch:version">
+    <meta content="2023-01-01T12:00:00+00:00" name="docsearch:modified">
+    <link href="http://purl.org/dc/elements/1.1/" rel="schema.dc">
+    <meta content="2023-01-01T12:00:00+00:00" name="dc.modified">
+    <meta content="2023-01-01T12:00:00+00:00" property="article:modified_time">
     <title>Document Title documentation</title>
 
-    <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/fontawesome.css" rel="stylesheet" type="text/css"/>
-    <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/webfonts.css" rel="stylesheet" type="text/css"/>
-    <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/theme.css" rel="stylesheet" type="text/css"/>
-    <link href="https://docs.typo3.org/search/" rel="search" title="Search"/>
+    <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/fontawesome.css" rel="stylesheet">
+    <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/webfonts.css" rel="stylesheet">
+    <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/theme.css" rel="stylesheet">
+    <link href="https://docs.typo3.org/search/" rel="search" title="Search">
                 <link href="/page.html" rel="next" title="Page"/>
             <link href="/index.html" rel="top" title="Document Title"/>
         <!-- extrahead --><!-- /extrahead -->
@@ -41,7 +41,7 @@
         <div class="page-header-inner">
             <!-- pageheader -->
             <a class="logo" href="https://docs.typo3.org/" title="TYPO3 Documentation">
-                <img alt="TYPO3 Logo" class="logo-image" height="130" src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.4.3/img/typo3-logo.svg" width="484"/>
+                <img alt="TYPO3 Logo" class="logo-image" src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.4.3/img/typo3-logo.svg" width="484" height="130">
             </a>
             <!-- /pageheader -->
         </div>
@@ -51,7 +51,7 @@
         <div class="page-main-inner">
             <div class="page-main-navigation">
                 <nav>
-                    <input class="toc-checkbox" id="toggleToc" type="checkbox"/>
+                    <input class="toc-checkbox" id="toggleToc" type="checkbox">
                     <div class="toc-header">
                         <div class="toc-title">
                             <a class="toc-title-project" href="/"></a>
@@ -158,7 +158,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     </div>
 </div>
 
-<script type="text/javascript">
+<script>
     var DOCUMENTATION_OPTIONS = {
         URL_ROOT: './',
         VERSION: '',
@@ -167,20 +167,20 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         HAS_SOURCE: true
     };
 </script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/jquery.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/underscore.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/doctools.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/popper.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/bootstrap.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/theme.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/searchtools.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/autocomplete.min.js" type="text/javascript"></script>
-<script type="text/javascript">
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/jquery.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/underscore.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/doctools.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/popper.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/bootstrap.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/theme.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/searchtools.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/autocomplete.min.js"></script>
+<script>
     jQuery(function() { Search.loadIndex("searchindex.js"); });
 </script>
-<script id="searchindexloader" type="text/javascript"></script>
+<script id="searchindexloader"></script>
 
-<script id="R9wBKTwzv" src="https://app.usercentrics.eu/latest/main.js" type="application/javascript"></script>
+<script id="R9wBKTwzv" src="https://app.usercentrics.eu/latest/main.js"></script>
 <script data-usercentrics="Matomo" src="/js/piwik.js" type="text/plain"></script>
 </body>
 </html>

--- a/tests/Integration/tests-full/next-prev/expected/page.html
+++ b/tests/Integration/tests-full/next-prev/expected/page.html
@@ -1,22 +1,22 @@
 <!DOCTYPE html>
 <html class="no-js" lang="en">
 <head>
-    <meta charset="utf-8"/>
-    <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-    <meta content="" name="docsearch:name"/>
-    <meta content="" name="docsearch:package_type"/>
-    <meta content="" name="docsearch:release"/>
-    <meta content="" name="docsearch:version"/>
-    <meta content="2023-01-01T12:00:00+00:00" name="docsearch:modified"/>
-    <link href="http://purl.org/dc/elements/1.1/" rel="schema.dc"/>
-    <meta content="2023-01-01T12:00:00+00:00" name="dc.modified"/>
-    <meta content="2023-01-01T12:00:00+00:00" property="article:modified_time"/>
+    <meta charset="utf-8">
+    <meta content="width=device-width, initial-scale=1.0" name="viewport">
+    <meta content="" name="docsearch:name">
+    <meta content="" name="docsearch:package_type">
+    <meta content="" name="docsearch:release">
+    <meta content="" name="docsearch:version">
+    <meta content="2023-01-01T12:00:00+00:00" name="docsearch:modified">
+    <link href="http://purl.org/dc/elements/1.1/" rel="schema.dc">
+    <meta content="2023-01-01T12:00:00+00:00" name="dc.modified">
+    <meta content="2023-01-01T12:00:00+00:00" property="article:modified_time">
     <title>Page documentation</title>
 
-    <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/fontawesome.css" rel="stylesheet" type="text/css"/>
-    <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/webfonts.css" rel="stylesheet" type="text/css"/>
-    <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/theme.css" rel="stylesheet" type="text/css"/>
-    <link href="https://docs.typo3.org/search/" rel="search" title="Search"/>
+    <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/fontawesome.css" rel="stylesheet">
+    <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/webfonts.css" rel="stylesheet">
+    <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/theme.css" rel="stylesheet">
+    <link href="https://docs.typo3.org/search/" rel="search" title="Search">
                 <link href="/index.html" rel="prev" title="Document Title"/>
             <link href="/yetAnotherPage.html" rel="next" title="Another Page"/>
             <link href="/index.html" rel="top" title="Document Title"/>
@@ -42,7 +42,7 @@
         <div class="page-header-inner">
             <!-- pageheader -->
             <a class="logo" href="https://docs.typo3.org/" title="TYPO3 Documentation">
-                <img alt="TYPO3 Logo" class="logo-image" height="130" src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.4.3/img/typo3-logo.svg" width="484"/>
+                <img alt="TYPO3 Logo" class="logo-image" src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.4.3/img/typo3-logo.svg" width="484" height="130">
             </a>
             <!-- /pageheader -->
         </div>
@@ -52,7 +52,7 @@
         <div class="page-main-inner">
             <div class="page-main-navigation">
                 <nav>
-                    <input class="toc-checkbox" id="toggleToc" type="checkbox"/>
+                    <input class="toc-checkbox" id="toggleToc" type="checkbox">
                     <div class="toc-header">
                         <div class="toc-title">
                             <a class="toc-title-project" href="/"></a>
@@ -166,7 +166,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     </div>
 </div>
 
-<script type="text/javascript">
+<script>
     var DOCUMENTATION_OPTIONS = {
         URL_ROOT: './',
         VERSION: '',
@@ -175,20 +175,20 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         HAS_SOURCE: true
     };
 </script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/jquery.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/underscore.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/doctools.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/popper.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/bootstrap.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/theme.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/searchtools.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/autocomplete.min.js" type="text/javascript"></script>
-<script type="text/javascript">
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/jquery.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/underscore.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/doctools.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/popper.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/bootstrap.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/theme.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/searchtools.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/autocomplete.min.js"></script>
+<script>
     jQuery(function() { Search.loadIndex("searchindex.js"); });
 </script>
-<script id="searchindexloader" type="text/javascript"></script>
+<script id="searchindexloader"></script>
 
-<script id="R9wBKTwzv" src="https://app.usercentrics.eu/latest/main.js" type="application/javascript"></script>
+<script id="R9wBKTwzv" src="https://app.usercentrics.eu/latest/main.js"></script>
 <script data-usercentrics="Matomo" src="/js/piwik.js" type="text/plain"></script>
 </body>
 </html>

--- a/tests/Integration/tests-full/next-prev/expected/yetAnotherPage.html
+++ b/tests/Integration/tests-full/next-prev/expected/yetAnotherPage.html
@@ -1,22 +1,22 @@
 <!DOCTYPE html>
 <html class="no-js" lang="en">
 <head>
-    <meta charset="utf-8"/>
-    <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-    <meta content="" name="docsearch:name"/>
-    <meta content="" name="docsearch:package_type"/>
-    <meta content="" name="docsearch:release"/>
-    <meta content="" name="docsearch:version"/>
-    <meta content="2023-01-01T12:00:00+00:00" name="docsearch:modified"/>
-    <link href="http://purl.org/dc/elements/1.1/" rel="schema.dc"/>
-    <meta content="2023-01-01T12:00:00+00:00" name="dc.modified"/>
-    <meta content="2023-01-01T12:00:00+00:00" property="article:modified_time"/>
+    <meta charset="utf-8">
+    <meta content="width=device-width, initial-scale=1.0" name="viewport">
+    <meta content="" name="docsearch:name">
+    <meta content="" name="docsearch:package_type">
+    <meta content="" name="docsearch:release">
+    <meta content="" name="docsearch:version">
+    <meta content="2023-01-01T12:00:00+00:00" name="docsearch:modified">
+    <link href="http://purl.org/dc/elements/1.1/" rel="schema.dc">
+    <meta content="2023-01-01T12:00:00+00:00" name="dc.modified">
+    <meta content="2023-01-01T12:00:00+00:00" property="article:modified_time">
     <title>Another Page documentation</title>
 
-    <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/fontawesome.css" rel="stylesheet" type="text/css"/>
-    <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/webfonts.css" rel="stylesheet" type="text/css"/>
-    <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/theme.css" rel="stylesheet" type="text/css"/>
-    <link href="https://docs.typo3.org/search/" rel="search" title="Search"/>
+    <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/fontawesome.css" rel="stylesheet">
+    <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/webfonts.css" rel="stylesheet">
+    <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/theme.css" rel="stylesheet">
+    <link href="https://docs.typo3.org/search/" rel="search" title="Search">
                 <link href="/page.html" rel="prev" title="Page"/>
             <link href="/index.html" rel="top" title="Document Title"/>
         <!-- extrahead --><!-- /extrahead -->
@@ -41,7 +41,7 @@
         <div class="page-header-inner">
             <!-- pageheader -->
             <a class="logo" href="https://docs.typo3.org/" title="TYPO3 Documentation">
-                <img alt="TYPO3 Logo" class="logo-image" height="130" src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.4.3/img/typo3-logo.svg" width="484"/>
+                <img alt="TYPO3 Logo" class="logo-image" src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.4.3/img/typo3-logo.svg" width="484" height="130">
             </a>
             <!-- /pageheader -->
         </div>
@@ -51,7 +51,7 @@
         <div class="page-main-inner">
             <div class="page-main-navigation">
                 <nav>
-                    <input class="toc-checkbox" id="toggleToc" type="checkbox"/>
+                    <input class="toc-checkbox" id="toggleToc" type="checkbox">
                     <div class="toc-header">
                         <div class="toc-title">
                             <a class="toc-title-project" href="/"></a>
@@ -159,7 +159,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     </div>
 </div>
 
-<script type="text/javascript">
+<script>
     var DOCUMENTATION_OPTIONS = {
         URL_ROOT: './',
         VERSION: '',
@@ -168,20 +168,20 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         HAS_SOURCE: true
     };
 </script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/jquery.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/underscore.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/doctools.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/popper.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/bootstrap.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/theme.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/searchtools.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/autocomplete.min.js" type="text/javascript"></script>
-<script type="text/javascript">
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/jquery.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/underscore.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/doctools.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/popper.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/bootstrap.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/theme.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/searchtools.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/autocomplete.min.js"></script>
+<script>
     jQuery(function() { Search.loadIndex("searchindex.js"); });
 </script>
-<script id="searchindexloader" type="text/javascript"></script>
+<script id="searchindexloader"></script>
 
-<script id="R9wBKTwzv" src="https://app.usercentrics.eu/latest/main.js" type="application/javascript"></script>
+<script id="R9wBKTwzv" src="https://app.usercentrics.eu/latest/main.js"></script>
 <script data-usercentrics="Matomo" src="/js/piwik.js" type="text/plain"></script>
 </body>
 </html>

--- a/tests/Integration/tests-full/page-with-subpages/expected/index.html
+++ b/tests/Integration/tests-full/page-with-subpages/expected/index.html
@@ -1,22 +1,22 @@
 <!DOCTYPE html>
 <html class="no-js" lang="en">
 <head>
-    <meta charset="utf-8"/>
-    <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-    <meta content="" name="docsearch:name"/>
-    <meta content="" name="docsearch:package_type"/>
-    <meta content="" name="docsearch:release"/>
-    <meta content="" name="docsearch:version"/>
-    <meta content="2023-01-01T12:00:00+00:00" name="docsearch:modified"/>
-    <link href="http://purl.org/dc/elements/1.1/" rel="schema.dc"/>
-    <meta content="2023-01-01T12:00:00+00:00" name="dc.modified"/>
-    <meta content="2023-01-01T12:00:00+00:00" property="article:modified_time"/>
+    <meta charset="utf-8">
+    <meta content="width=device-width, initial-scale=1.0" name="viewport">
+    <meta content="" name="docsearch:name">
+    <meta content="" name="docsearch:package_type">
+    <meta content="" name="docsearch:release">
+    <meta content="" name="docsearch:version">
+    <meta content="2023-01-01T12:00:00+00:00" name="docsearch:modified">
+    <link href="http://purl.org/dc/elements/1.1/" rel="schema.dc">
+    <meta content="2023-01-01T12:00:00+00:00" name="dc.modified">
+    <meta content="2023-01-01T12:00:00+00:00" property="article:modified_time">
     <title>Root index documentation</title>
 
-    <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/fontawesome.css" rel="stylesheet" type="text/css"/>
-    <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/webfonts.css" rel="stylesheet" type="text/css"/>
-    <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/theme.css" rel="stylesheet" type="text/css"/>
-    <link href="https://docs.typo3.org/search/" rel="search" title="Search"/>
+    <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/fontawesome.css" rel="stylesheet">
+    <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/webfonts.css" rel="stylesheet">
+    <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/theme.css" rel="stylesheet">
+    <link href="https://docs.typo3.org/search/" rel="search" title="Search">
                 <link href="sub/index.html" rel="next" title="Sub index"/>
             <link href="#" rel="top" title="Root index"/>
         <!-- extrahead --><!-- /extrahead -->
@@ -41,7 +41,7 @@
         <div class="page-header-inner">
             <!-- pageheader -->
             <a class="logo" href="https://docs.typo3.org/" title="TYPO3 Documentation">
-                <img alt="TYPO3 Logo" class="logo-image" height="130" src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.4.3/img/typo3-logo.svg" width="484"/>
+                <img alt="TYPO3 Logo" class="logo-image" src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.4.3/img/typo3-logo.svg" width="484" height="130">
             </a>
             <!-- /pageheader -->
         </div>
@@ -51,7 +51,7 @@
         <div class="page-main-inner">
             <div class="page-main-navigation">
                 <nav>
-                    <input class="toc-checkbox" id="toggleToc" type="checkbox"/>
+                    <input class="toc-checkbox" id="toggleToc" type="checkbox">
                     <div class="toc-header">
                         <div class="toc-title">
                             <a class="toc-title-project" href="/"></a>
@@ -166,7 +166,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     </div>
 </div>
 
-<script type="text/javascript">
+<script>
     var DOCUMENTATION_OPTIONS = {
         URL_ROOT: './',
         VERSION: '',
@@ -175,20 +175,20 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         HAS_SOURCE: true
     };
 </script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/jquery.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/underscore.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/doctools.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/popper.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/bootstrap.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/theme.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/searchtools.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/autocomplete.min.js" type="text/javascript"></script>
-<script type="text/javascript">
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/jquery.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/underscore.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/doctools.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/popper.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/bootstrap.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/theme.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/searchtools.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/autocomplete.min.js"></script>
+<script>
     jQuery(function() { Search.loadIndex("searchindex.js"); });
 </script>
-<script id="searchindexloader" type="text/javascript"></script>
+<script id="searchindexloader"></script>
 
-<script id="R9wBKTwzv" src="https://app.usercentrics.eu/latest/main.js" type="application/javascript"></script>
+<script id="R9wBKTwzv" src="https://app.usercentrics.eu/latest/main.js"></script>
 <script data-usercentrics="Matomo" src="/js/piwik.js" type="text/plain"></script>
 </body>
 </html>

--- a/tests/Integration/tests-full/page-with-subpages/expected/sub/index.html
+++ b/tests/Integration/tests-full/page-with-subpages/expected/sub/index.html
@@ -1,22 +1,22 @@
 <!DOCTYPE html>
 <html class="no-js" lang="en">
 <head>
-    <meta charset="utf-8"/>
-    <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-    <meta content="" name="docsearch:name"/>
-    <meta content="" name="docsearch:package_type"/>
-    <meta content="" name="docsearch:release"/>
-    <meta content="" name="docsearch:version"/>
-    <meta content="2023-01-01T12:00:00+00:00" name="docsearch:modified"/>
-    <link href="http://purl.org/dc/elements/1.1/" rel="schema.dc"/>
-    <meta content="2023-01-01T12:00:00+00:00" name="dc.modified"/>
-    <meta content="2023-01-01T12:00:00+00:00" property="article:modified_time"/>
+    <meta charset="utf-8">
+    <meta content="width=device-width, initial-scale=1.0" name="viewport">
+    <meta content="" name="docsearch:name">
+    <meta content="" name="docsearch:package_type">
+    <meta content="" name="docsearch:release">
+    <meta content="" name="docsearch:version">
+    <meta content="2023-01-01T12:00:00+00:00" name="docsearch:modified">
+    <link href="http://purl.org/dc/elements/1.1/" rel="schema.dc">
+    <meta content="2023-01-01T12:00:00+00:00" name="dc.modified">
+    <meta content="2023-01-01T12:00:00+00:00" property="article:modified_time">
     <title>Sub index documentation</title>
 
-    <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/fontawesome.css" rel="stylesheet" type="text/css"/>
-    <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/webfonts.css" rel="stylesheet" type="text/css"/>
-    <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/theme.css" rel="stylesheet" type="text/css"/>
-    <link href="https://docs.typo3.org/search/" rel="search" title="Search"/>
+    <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/fontawesome.css" rel="stylesheet">
+    <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/webfonts.css" rel="stylesheet">
+    <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/theme.css" rel="stylesheet">
+    <link href="https://docs.typo3.org/search/" rel="search" title="Search">
                 <link href="../index.html" rel="prev" title="Root index"/>
             <link href="../index.html" rel="top" title="Root index"/>
         <!-- extrahead --><!-- /extrahead -->
@@ -41,7 +41,7 @@
         <div class="page-header-inner">
             <!-- pageheader -->
             <a class="logo" href="https://docs.typo3.org/" title="TYPO3 Documentation">
-                <img alt="TYPO3 Logo" class="logo-image" height="130" src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.4.3/img/typo3-logo.svg" width="484"/>
+                <img alt="TYPO3 Logo" class="logo-image" src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.4.3/img/typo3-logo.svg" width="484" height="130">
             </a>
             <!-- /pageheader -->
         </div>
@@ -51,7 +51,7 @@
         <div class="page-main-inner">
             <div class="page-main-navigation">
                 <nav>
-                    <input class="toc-checkbox" id="toggleToc" type="checkbox"/>
+                    <input class="toc-checkbox" id="toggleToc" type="checkbox">
                     <div class="toc-header">
                         <div class="toc-title">
                             <a class="toc-title-project" href="/"></a>
@@ -162,7 +162,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     </div>
 </div>
 
-<script type="text/javascript">
+<script>
     var DOCUMENTATION_OPTIONS = {
         URL_ROOT: './',
         VERSION: '',
@@ -171,20 +171,20 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         HAS_SOURCE: true
     };
 </script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/jquery.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/underscore.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/doctools.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/popper.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/bootstrap.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/theme.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/searchtools.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/autocomplete.min.js" type="text/javascript"></script>
-<script type="text/javascript">
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/jquery.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/underscore.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/doctools.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/popper.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/bootstrap.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/theme.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/searchtools.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/autocomplete.min.js"></script>
+<script>
     jQuery(function() { Search.loadIndex("searchindex.js"); });
 </script>
-<script id="searchindexloader" type="text/javascript"></script>
+<script id="searchindexloader"></script>
 
-<script id="R9wBKTwzv" src="https://app.usercentrics.eu/latest/main.js" type="application/javascript"></script>
+<script id="R9wBKTwzv" src="https://app.usercentrics.eu/latest/main.js"></script>
 <script data-usercentrics="Matomo" src="/js/piwik.js" type="text/plain"></script>
 </body>
 </html>

--- a/tests/Integration/tests-full/sitemap/expected/Sitemap.html
+++ b/tests/Integration/tests-full/sitemap/expected/Sitemap.html
@@ -1,22 +1,22 @@
 <!DOCTYPE html>
 <html class="no-js" lang="en">
 <head>
-    <meta charset="utf-8"/>
-    <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-    <meta content="" name="docsearch:name"/>
-    <meta content="" name="docsearch:package_type"/>
-    <meta content="" name="docsearch:release"/>
-    <meta content="" name="docsearch:version"/>
-    <meta content="2023-01-01T12:00:00+00:00" name="docsearch:modified"/>
-    <link href="http://purl.org/dc/elements/1.1/" rel="schema.dc"/>
-    <meta content="2023-01-01T12:00:00+00:00" name="dc.modified"/>
-    <meta content="2023-01-01T12:00:00+00:00" property="article:modified_time"/>
+    <meta charset="utf-8">
+    <meta content="width=device-width, initial-scale=1.0" name="viewport">
+    <meta content="" name="docsearch:name">
+    <meta content="" name="docsearch:package_type">
+    <meta content="" name="docsearch:release">
+    <meta content="" name="docsearch:version">
+    <meta content="2023-01-01T12:00:00+00:00" name="docsearch:modified">
+    <link href="http://purl.org/dc/elements/1.1/" rel="schema.dc">
+    <meta content="2023-01-01T12:00:00+00:00" name="dc.modified">
+    <meta content="2023-01-01T12:00:00+00:00" property="article:modified_time">
     <title>Sitemap documentation</title>
 
-    <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/fontawesome.css" rel="stylesheet" type="text/css"/>
-    <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/webfonts.css" rel="stylesheet" type="text/css"/>
-    <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/theme.css" rel="stylesheet" type="text/css"/>
-    <link href="https://docs.typo3.org/search/" rel="search" title="Search"/>
+    <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/fontawesome.css" rel="stylesheet">
+    <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/webfonts.css" rel="stylesheet">
+    <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/theme.css" rel="stylesheet">
+    <link href="https://docs.typo3.org/search/" rel="search" title="Search">
                 <link href="/page1.html" rel="prev" title="Page 1"/>
             <link href="/subpages/index.html" rel="next" title="Subpages"/>
             <link href="/index.html" rel="top" title="Document Title"/>
@@ -42,7 +42,7 @@
         <div class="page-header-inner">
             <!-- pageheader -->
             <a class="logo" href="https://docs.typo3.org/" title="TYPO3 Documentation">
-                <img alt="TYPO3 Logo" class="logo-image" height="130" src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.4.3/img/typo3-logo.svg" width="484"/>
+                <img alt="TYPO3 Logo" class="logo-image" src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.4.3/img/typo3-logo.svg" width="484" height="130">
             </a>
             <!-- /pageheader -->
         </div>
@@ -52,7 +52,7 @@
         <div class="page-main-inner">
             <div class="page-main-navigation">
                 <nav>
-                    <input class="toc-checkbox" id="toggleToc" type="checkbox"/>
+                    <input class="toc-checkbox" id="toggleToc" type="checkbox">
                     <div class="toc-header">
                         <div class="toc-title">
                             <a class="toc-title-project" href="/"></a>
@@ -226,7 +226,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     </div>
 </div>
 
-<script type="text/javascript">
+<script>
     var DOCUMENTATION_OPTIONS = {
         URL_ROOT: './',
         VERSION: '',
@@ -235,20 +235,20 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         HAS_SOURCE: true
     };
 </script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/jquery.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/underscore.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/doctools.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/popper.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/bootstrap.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/theme.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/searchtools.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/autocomplete.min.js" type="text/javascript"></script>
-<script type="text/javascript">
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/jquery.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/underscore.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/doctools.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/popper.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/bootstrap.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/theme.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/searchtools.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/autocomplete.min.js"></script>
+<script>
     jQuery(function() { Search.loadIndex("searchindex.js"); });
 </script>
-<script id="searchindexloader" type="text/javascript"></script>
+<script id="searchindexloader"></script>
 
-<script id="R9wBKTwzv" src="https://app.usercentrics.eu/latest/main.js" type="application/javascript"></script>
+<script id="R9wBKTwzv" src="https://app.usercentrics.eu/latest/main.js"></script>
 <script data-usercentrics="Matomo" src="/js/piwik.js" type="text/plain"></script>
 </body>
 </html>

--- a/tests/Integration/tests-full/sitemap/expected/index.html
+++ b/tests/Integration/tests-full/sitemap/expected/index.html
@@ -1,22 +1,22 @@
 <!DOCTYPE html>
 <html class="no-js" lang="en">
 <head>
-    <meta charset="utf-8"/>
-    <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-    <meta content="" name="docsearch:name"/>
-    <meta content="" name="docsearch:package_type"/>
-    <meta content="" name="docsearch:release"/>
-    <meta content="" name="docsearch:version"/>
-    <meta content="2023-01-01T12:00:00+00:00" name="docsearch:modified"/>
-    <link href="http://purl.org/dc/elements/1.1/" rel="schema.dc"/>
-    <meta content="2023-01-01T12:00:00+00:00" name="dc.modified"/>
-    <meta content="2023-01-01T12:00:00+00:00" property="article:modified_time"/>
+    <meta charset="utf-8">
+    <meta content="width=device-width, initial-scale=1.0" name="viewport">
+    <meta content="" name="docsearch:name">
+    <meta content="" name="docsearch:package_type">
+    <meta content="" name="docsearch:release">
+    <meta content="" name="docsearch:version">
+    <meta content="2023-01-01T12:00:00+00:00" name="docsearch:modified">
+    <link href="http://purl.org/dc/elements/1.1/" rel="schema.dc">
+    <meta content="2023-01-01T12:00:00+00:00" name="dc.modified">
+    <meta content="2023-01-01T12:00:00+00:00" property="article:modified_time">
     <title>Document Title documentation</title>
 
-    <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/fontawesome.css" rel="stylesheet" type="text/css"/>
-    <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/webfonts.css" rel="stylesheet" type="text/css"/>
-    <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/theme.css" rel="stylesheet" type="text/css"/>
-    <link href="https://docs.typo3.org/search/" rel="search" title="Search"/>
+    <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/fontawesome.css" rel="stylesheet">
+    <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/webfonts.css" rel="stylesheet">
+    <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/theme.css" rel="stylesheet">
+    <link href="https://docs.typo3.org/search/" rel="search" title="Search">
                 <link href="/page1.html" rel="next" title="Page 1"/>
             <link href="/index.html" rel="top" title="Document Title"/>
         <!-- extrahead --><!-- /extrahead -->
@@ -41,7 +41,7 @@
         <div class="page-header-inner">
             <!-- pageheader -->
             <a class="logo" href="https://docs.typo3.org/" title="TYPO3 Documentation">
-                <img alt="TYPO3 Logo" class="logo-image" height="130" src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.4.3/img/typo3-logo.svg" width="484"/>
+                <img alt="TYPO3 Logo" class="logo-image" src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.4.3/img/typo3-logo.svg" width="484" height="130">
             </a>
             <!-- /pageheader -->
         </div>
@@ -51,7 +51,7 @@
         <div class="page-main-inner">
             <div class="page-main-navigation">
                 <nav>
-                    <input class="toc-checkbox" id="toggleToc" type="checkbox"/>
+                    <input class="toc-checkbox" id="toggleToc" type="checkbox">
                     <div class="toc-header">
                         <div class="toc-title">
                             <a class="toc-title-project" href="/"></a>
@@ -201,7 +201,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     </div>
 </div>
 
-<script type="text/javascript">
+<script>
     var DOCUMENTATION_OPTIONS = {
         URL_ROOT: './',
         VERSION: '',
@@ -210,20 +210,20 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         HAS_SOURCE: true
     };
 </script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/jquery.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/underscore.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/doctools.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/popper.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/bootstrap.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/theme.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/searchtools.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/autocomplete.min.js" type="text/javascript"></script>
-<script type="text/javascript">
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/jquery.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/underscore.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/doctools.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/popper.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/bootstrap.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/theme.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/searchtools.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/autocomplete.min.js"></script>
+<script>
     jQuery(function() { Search.loadIndex("searchindex.js"); });
 </script>
-<script id="searchindexloader" type="text/javascript"></script>
+<script id="searchindexloader"></script>
 
-<script id="R9wBKTwzv" src="https://app.usercentrics.eu/latest/main.js" type="application/javascript"></script>
+<script id="R9wBKTwzv" src="https://app.usercentrics.eu/latest/main.js"></script>
 <script data-usercentrics="Matomo" src="/js/piwik.js" type="text/plain"></script>
 </body>
 </html>

--- a/tests/Integration/tests-full/two-toctrees/expected/index.html
+++ b/tests/Integration/tests-full/two-toctrees/expected/index.html
@@ -1,22 +1,22 @@
 <!DOCTYPE html>
 <html class="no-js" lang="en">
 <head>
-    <meta charset="utf-8"/>
-    <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-    <meta content="Example Project" name="docsearch:name"/>
-    <meta content="" name="docsearch:package_type"/>
-    <meta content="12.4" name="docsearch:release"/>
-    <meta content="12.4" name="docsearch:version"/>
-    <meta content="2023-01-01T12:00:00+00:00" name="docsearch:modified"/>
-    <link href="http://purl.org/dc/elements/1.1/" rel="schema.dc"/>
-    <meta content="2023-01-01T12:00:00+00:00" name="dc.modified"/>
-    <meta content="2023-01-01T12:00:00+00:00" property="article:modified_time"/>
+    <meta charset="utf-8">
+    <meta content="width=device-width, initial-scale=1.0" name="viewport">
+    <meta content="Example Project" name="docsearch:name">
+    <meta content="" name="docsearch:package_type">
+    <meta content="12.4" name="docsearch:release">
+    <meta content="12.4" name="docsearch:version">
+    <meta content="2023-01-01T12:00:00+00:00" name="docsearch:modified">
+    <link href="http://purl.org/dc/elements/1.1/" rel="schema.dc">
+    <meta content="2023-01-01T12:00:00+00:00" name="dc.modified">
+    <meta content="2023-01-01T12:00:00+00:00" property="article:modified_time">
     <title>Document Title — Example Project 12.4 documentation</title>
 
-    <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/fontawesome.css" rel="stylesheet" type="text/css"/>
-    <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/webfonts.css" rel="stylesheet" type="text/css"/>
-    <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/theme.css" rel="stylesheet" type="text/css"/>
-    <link href="https://docs.typo3.org/search/" rel="search" title="Search"/>
+    <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/fontawesome.css" rel="stylesheet">
+    <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/webfonts.css" rel="stylesheet">
+    <link href="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/css/theme.css" rel="stylesheet">
+    <link href="https://docs.typo3.org/search/" rel="search" title="Search">
                 <link href="page1.html" rel="next" title="Page 1"/>
             <link href="#" rel="top" title="Document Title"/>
         <!-- extrahead --><!-- /extrahead -->
@@ -41,7 +41,7 @@
         <div class="page-header-inner">
             <!-- pageheader -->
             <a class="logo" href="https://docs.typo3.org/" title="TYPO3 Documentation">
-                <img alt="TYPO3 Logo" class="logo-image" height="130" src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.4.3/img/typo3-logo.svg" width="484"/>
+                <img alt="TYPO3 Logo" class="logo-image" src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.4.3/img/typo3-logo.svg" width="484" height="130">
             </a>
             <!-- /pageheader -->
         </div>
@@ -51,7 +51,7 @@
         <div class="page-main-inner">
             <div class="page-main-navigation">
                 <nav>
-                    <input class="toc-checkbox" id="toggleToc" type="checkbox"/>
+                    <input class="toc-checkbox" id="toggleToc" type="checkbox">
                     <div class="toc-header">
                         <div class="toc-title">
                             <a class="toc-title-project" href="/">Example Project</a>
@@ -202,7 +202,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     </div>
 </div>
 
-<script type="text/javascript">
+<script>
     var DOCUMENTATION_OPTIONS = {
         URL_ROOT: './',
         VERSION: '12.4',
@@ -211,20 +211,20 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         HAS_SOURCE: true
     };
 </script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/jquery.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/underscore.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/doctools.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/popper.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/bootstrap.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/theme.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/searchtools.min.js" type="text/javascript"></script>
-<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/autocomplete.min.js" type="text/javascript"></script>
-<script type="text/javascript">
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/jquery.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/underscore.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/doctools.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/popper.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/bootstrap.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/theme.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/searchtools.min.js"></script>
+<script src="https://typo3.azureedge.net/typo3documentation/theme/sphinx_typo3_theme/4.9.0/js/autocomplete.min.js"></script>
+<script>
     jQuery(function() { Search.loadIndex("searchindex.js"); });
 </script>
-<script id="searchindexloader" type="text/javascript"></script>
+<script id="searchindexloader"></script>
 
-<script id="R9wBKTwzv" src="https://app.usercentrics.eu/latest/main.js" type="application/javascript"></script>
+<script id="R9wBKTwzv" src="https://app.usercentrics.eu/latest/main.js"></script>
 <script data-usercentrics="Matomo" src="/js/piwik.js" type="text/plain"></script>
 </body>
 </html>


### PR DESCRIPTION
- Remove superfluous closing `/`
- Remove superfluous `type="text/css"` in stylesheet links
- Remove superfluous `type="text/javascript"` in script tags