### PR TITLE
[TASK] Move logic for parsing Settings.cfg into a separate class

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,6 +47,7 @@
     },
     "autoload-dev": {
         "psr-4": {
+            "T3Docs\\GuidesCli\\Tests\\": "tests/",
             "T3Docs\\Typo3DocsTheme\\": "tests/"
         }
     },

--- a/packages/typo3-guides-cli/src/Repository/Exception/FileException.php
+++ b/packages/typo3-guides-cli/src/Repository/Exception/FileException.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace T3Docs\GuidesCli\Repository\Exception;
+
+final class FileException extends \RuntimeException
+{
+    public static function notFound(string $filePath): self
+    {
+        return new self(
+            \sprintf(
+                'File "%s" cannot be found!',
+                $filePath,
+            )
+        );
+    }
+
+    public static function notReadable(string $filePath): self
+    {
+        return new self(
+            \sprintf(
+                'File "%s" cannot be read!',
+                $filePath,
+            )
+        );
+    }
+
+    public static function notParsable(string $filePath): self
+    {
+        return new self(
+            \sprintf(
+                'File "%s" cannot be parsed!',
+                $filePath,
+            )
+        );
+    }
+}

--- a/packages/typo3-guides-cli/src/Repository/LegacySettingsRepository.php
+++ b/packages/typo3-guides-cli/src/Repository/LegacySettingsRepository.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace T3Docs\GuidesCli\Repository;
+
+use T3Docs\GuidesCli\Repository\Exception\FileException;
+
+class LegacySettingsRepository
+{
+    /**
+     * @return array<string, string>
+     */
+    public function get(string $filePath): array
+    {
+        if (!file_exists($filePath)) {
+            throw FileException::notFound($filePath);
+        }
+
+        // Settings.cfg can be parsed as an INI file. If it fails, bail out.
+        $fileContent = file_get_contents($filePath);
+        if ($fileContent === false) {
+            throw FileException::notReadable($filePath);
+        }
+
+        // Remove lines starting with a hashtag and optional whitespace
+        $filteredContent = preg_replace('/^\s*#.*$/m', '', $fileContent);
+        if ($filteredContent === null) {
+            throw FileException::notParsable($filePath);
+        }
+
+        // When invalid syntax is given an error is thrown. We do not want this,
+        // as we check the result of the function, so we silence the error with
+        // "@".
+        $settings = @parse_ini_string($filteredContent, true, INI_SCANNER_RAW);
+        if (!is_array($settings)) {
+            throw FileException::notParsable($filePath);
+        }
+
+        return $settings;
+    }
+}

--- a/packages/typo3-guides-cli/tests/fixtures/Settings.cfg
+++ b/packages/typo3-guides-cli/tests/fixtures/Settings.cfg
@@ -1,0 +1,66 @@
+# More information about this file:
+# https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/GeneralConventions/FileStructure.html#settings-cfg
+
+[general]
+
+project     = Fluid ViewHelper Reference
+version     = main (development)
+release     = main (development)
+copyright   = since 2018 by the TYPO3 contributors
+
+[html_theme_options]
+
+# "Edit on GitHub" button
+# !!! Do not show "Edit on GitHub" in automatically generated ViewHelper reference
+# github_repository    = TYPO3-Documentation/TYPO3CMS-Reference-ViewHelper
+# github_branch        = main
+
+# Footer links
+project_home         = https://docs.typo3.org/other/typo3/view-helper-reference/main/en-us/
+project_contact      = https://typo3.slack.com/archives/C028JEPJL
+project_repository   = https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-ViewHelper
+project_issues       = https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-ViewHelper/issues
+project_discussions  =
+
+use_opensearch       =
+
+[intersphinx_mapping]
+
+# Official TYPO3 manuals
+h2document     = https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/
+# t3cheatsheets  = https://docs.typo3.org/m/typo3/docs-cheatsheets/main/en-us/
+# t3contribute   = https://docs.typo3.org/m/typo3/guide-contributionworkflow/main/en-us/
+t3coreapi      = https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/
+# t3docteam      = https://docs.typo3.org/m/typo3/team-t3docteam/main/en-us/
+# t3editors      = https://docs.typo3.org/m/typo3/tutorial-editors/main/en-us/
+# t3extexample   = https://docs.typo3.org/m/typo3/guide-example-extension-manual/main/en-us/
+# t3home         = https://docs.typo3.org/
+# t3install      = https://docs.typo3.org/m/typo3/guide-installation/main/en-us/
+# t3l10n         = https://docs.typo3.org/m/typo3/guide-frontendlocalization/main/en-us/
+# t3sitepackage  = https://docs.typo3.org/m/typo3/tutorial-sitepackage/main/en-us/
+# t3start        = https://docs.typo3.org/m/typo3/tutorial-getting-started/main/en-us/
+# t3tca          = https://docs.typo3.org/m/typo3/reference-tca/main/en-us/
+# t3templating   = https://docs.typo3.org/m/typo3/tutorial-templating/main/en-us/
+# t3translate    = https://docs.typo3.org/m/typo3/guide-frontendlocalization/main/en-us/
+# t3tsconfig     = https://docs.typo3.org/m/typo3/reference-tsconfig/main/en-us/
+# t3tsref        = https://docs.typo3.org/m/typo3/reference-typoscript/main/en-us/
+# t3ts45         = https://docs.typo3.org/m/typo3/tutorial-typoscript-in-45-minutes/main/en-us/
+# t3viewhelper   = https://docs.typo3.org/other/typo3/view-helper-reference/main/en-us/
+# t3upgrade      = https://docs.typo3.org/m/typo3/guide-installation/main/en-us/
+
+# TYPO3 system extensions
+# ext_adminpanel     = https://docs.typo3.org/c/typo3/cms-adminpanel/main/en-us/
+# ext_core           = https://docs.typo3.org/c/typo3/cms-core/main/en-us/
+# ext_dashboard      = https://docs.typo3.org/c/typo3/cms-dashboard/main/en-us/
+# ext_felogin        = https://docs.typo3.org/c/typo3/cms-felogin/main/en-us/
+# ext_form           = https://docs.typo3.org/c/typo3/cms-form/main/en-us/
+# ext_fsc            = https://docs.typo3.org/c/typo3/cms-fluid-styled-content/main/en-us/
+# ext_indexed_search = https://docs.typo3.org/c/typo3/cms-indexed-search/main/en-us/
+# ext_rte_ckeditor   = https://docs.typo3.org/c/typo3/cms-rte-ckeditor/main/en-us/
+# ext_scheduler      = https://docs.typo3.org/c/typo3/cms-scheduler/main/en-us/
+# ext_seo            = https://docs.typo3.org/c/typo3/cms-seo/main/en-us/
+# ext_workspaces     = https://docs.typo3.org/c/typo3/cms-workspaces/main/en-us/
+
+# Others
+
+other_typo3fluid     = https://docs.typo3.org/other/typo3fluid/fluid/main/en-us/

--- a/packages/typo3-guides-cli/tests/unit/Repository/Exception/FileExceptionTest.php
+++ b/packages/typo3-guides-cli/tests/unit/Repository/Exception/FileExceptionTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace T3Docs\GuidesCli\Tests\Repository\Exception;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use T3Docs\GuidesCli\Repository\Exception\FileException;
+
+final class FileExceptionTest extends TestCase
+{
+    #[Test]
+    public function classIsInstanceOfRuntimeException(): void
+    {
+        self::assertInstanceOf(\RuntimeException::class, new FileException());
+    }
+
+    #[Test]
+    public function notFound(): void
+    {
+        $actual = FileException::notFound('/some/path/to/Settings.cfg');
+
+        $expectedMessage = 'File "/some/path/to/Settings.cfg" cannot be found!';
+
+        self::assertInstanceOf(FileException::class, $actual);
+        self::assertSame($expectedMessage, $actual->getMessage());
+    }
+
+    #[Test]
+    public function notReadable(): void
+    {
+        $actual = FileException::notReadable('/some/path/to/Settings.cfg');
+
+        $expectedMessage = 'File "/some/path/to/Settings.cfg" cannot be read!';
+
+        self::assertInstanceOf(FileException::class, $actual);
+        self::assertSame($expectedMessage, $actual->getMessage());
+    }
+
+    #[Test]
+    public function notParsable(): void
+    {
+        $actual = FileException::notParsable('/some/path/to/Settings.cfg');
+
+        $expectedMessage = 'File "/some/path/to/Settings.cfg" cannot be parsed!';
+
+        self::assertInstanceOf(FileException::class, $actual);
+        self::assertSame($expectedMessage, $actual->getMessage());
+    }
+}

--- a/packages/typo3-guides-cli/tests/unit/Repository/LegacySettingsRepositoryTest.php
+++ b/packages/typo3-guides-cli/tests/unit/Repository/LegacySettingsRepositoryTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace T3Docs\GuidesCli\Tests\Repository;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use T3Docs\GuidesCli\Repository\Exception\FileException;
+use T3Docs\GuidesCli\Repository\LegacySettingsRepository;
+
+final class LegacySettingsRepositoryTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $this->subject = new LegacySettingsRepository();
+    }
+
+    #[Test]
+    public function settingsAreReturnedCorrectly(): void
+    {
+        $actual = $this->subject->get(realpath(__DIR__ . '/../../fixtures/Settings.cfg') ?: '');
+
+        self::assertSame([
+            'general' => [
+                'project' => 'Fluid ViewHelper Reference',
+                'version' => 'main (development)',
+                'release' => 'main (development)',
+                'copyright' => 'since 2018 by the TYPO3 contributors',
+            ],
+            'html_theme_options' => [
+                'project_home' => 'https://docs.typo3.org/other/typo3/view-helper-reference/main/en-us/',
+                'project_contact' => 'https://typo3.slack.com/archives/C028JEPJL',
+                'project_repository' => 'https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-ViewHelper',
+                'project_issues' => 'https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-ViewHelper/issues',
+                'project_discussions' => '',
+                'use_opensearch' => '',
+            ],
+            'intersphinx_mapping' => [
+                'h2document' => 'https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/',
+                't3coreapi' => 'https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/',
+                'other_typo3fluid' => 'https://docs.typo3.org/other/typo3fluid/fluid/main/en-us/',
+            ],
+        ], $actual);
+    }
+
+    #[Test]
+    public function whenFileDoesNotExistAnExceptionIsThrown(): void
+    {
+        $this->expectException(FileException::class);
+        $this->expectExceptionMessageMatches('/not.*found/');
+
+        $this->subject->get(sys_get_temp_dir() . '/cli_guides_test_' . uniqid() . '/Settings.cfg');
+    }
+
+    #[Test]
+    public function whenFileCannotParsedAnExceptionIsThrown(): void
+    {
+        $this->expectException(FileException::class);
+        $this->expectExceptionMessageMatches('/not.*parsed/');
+
+        $folder = sys_get_temp_dir() . '/cli_guides_test_' . uniqid();
+        $filePath = $folder . '/Settings.cfg';
+        mkdir($folder);
+        file_put_contents($filePath, '(invalid key) = some value');
+
+        $this->subject->get($filePath);
+    }
+}


### PR DESCRIPTION
This is the first step in refactoring the "god" command class for migrating settings. The handling of reading and parsing of the Settings.cfg is moved into a separate class.

Additionally, now we can add initial unit tests.