### PR TITLE
[TASK] Downgrade to nodejs 18

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -13,7 +13,7 @@ webimage_extra_packages: [build-essential]
 use_dns_when_possible: true
 composer_version: "2"
 web_environment: []
-nodejs_version: "20"
+nodejs_version: "18"
 
 # Key features of DDEV's config.yaml:
 


### PR DESCRIPTION
Unfortunary nodejs 20 does not run on my current machine as I cannot upgrade my ddev. As soon as I have upgraded my hardware we can switch back to nodejs 20.