### PR TITLE
[TASK] Update codehighlight extension to log non-existing languages

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -12,12 +12,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/brotkrueml/twig-codehighlight.git",
-                "reference": "ae9775ca23d5a3e4375317ff2c23a445858d3cde"
+                "reference": "55aa9036035e0d14244a2869fc9ec1aac6f235c2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/brotkrueml/twig-codehighlight/zipball/ae9775ca23d5a3e4375317ff2c23a445858d3cde",
-                "reference": "ae9775ca23d5a3e4375317ff2c23a445858d3cde",
+                "url": "https://api.github.com/repos/brotkrueml/twig-codehighlight/zipball/55aa9036035e0d14244a2869fc9ec1aac6f235c2",
+                "reference": "55aa9036035e0d14244a2869fc9ec1aac6f235c2",
                 "shasum": ""
             },
             "require": {
@@ -31,7 +31,11 @@
                 "infection/infection": "^0.27.8",
                 "phpstan/phpstan": "1.10.41",
                 "phpunit/phpunit": "^10.4",
+                "psr/log": "^3.0",
                 "rector/rector": "0.18.7"
+            },
+            "suggest": {
+                "psr/log": "Output a warning when a given language is not available"
             },
             "default-branch": true,
             "type": "library",
@@ -63,7 +67,7 @@
                 "source": "https://github.com/brotkrueml/twig-codehighlight/tree/main",
                 "issues": "https://github.com/brotkrueml/twig-codehighlight/issues"
             },
-            "time": "2023-11-22T10:11:48+00:00"
+            "time": "2023-11-25T18:31:36+00:00"
         },
         {
             "name": "dflydev/dot-access-data",


### PR DESCRIPTION
The logger will be injected automatically by dependency injection.

A log entry looks now like this:

    [2023-11-25T19:34:34.186907+01:00] app.WARNING: Language "kjsdfhs" is not available to highlight code [] []