### PR TITLE
[BUGFIX] Limit PHP to 8.1 during phar building.

### DIFF
--- a/.github/workflows/phar.yaml
+++ b/.github/workflows/phar.yaml
@@ -7,6 +7,10 @@ on:
     types:
       - published
 
+env:
+  DEFAULT_PHP_VERSION: "8.1"
+  RUN_ENVIRONMENT: "local"
+
 name: Phar
 jobs:
   build:


### PR DESCRIPTION
shivammathur/setup-php@v2 currently fails with PHP 8.3 See for example https://github.com/TYPO3-Documentation/render-guides/actions/runs/6995451358/job/19030317471?pr=144