### PR TITLE
[TASK] Move class constants into dedicated enums

### DIFF
--- a/packages/typo3-guides-cli/src/Migration/Deprecated.php
+++ b/packages/typo3-guides-cli/src/Migration/Deprecated.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace T3Docs\GuidesCli\Migration;
+
+/**
+ * List of all Settings.cfg sections that are not covered by this converter
+ */
+enum Deprecated
+{
+    case latex_elements;
+    case notify;
+}

--- a/packages/typo3-guides-cli/src/Migration/HtmlThemeOptions.php
+++ b/packages/typo3-guides-cli/src/Migration/HtmlThemeOptions.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace T3Docs\GuidesCli\Migration;
+
+/**
+ * Mapping of a Settings.cfg key for [html_theme_options] to the guides.xml
+ * <extension> element
+ */
+enum HtmlThemeOptions: string
+{
+    case project_home = 'project-home';
+    case project_contact = 'project-contact';
+    case project_repository = 'project-repository';
+    case project_issues = 'project-issues';
+    case project_discussions = 'project-discussions';
+
+    case use_opensearch = 'use-opensearch';
+
+    case github_revision_msg = 'github-revision-msg';
+    case github_branch = 'edit-on-github-branch';
+    case github_repository = 'edit-on-github';
+    case github_sphinx_locale = 'github-sphinx-locale';
+    case github_commit_hash = 'github-commit-hash';
+}

--- a/packages/typo3-guides-cli/src/Migration/Project.php
+++ b/packages/typo3-guides-cli/src/Migration/Project.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace T3Docs\GuidesCli\Migration;
+
+/**
+ * Mapping of a Settings.cfg key for [general] to the XML <project> element
+ */
+enum Project: string
+{
+    case project = 'title';
+    case release = 'release';
+    case version = 'version';
+    case copyright = 'copyright';
+}

--- a/packages/typo3-guides-cli/src/Migration/Sections.php
+++ b/packages/typo3-guides-cli/src/Migration/Sections.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace T3Docs\GuidesCli\Migration;
+
+/**
+ * List of all Settings.cfg sections that are converted
+ */
+enum Sections
+{
+    case html_theme_options;
+    case general;
+    case intersphinx_mapping;
+
+    /**
+     * @return list<string>
+     */
+    public static function names(): array
+    {
+        return array_map(
+            static fn(self $section): string => $section->name,
+            self::cases()
+        );
+    }
+}


### PR DESCRIPTION
The goal is to reduce the "god" command for migrating the legacy configuration. This change moves the class constants into dedicated enums to decouple them from the command. A next step would be to move the logic for building the XML into a dedicated class.