### PR TITLE
[TASK] Move XML handling out of MigrateSettingsCommand

### DIFF
--- a/packages/typo3-guides-cli/src/Command/MigrateSettingsCommand.php
+++ b/packages/typo3-guides-cli/src/Command/MigrateSettingsCommand.php
@@ -9,10 +9,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use T3Docs\GuidesCli\Migration\Deprecated;
-use T3Docs\GuidesCli\Migration\HtmlThemeOptions;
-use T3Docs\GuidesCli\Migration\Project;
-use T3Docs\GuidesCli\Migration\Sections;
+use T3Docs\GuidesCli\Migration\SettingsMigrator;
 use T3Docs\GuidesCli\Repository\LegacySettingsRepository;
 
 final class MigrateSettingsCommand extends Command
@@ -20,15 +17,13 @@ final class MigrateSettingsCommand extends Command
     protected static $defaultName = 'migrate';
 
     private readonly LegacySettingsRepository $legacySettingsRepository;
+    private readonly SettingsMigrator $settingsMigrator;
 
     /** @var \DOMDocument Holds the XML document that will be written (guides.xml) */
     private \DOMDocument $xmlDocument;
 
-    /** @var array Holds an array of parsed settings from Settings.cfg */
-    private array $settings = [];
-
-    /** @var array Will hold an array of Settings.cfg keys that were not converted */
-    private array $unmigratedSettings = [];
+    /** @var array Will hold an array of messages for output */
+    private array $migrationMessages = [];
 
     /** @var int The number of successfully converted settings */
     private int $convertedSettings = 0;
@@ -37,6 +32,7 @@ final class MigrateSettingsCommand extends Command
     {
         parent::__construct($name);
         $this->legacySettingsRepository = new LegacySettingsRepository();
+        $this->settingsMigrator = new SettingsMigrator();
     }
 
     protected function configure(): void
@@ -85,6 +81,10 @@ final class MigrateSettingsCommand extends Command
                 $output->writeln('<error>Settings could not be converted. Please check for proper syntax.</error>');
                 return Command::FAILURE;
             }
+
+            foreach ($this->migrationMessages as $message) {
+                $output->writeln($message);
+            }
         } catch (\Exception $e) {
             $output->writeln('<error>' . $e->getMessage() . '</error>');
         }
@@ -94,130 +94,13 @@ final class MigrateSettingsCommand extends Command
         return Command::SUCCESS;
     }
 
-    /**
-     * Setup basic DOM Document
-     **/
-    private function createXmlSectionGuides(): \DOMElement
+    private function convertSettingsToGuide(OutputInterface $output, string $inputFile, string $outputFile): bool
     {
-        // Add static <guides> element with proper XMLNS
-        $guides = $this->xmlDocument->createElement('guides');
-        $guides->setAttribute('xmlns', 'https://www.phpdoc.org/guides');
-        $guides->setAttribute('xmlns:xsi', 'http://www.w3.org/2001/XMLSchema-instance');
-        $guides->setAttribute('xsi:schemaLocation', 'https://www.phpdoc.org/guides ../vendor/phpdocumentor/guides-cli/resources/schema/guides.xsd');
-        $guides->setAttribute('links-are-relative', 'true');
+        $legacySettings = $this->legacySettingsRepository->get($inputFile);
+        [$this->xmlDocument, $this->convertedSettings, $this->migrationMessages]
+            = $this->settingsMigrator->migrate($legacySettings);
 
-        return $guides;
-    }
-
-    /**
-     * Add <extension> Element. This gets filled with the old "html_theme_options" section.
-     **/
-    private function createXmlSectionExtension(\DOMElement $parentNode): bool
-    {
-        $extension = $this->xmlDocument->createElement('extension');
-        $extension->setAttribute('class', '\T3Docs\Typo3DocsTheme\DependencyInjection\Typo3DocsThemeExtension');
-        if (is_array($this->settings['html_theme_options'] ?? false)) {
-            foreach (HtmlThemeOptions::cases() as $option) {
-                if (isset($this->settings['html_theme_options'][$option->name])) {
-                    $this->convertedSettings++;
-                    $extension->setAttribute($option->value, $this->settings['html_theme_options'][$option->name]);
-                    unset($this->unmigratedSettings['html_theme_options'][$option->name]);
-                }
-            }
-
-            $parentNode->append($extension);
-            return true;
-        }
-
-        return false;
-    }
-
-    /**
-     * Add <project> Element. This gets filled with the old "general" section.
-     **/
-    private function createXmlSectionProject(\DOMElement $parentNode): bool
-    {
-        $project = $this->xmlDocument->createElement('project');
-        if (is_array($this->settings['general'] ?? false)) {
-            foreach (Project::cases() as $option) {
-                if (isset($this->settings['general'][$option->name])) {
-                    $this->convertedSettings++;
-                    $project->setAttribute($option->value, $this->settings['general'][$option->name]);
-                    unset($this->unmigratedSettings['general'][$option->name]);
-                }
-            }
-
-            $parentNode->append($project);
-
-            return true;
-        }
-
-        return false;
-    }
-
-    /**
-     * Add <inventory> Element. This gets filled with the old "intersphinx_mapping" section.
-     **/
-    private function createXmlSectionInventory(\DOMElement $parentNode): bool
-    {
-        if (is_array($this->settings['intersphinx_mapping'] ?? false)) {
-            $hasAnyMapping = false;
-            foreach ($this->settings['intersphinx_mapping'] as $inventoryKey => $inventoryUrl) {
-                unset($this->unmigratedSettings['intersphinx_mapping'][$inventoryKey]);
-                $this->convertedSettings++;
-                $inventoryKey = trim($inventoryKey);
-                if (!str_starts_with($inventoryKey, '#')) {
-                    $inventory = $this->xmlDocument->createElement('inventory');
-                    $inventory->setAttribute('id', $inventoryKey);
-                    $inventory->setAttribute('url', $inventoryUrl);
-                    $parentNode->appendChild($inventory);
-                    $hasAnyMapping = true;
-                }
-            }
-
-            if ($hasAnyMapping) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    private function checkUnmigratedSettings(OutputInterface $output): bool
-    {
-        // Iterate remaining settings, remove all empty sections.
-        // What remains are then missing settings.
-        foreach ($this->unmigratedSettings as $section => $sectionKeys) {
-            if (count($sectionKeys) == 0) {
-                unset($this->unmigratedSettings[$section]);
-            }
-        }
-
-        foreach (Deprecated::cases() as $option) {
-            if (isset($this->unmigratedSettings[$option->name])) {
-                unset($this->unmigratedSettings[$option->name]);
-            }
-        }
-
-        // Ignored settings that have no new matching, but we are aware of it
-        if (count($this->unmigratedSettings) > 0) {
-            $output->writeln('Note: Some of your settings could not be converted:');
-            foreach ($this->unmigratedSettings as $unmigratedSettingSection => $unmigratedSettingValues) {
-                $output->writeln('  * ' . $unmigratedSettingSection);
-
-                // For known sections we output the remaining keys
-                if (in_array($unmigratedSettingSection, Sections::names(), true)) {
-                    foreach ($unmigratedSettingValues as $unmigratedSettingKey => $unmigratedSettingValue) {
-                        $output->writeln('    * ' . $unmigratedSettingKey);
-                    }
-                }
-            }
-            $output->writeln('');
-
-            return true;
-        }
-
-        return false;
+        return $this->writeXmlDocument($outputFile, $output);
     }
 
     private function writeXmlDocument(string $outputFile, OutputInterface $output): bool
@@ -233,29 +116,5 @@ final class MigrateSettingsCommand extends Command
         $output->writeln('<info>' . $this->convertedSettings . ' settings were migrated.</info>');
 
         return true;
-    }
-
-    private function convertSettingsToGuide(OutputInterface $output, string $inputFile, string $outputFile): bool
-    {
-        $this->settings = $this->legacySettingsRepository->get($inputFile);
-
-        // This array will hold all setting values that we could not migrate to guides.xml
-        $this->unmigratedSettings = $this->settings;
-
-        $this->xmlDocument = new \DOMDocument('1.0', 'UTF-8');
-        $this->xmlDocument->preserveWhiteSpace = true;
-        $this->xmlDocument->formatOutput = true;
-
-        $guides = $this->createXmlSectionGuides();
-        $this->createXmlSectionExtension($guides);
-        $this->createXmlSectionProject($guides);
-        $this->createXmlSectionInventory($guides);
-
-        $this->checkUnmigratedSettings($output);
-
-        // Attach the <guides> element to the root XML
-        $this->xmlDocument->appendChild($guides);
-
-        return $this->writeXmlDocument($outputFile, $output);
     }
 }

--- a/packages/typo3-guides-cli/src/Migration/SettingsMigrator.php
+++ b/packages/typo3-guides-cli/src/Migration/SettingsMigrator.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace T3Docs\GuidesCli\Migration;
+
+class SettingsMigrator
+{
+    private \DOMDocument $xmlDocument;
+    /**
+     * @var array<string, array<string, string>>
+     */
+    private array $legacySettings;
+    /**
+     * @var array<string, array<string, string>>
+     */
+    private array $unmigratedSettings = [];
+    private int $convertedSettings = 0;
+
+    /**
+     * Return the XML document, the number of converted settings and
+     * a list of messages for output
+     *
+     * @param array<string, array<string, string>> $legacySettings
+     * @return array{0: \DOMDocument, 1: int, 2: list<string>}
+     */
+    public function migrate(array $legacySettings): array
+    {
+        $this->legacySettings = $legacySettings;
+        $this->unmigratedSettings = $legacySettings;
+
+        $this->xmlDocument = new \DOMDocument('1.0', 'UTF-8');
+        $this->xmlDocument->preserveWhiteSpace = true;
+        $this->xmlDocument->formatOutput = true;
+
+        $guides = $this->createRootElement();
+        $this->createExtensionSection($guides);
+        $this->createProjectSection($guides);
+        $this->createInventorySection($guides);
+
+        $messages = $this->collectUnmigratedLegacySettings();
+
+        // Attach the <guides> element to the root XML
+        $this->xmlDocument->appendChild($guides);
+
+        return [$this->xmlDocument, $this->convertedSettings, $messages];
+    }
+
+    private function createRootElement(): \DOMElement
+    {
+        $guides = $this->xmlDocument->createElement('guides');
+        $guides->setAttribute('xmlns', 'https://www.phpdoc.org/guides');
+        $guides->setAttribute('xmlns:xsi', 'http://www.w3.org/2001/XMLSchema-instance');
+        $guides->setAttribute('xsi:schemaLocation', 'https://www.phpdoc.org/guides ../vendor/phpdocumentor/guides-cli/resources/schema/guides.xsd');
+        $guides->setAttribute('links-are-relative', 'true');
+
+        return $guides;
+    }
+
+    /**
+     * Add <extension> Element. This gets filled with the old "html_theme_options" section.
+     **/
+    private function createExtensionSection(\DOMElement $parentNode): void
+    {
+        $extension = $this->xmlDocument->createElement('extension');
+        $extension->setAttribute('class', '\T3Docs\Typo3DocsTheme\DependencyInjection\Typo3DocsThemeExtension');
+
+        if (!is_array($this->legacySettings['html_theme_options'] ?? false)) {
+            return;
+        }
+
+        foreach (HtmlThemeOptions::cases() as $option) {
+            if ($this->legacySettings['html_theme_options'][$option->name] ?? false) {
+                $this->convertedSettings++;
+                $extension->setAttribute($option->value, $this->legacySettings['html_theme_options'][$option->name]);
+                unset($this->unmigratedSettings['html_theme_options'][$option->name]);
+            }
+        }
+
+        $parentNode->append($extension);
+    }
+
+    /**
+     * Add <project> Element. This gets filled with the old "general" section.
+     **/
+    private function createProjectSection(\DOMElement $parentNode): void
+    {
+        $project = $this->xmlDocument->createElement('project');
+        if (!is_array($this->legacySettings['general'] ?? false)) {
+            return;
+        }
+
+        foreach (Project::cases() as $option) {
+            if ($this->legacySettings['general'][$option->name] ?? false) {
+                $this->convertedSettings++;
+                $project->setAttribute(
+                    $option->value,
+                    $this->legacySettings['general'][$option->name]
+                );
+                unset($this->unmigratedSettings['general'][$option->name]);
+            }
+        }
+
+        $parentNode->append($project);
+    }
+
+    /**
+     * Add <inventory> Element. This gets filled with the old "intersphinx_mapping" section.
+     **/
+    private function createInventorySection(\DOMElement $parentNode): void
+    {
+        if (!is_array($this->legacySettings['intersphinx_mapping'] ?? false)) {
+            return;
+        }
+
+        foreach ($this->legacySettings['intersphinx_mapping'] as $id => $url) {
+            unset($this->unmigratedSettings['intersphinx_mapping'][$id]);
+            $this->convertedSettings++;
+
+            $inventory = $this->xmlDocument->createElement('inventory');
+            $inventory->setAttribute('id', $id);
+            $inventory->setAttribute('url', $url);
+            $parentNode->appendChild($inventory);
+        }
+    }
+
+    private function collectUnmigratedLegacySettings(): array
+    {
+        $messages = [];
+
+        // Iterate remaining settings, remove all empty sections.
+        // What remains are then missing settings.
+        foreach ($this->unmigratedSettings as $section => $sectionKeys) {
+            if ($sectionKeys === []) {
+                unset($this->unmigratedSettings[$section]);
+            }
+        }
+
+        foreach (Deprecated::cases() as $option) {
+            if (isset($this->unmigratedSettings[$option->name])) {
+                unset($this->unmigratedSettings[$option->name]);
+            }
+        }
+
+        // Ignored settings that have no new matching, but we are aware of it
+        if ($this->unmigratedSettings !== []) {
+            $messages[] = 'Note: Some of your settings could not be converted:';
+            foreach ($this->unmigratedSettings as $unmigratedSettingSection => $unmigratedSettingValues) {
+                $messages[] = '  * ' . $unmigratedSettingSection;
+
+                // For known sections we output the remaining keys
+                if (in_array($unmigratedSettingSection, Sections::names(), true)) {
+                    foreach ($unmigratedSettingValues as $unmigratedSettingKey => $unmigratedSettingValue) {
+                        $messages[] = '    * ' . $unmigratedSettingKey;
+                    }
+                }
+            }
+        }
+
+        return $messages;
+    }
+}

--- a/packages/typo3-guides-cli/src/Repository/LegacySettingsRepository.php
+++ b/packages/typo3-guides-cli/src/Repository/LegacySettingsRepository.php
@@ -9,7 +9,7 @@ use T3Docs\GuidesCli\Repository\Exception\FileException;
 class LegacySettingsRepository
 {
     /**
-     * @return array<string, string>
+     * @return array<string, array<string, string>>
      */
     public function get(string $filePath): array
     {

--- a/packages/typo3-guides-cli/tests/unit/Migration/SettingsMigratorTest.php
+++ b/packages/typo3-guides-cli/tests/unit/Migration/SettingsMigratorTest.php
@@ -1,0 +1,231 @@
+<?php
+
+declare(strict_types=1);
+
+namespace T3Docs\GuidesCli\Tests\Migration;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use T3Docs\GuidesCli\Migration\SettingsMigrator;
+
+final class SettingsMigratorTest extends TestCase
+{
+    private SettingsMigrator $subject;
+
+    protected function setUp(): void
+    {
+        $this->subject = new SettingsMigrator();
+    }
+
+    /**
+     * @param array<string, array<string, string>> $legacySettings
+     */
+    #[Test]
+    #[DataProvider('providerForMigrateReturnsXmlDocumentCorrectly')]
+    public function migrateReturnsXmlDocumentCorrectly(array $legacySettings, string $expected): void
+    {
+        $actual = $this->subject->migrate($legacySettings)[0]->saveXML() ?: '';
+
+        self::assertXmlStringEqualsXmlString($expected, $actual);
+    }
+
+    public static function providerForMigrateReturnsXmlDocumentCorrectly(): \Generator
+    {
+        yield 'with empty legacy settings' => [
+            'legacy settings' => [],
+            'expected' => <<<EXPECTED
+<?xml version="1.0" encoding="UTF-8"?>
+<guides xmlns="https://www.phpdoc.org/guides" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://www.phpdoc.org/guides ../vendor/phpdocumentor/guides-cli/resources/schema/guides.xsd" links-are-relative="true"/>
+EXPECTED,
+        ];
+
+        yield 'with all html_theme_options given' => [
+            'legacy settings' => [
+                'html_theme_options' => [
+                    'project_home' => 'https://example.org/',
+                    'project_contact' => 'https://example.org/contact',
+                    'project_repository' => 'https://example.org/repository',
+                    'project_issues' => 'https://example.org/issues',
+                    'project_discussions' => 'https://example.org/discussions',
+                    'use_opensearch' => 'false',
+                    'github_revision_msg' => 'some github message',
+                    'github_branch' => 'main',
+                    'github_repository' => 'my-example-repository',
+                    'github_sphinx_locale' => 'de',
+                    'github_commit_hash' => 'abcdef',
+                ],
+            ],
+            'expected' => <<<EXPECTED
+<guides xmlns="https://www.phpdoc.org/guides" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" links-are-relative="true" xsi:schemaLocation="https://www.phpdoc.org/guides ../vendor/phpdocumentor/guides-cli/resources/schema/guides.xsd">
+    <extension
+        class="\T3Docs\Typo3DocsTheme\DependencyInjection\Typo3DocsThemeExtension"
+        edit-on-github="my-example-repository"
+        edit-on-github-branch="main"
+        github-commit-hash="abcdef"
+        github-revision-msg="some github message"
+        github-sphinx-locale="de"
+        use-opensearch="false"
+        project-contact="https://example.org/contact"
+        project-discussions="https://example.org/discussions"
+        project-home="https://example.org/"
+        project-issues="https://example.org/issues"
+        project-repository="https://example.org/repository"
+    />
+</guides>
+EXPECTED,
+        ];
+
+        yield 'with only one of the html_theme_options given' => [
+            'legacy settings' => [
+                'html_theme_options' => [
+                    'project_home' => 'https://example.org/',
+                ],
+            ],
+            'expected' => <<<EXPECTED
+<guides xmlns="https://www.phpdoc.org/guides" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" links-are-relative="true" xsi:schemaLocation="https://www.phpdoc.org/guides ../vendor/phpdocumentor/guides-cli/resources/schema/guides.xsd">
+    <extension
+        class="\T3Docs\Typo3DocsTheme\DependencyInjection\Typo3DocsThemeExtension"
+        project-home="https://example.org/"
+    />
+</guides>
+EXPECTED,
+        ];
+
+        yield 'with all general options given' => [
+            'legacy settings' => [
+                'general' => [
+                    'project' => 'Some project',
+                    'version' => '1.0',
+                    'release' => '1.0.3',
+                    'copyright' => 'Some copyright',
+                ],
+            ],
+            'expected' => <<<EXPECTED
+<guides xmlns="https://www.phpdoc.org/guides" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" links-are-relative="true" xsi:schemaLocation="https://www.phpdoc.org/guides ../vendor/phpdocumentor/guides-cli/resources/schema/guides.xsd">
+    <project
+        copyright="Some copyright"
+        release="1.0.3"
+        title="Some project"
+        version="1.0"
+    />
+</guides>
+EXPECTED,
+        ];
+
+        yield 'with only one of the general options given' => [
+            'legacy settings' => [
+                'general' => [
+                    'project' => 'Some project',
+                ],
+            ],
+            'expected' => <<<EXPECTED
+<guides xmlns="https://www.phpdoc.org/guides" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" links-are-relative="true" xsi:schemaLocation="https://www.phpdoc.org/guides ../vendor/phpdocumentor/guides-cli/resources/schema/guides.xsd">
+    <project
+        title="Some project"
+    />
+</guides>
+EXPECTED,
+        ];
+
+        yield 'with intersphinx_mapping given' => [
+            'legacy settings' => [
+                'intersphinx_mapping' => [
+                    'manual_1' => 'https://example.com/manual-1/',
+                    'manual_2' => 'https://example.com/manual-2/',
+                    'manual_3' => 'https://example.com/manual-3/',
+                ],
+            ],
+            'expected' => <<<EXPECTED
+<guides xmlns="https://www.phpdoc.org/guides" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" links-are-relative="true" xsi:schemaLocation="https://www.phpdoc.org/guides ../vendor/phpdocumentor/guides-cli/resources/schema/guides.xsd">
+    <inventory id="manual_1" url="https://example.com/manual-1/"/>
+    <inventory id="manual_2" url="https://example.com/manual-2/"/>
+    <inventory id="manual_3" url="https://example.com/manual-3/"/>
+</guides>
+EXPECTED,
+        ];
+
+        yield 'with all sections given' => [
+            'legacy settings' => [
+                'html_theme_options' => [
+                    'project_home' => 'https://example.org/',
+                ],
+                'general' => [
+                    'project' => 'Some project',
+                ],
+                'intersphinx_mapping' => [
+                    'manual_1' => 'https://example.com/manual-1/',
+                ],
+            ],
+            'expected' => <<<EXPECTED
+<guides xmlns="https://www.phpdoc.org/guides" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" links-are-relative="true" xsi:schemaLocation="https://www.phpdoc.org/guides ../vendor/phpdocumentor/guides-cli/resources/schema/guides.xsd">
+    <extension class="\T3Docs\Typo3DocsTheme\DependencyInjection\Typo3DocsThemeExtension" project-home="https://example.org/"/>
+    <project title="Some project"/>
+    <inventory id="manual_1" url="https://example.com/manual-1/"/>
+</guides>
+EXPECTED,
+        ];
+    }
+
+    #[Test]
+    public function migrateReturnsTheNumberOfConvertedSettingsCorrectly(): void
+    {
+        $legacySettings = [
+            'html_theme_options' => [
+                'project_home' => 'https://example.org/',
+                'project_repository' => 'https://example.org/repository',
+                'project_issues' => 'https://example.org/issues',
+            ],
+            'general' => [
+                'project' => 'Some project',
+                'version' => '1.0',
+                'unknown' => 'some value',
+            ],
+            'intersphinx_mapping' => [
+                'manual_1' => 'https://example.com/manual-1/',
+            ],
+        ];
+
+        $actual = $this->subject->migrate($legacySettings)[1];
+
+        self::assertSame(6, $actual);
+    }
+
+    /**
+     * @param array<string, array<string, string>> $legacySettings
+     * @param list<string> $expected
+     */
+    #[Test]
+    #[DataProvider('providerForMigrateReturnsMessagesCorrectly')]
+    public function migrateReturnsMessagesCorrectly(array $legacySettings, array $expected): void
+    {
+        $actual = $this->subject->migrate($legacySettings)[2];
+
+        self::assertSame($expected, $actual);
+    }
+
+    public static function providerForMigrateReturnsMessagesCorrectly(): \Generator
+    {
+        yield 'no messages given with empty legacy settings' => [
+            'legacy settings' => [],
+            'expected' => [],
+        ];
+
+        yield 'messages given with unknown legacy settings' => [
+            'legacy settings' => [
+                'html_theme_options' => [
+                    'unknown_html_theme_option' => 'some value',
+                ],
+                'project' => [
+                    'unknown_project_setting' => 'another value',
+                ],
+            ],
+            'expected' => [
+                'Note: Some of your settings could not be converted:',
+                '  * html_theme_options',
+                '    * unknown_html_theme_option',
+                '  * project',
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
The return value of the migrate() method is still ugly, but can be addressed later in a separate change.

There are some glitches, like when a legacy setting has an empty value, a message "Some of your settings could not be converted" is displayed. Or if an id or value has whitespaces. This will also be addressed in a separate change to be as near as possible to the original code.

Additionally, the generating of the XML is now covered by unit tests.