### PR TITLE
[TASK] Use php-cs-fixer directly

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,13 +1,27 @@
 <?php
 
-$config = \TYPO3\CodingStandards\CsFixerConfig::create();
-$config
-    ->setCacheFile('.cache/.php-cs-fixer.cache')
-    ->getFinder()->in(__DIR__)
+$finder = (new PhpCsFixer\Finder())
+    ->in(__DIR__)
     ->exclude([
         'docs',
         'fixtures-local',
-    ])
-;
+    ]);
 
-return $config;
+return (new PhpCsFixer\Config())
+    ->setCacheFile('.cache/.php-cs-fixer.cache')
+    ->setRules([
+        '@PER-CS1.0' => true,
+        '@PHP81Migration' => true,
+
+        // Already implemented PER-CS2 rules we opt-in explicitly
+        // @todo: Can be dropped once we enable @PER-CS2.0
+        'concat_space' => [
+            'spacing' => 'one'
+        ],
+        'function_declaration' => [
+            'closure_fn_spacing' => 'none',
+        ],
+        'method_argument_space' => true,
+        'single_line_empty_body' => true,
+    ])
+    ->setFinder($finder);

--- a/composer.json
+++ b/composer.json
@@ -18,14 +18,14 @@
     },
     "require-dev": {
         "ergebnis/composer-normalize": "^2.30",
+        "friendsofphp/php-cs-fixer": "^3.40",
         "phpstan/extension-installer": "^1.3",
         "phpstan/phpstan": "^1.10",
         "phpstan/phpstan-strict-rules": "^1.5",
         "phpunit/phpunit": "^10.4",
         "symfony/console": "^6.3",
         "symplify/monorepo-builder": "^11.2",
-        "symplify/phpstan-rules": "^12.4",
-        "typo3/coding-standards": "^0.7.1"
+        "symplify/phpstan-rules": "^12.4"
     },
     "replace": {
         "t3docs/typo3-docs-theme": "self.version",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e9d52e303a6e78151e9dcf44c8c04b5a",
+    "content-hash": "b7125411379a4ab1700dca2468dd3f70",
     "packages": [
         {
             "name": "brotkrueml/twig-codehighlight",
@@ -6623,89 +6623,6 @@
                 }
             ],
             "time": "2023-11-20T00:12:19+00:00"
-        },
-        {
-            "name": "typo3/coding-standards",
-            "version": "v0.7.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/TYPO3/coding-standards.git",
-                "reference": "b53fc46dc3fc997f98c96bc630d24c1e12028646"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3/coding-standards/zipball/b53fc46dc3fc997f98c96bc630d24c1e12028646",
-                "reference": "b53fc46dc3fc997f98c96bc630d24c1e12028646",
-                "shasum": ""
-            },
-            "require": {
-                "ext-json": "*",
-                "friendsofphp/php-cs-fixer": "^3.11",
-                "php": "^8.0",
-                "symfony/console": "^4.4.30 || ^5.3.7 || ^6.0",
-                "symfony/filesystem": "^4.4 || ^5.0 || ^6.0"
-            },
-            "require-dev": {
-                "composer/package-versions-deprecated": "^1.11.99.4",
-                "ergebnis/composer-normalize": "*",
-                "keradus/cli-executor": "^1.5",
-                "maglnet/composer-require-checker": "*",
-                "nikic/php-parser": "^4.13.1",
-                "overtrue/phplint": "^3.0",
-                "phpstan/extension-installer": "^1.1",
-                "phpstan/phpstan-deprecation-rules": "^1.0",
-                "phpstan/phpstan-phpunit": "^1.0",
-                "phpstan/phpstan-strict-rules": "^1.0",
-                "phpstan/phpstan-symfony": "^1.0",
-                "phpunit/phpunit": "^9.5.18",
-                "symfony/finder": ">=4.4",
-                "symfony/process": ">=4.4"
-            },
-            "bin": [
-                "t3-cs",
-                "typo3-coding-standards"
-            ],
-            "type": "coding-standards",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "0.7.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "TYPO3\\CodingStandards\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Benni Mack",
-                    "email": "benni@typo3.org"
-                },
-                {
-                    "name": "Simon Gilli",
-                    "email": "simon.gilli@typo3.org"
-                }
-            ],
-            "description": "A set of coding guidelines for any TYPO3-related project or extension",
-            "homepage": "https://typo3.org/",
-            "keywords": [
-                "Code style",
-                "cms",
-                "editorconfig",
-                "php-cs-fixer",
-                "typo3"
-            ],
-            "support": {
-                "chat": "https://typo3.org/help",
-                "docs": "https://docs.typo3.org",
-                "issues": "https://github.com/TYPO3/coding-standards/issues",
-                "source": "https://github.com/TYPO3/coding-standards"
-            },
-            "time": "2022-12-20T16:02:01+00:00"
         }
     ],
     "aliases": [],

--- a/packages/typo3-docs-theme/resources/config/typo3-docs-theme.php
+++ b/packages/typo3-docs-theme/resources/config/typo3-docs-theme.php
@@ -7,16 +7,13 @@ use phpDocumentor\Guides\RestructuredText\Directives\BaseDirective;
 use phpDocumentor\Guides\RestructuredText\Directives\SubDirective;
 use phpDocumentor\Guides\RestructuredText\Parser\Productions\DirectiveContentRule;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
-
-use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
-
 use T3Docs\Typo3DocsTheme\Directives\GroupTabDirective;
-
 use T3Docs\Typo3DocsTheme\Directives\T3FieldListTableDirective;
-
 use T3Docs\Typo3DocsTheme\Directives\YoutubeDirective;
 use T3Docs\Typo3DocsTheme\TextRoles\IssueReferenceTextRole;
 use T3Docs\Typo3DocsTheme\Twig\TwigExtension;
+
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 
 return static function (ContainerConfigurator $container): void {
     $container->services()

--- a/packages/typo3-docs-theme/src/DependencyInjection/Typo3DocsThemeExtension.php
+++ b/packages/typo3-docs-theme/src/DependencyInjection/Typo3DocsThemeExtension.php
@@ -4,22 +4,19 @@ declare(strict_types=1);
 
 namespace T3Docs\Typo3DocsTheme\DependencyInjection;
 
-use function dirname;
-
 use phpDocumentor\Guides\NodeRenderers\TemplateNodeRenderer;
-
 use phpDocumentor\Guides\TemplateRenderer;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Extension\Extension;
-
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
-
 use T3Docs\Typo3DocsTheme\Nodes\YoutubeNode;
 use T3Docs\Typo3DocsTheme\Settings\Typo3DocsThemeSettings;
+
+use function dirname;
 
 class Typo3DocsThemeExtension extends Extension implements PrependExtensionInterface
 {

--- a/packages/typo3-guides-cli/src/Command/ConfigureCommand.php
+++ b/packages/typo3-guides-cli/src/Command/ConfigureCommand.php
@@ -23,14 +23,14 @@ final class ConfigureCommand extends Command
         $this->setDescription('Configure guides.xml attributes programmatically.');
         $this->setHelp(
             <<<'EOT'
-                    The <info>%command.name%</info> command helps to set configuration options
-                    and attributes of the project to be rendered. These options are saved
-                    in a file <info>guides.xml</info>.
-                    You can use this CLI instead of manually editing the xml file.
+                The <info>%command.name%</info> command helps to set configuration options
+                and attributes of the project to be rendered. These options are saved
+                in a file <info>guides.xml</info>.
+                You can use this CLI instead of manually editing the xml file.
 
-                    <info>$ php %command.name% [parameters]</info>
+                <info>$ php %command.name% [parameters]</info>
 
-                    EOT
+                EOT
         );
         $this->setDefinition([
             new InputOption(

--- a/packages/typo3-guides-cli/src/Command/LintGuidesXmlCommand.php
+++ b/packages/typo3-guides-cli/src/Command/LintGuidesXmlCommand.php
@@ -22,12 +22,12 @@ final class LintGuidesXmlCommand extends Command
         $this->setDescription('Validates all guides.xml settings files.');
         $this->setHelp(
             <<<'EOT'
-                    The <info>%command.name%</info> command iterates all found files
-                    called <info>guides.xml</info> and checks the for XSD conformity.
+                The <info>%command.name%</info> command iterates all found files
+                called <info>guides.xml</info> and checks the for XSD conformity.
 
-                    <info>$ php %command.name% [parameters]</info>
+                <info>$ php %command.name% [parameters]</info>
 
-                    EOT
+                EOT
         );
         $this->setDefinition([
             new InputArgument(

--- a/packages/typo3-guides-cli/src/Command/MigrateSettingsCommand.php
+++ b/packages/typo3-guides-cli/src/Command/MigrateSettingsCommand.php
@@ -40,13 +40,13 @@ final class MigrateSettingsCommand extends Command
         $this->setDescription('Migrates Settings.cfg to guides.xml format.');
         $this->setHelp(
             <<<'EOT'
-                    The <info>%command.name%</info> command migrates a Settings.cfg in side the
-                    specified input directory, tries to parse it and convert all known settings
-                    to the XML format used in the guides.xml file.
+                The <info>%command.name%</info> command migrates a Settings.cfg in side the
+                specified input directory, tries to parse it and convert all known settings
+                to the XML format used in the guides.xml file.
 
-                    <info>$ php %command.name% [input]</info>
+                <info>$ php %command.name% [input]</info>
 
-                    EOT
+                EOT
         );
         $this->setDefinition([
             new InputArgument(

--- a/packages/typo3-guides-cli/tests/unit/Migration/SettingsMigratorTest.php
+++ b/packages/typo3-guides-cli/tests/unit/Migration/SettingsMigratorTest.php
@@ -35,9 +35,9 @@ final class SettingsMigratorTest extends TestCase
         yield 'with empty legacy settings' => [
             'legacy settings' => [],
             'expected' => <<<EXPECTED
-<?xml version="1.0" encoding="UTF-8"?>
-<guides xmlns="https://www.phpdoc.org/guides" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://www.phpdoc.org/guides ../vendor/phpdocumentor/guides-cli/resources/schema/guides.xsd" links-are-relative="true"/>
-EXPECTED,
+                <?xml version="1.0" encoding="UTF-8"?>
+                <guides xmlns="https://www.phpdoc.org/guides" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://www.phpdoc.org/guides ../vendor/phpdocumentor/guides-cli/resources/schema/guides.xsd" links-are-relative="true"/>
+                EXPECTED,
         ];
 
         yield 'with all html_theme_options given' => [
@@ -57,23 +57,23 @@ EXPECTED,
                 ],
             ],
             'expected' => <<<EXPECTED
-<guides xmlns="https://www.phpdoc.org/guides" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" links-are-relative="true" xsi:schemaLocation="https://www.phpdoc.org/guides ../vendor/phpdocumentor/guides-cli/resources/schema/guides.xsd">
-    <extension
-        class="\T3Docs\Typo3DocsTheme\DependencyInjection\Typo3DocsThemeExtension"
-        edit-on-github="my-example-repository"
-        edit-on-github-branch="main"
-        github-commit-hash="abcdef"
-        github-revision-msg="some github message"
-        github-sphinx-locale="de"
-        use-opensearch="false"
-        project-contact="https://example.org/contact"
-        project-discussions="https://example.org/discussions"
-        project-home="https://example.org/"
-        project-issues="https://example.org/issues"
-        project-repository="https://example.org/repository"
-    />
-</guides>
-EXPECTED,
+                <guides xmlns="https://www.phpdoc.org/guides" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" links-are-relative="true" xsi:schemaLocation="https://www.phpdoc.org/guides ../vendor/phpdocumentor/guides-cli/resources/schema/guides.xsd">
+                    <extension
+                        class="\T3Docs\Typo3DocsTheme\DependencyInjection\Typo3DocsThemeExtension"
+                        edit-on-github="my-example-repository"
+                        edit-on-github-branch="main"
+                        github-commit-hash="abcdef"
+                        github-revision-msg="some github message"
+                        github-sphinx-locale="de"
+                        use-opensearch="false"
+                        project-contact="https://example.org/contact"
+                        project-discussions="https://example.org/discussions"
+                        project-home="https://example.org/"
+                        project-issues="https://example.org/issues"
+                        project-repository="https://example.org/repository"
+                    />
+                </guides>
+                EXPECTED,
         ];
 
         yield 'with only one of the html_theme_options given' => [
@@ -83,13 +83,13 @@ EXPECTED,
                 ],
             ],
             'expected' => <<<EXPECTED
-<guides xmlns="https://www.phpdoc.org/guides" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" links-are-relative="true" xsi:schemaLocation="https://www.phpdoc.org/guides ../vendor/phpdocumentor/guides-cli/resources/schema/guides.xsd">
-    <extension
-        class="\T3Docs\Typo3DocsTheme\DependencyInjection\Typo3DocsThemeExtension"
-        project-home="https://example.org/"
-    />
-</guides>
-EXPECTED,
+                <guides xmlns="https://www.phpdoc.org/guides" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" links-are-relative="true" xsi:schemaLocation="https://www.phpdoc.org/guides ../vendor/phpdocumentor/guides-cli/resources/schema/guides.xsd">
+                    <extension
+                        class="\T3Docs\Typo3DocsTheme\DependencyInjection\Typo3DocsThemeExtension"
+                        project-home="https://example.org/"
+                    />
+                </guides>
+                EXPECTED,
         ];
 
         yield 'with all general options given' => [
@@ -102,15 +102,15 @@ EXPECTED,
                 ],
             ],
             'expected' => <<<EXPECTED
-<guides xmlns="https://www.phpdoc.org/guides" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" links-are-relative="true" xsi:schemaLocation="https://www.phpdoc.org/guides ../vendor/phpdocumentor/guides-cli/resources/schema/guides.xsd">
-    <project
-        copyright="Some copyright"
-        release="1.0.3"
-        title="Some project"
-        version="1.0"
-    />
-</guides>
-EXPECTED,
+                <guides xmlns="https://www.phpdoc.org/guides" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" links-are-relative="true" xsi:schemaLocation="https://www.phpdoc.org/guides ../vendor/phpdocumentor/guides-cli/resources/schema/guides.xsd">
+                    <project
+                        copyright="Some copyright"
+                        release="1.0.3"
+                        title="Some project"
+                        version="1.0"
+                    />
+                </guides>
+                EXPECTED,
         ];
 
         yield 'with only one of the general options given' => [
@@ -120,12 +120,12 @@ EXPECTED,
                 ],
             ],
             'expected' => <<<EXPECTED
-<guides xmlns="https://www.phpdoc.org/guides" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" links-are-relative="true" xsi:schemaLocation="https://www.phpdoc.org/guides ../vendor/phpdocumentor/guides-cli/resources/schema/guides.xsd">
-    <project
-        title="Some project"
-    />
-</guides>
-EXPECTED,
+                <guides xmlns="https://www.phpdoc.org/guides" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" links-are-relative="true" xsi:schemaLocation="https://www.phpdoc.org/guides ../vendor/phpdocumentor/guides-cli/resources/schema/guides.xsd">
+                    <project
+                        title="Some project"
+                    />
+                </guides>
+                EXPECTED,
         ];
 
         yield 'with intersphinx_mapping given' => [
@@ -137,12 +137,12 @@ EXPECTED,
                 ],
             ],
             'expected' => <<<EXPECTED
-<guides xmlns="https://www.phpdoc.org/guides" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" links-are-relative="true" xsi:schemaLocation="https://www.phpdoc.org/guides ../vendor/phpdocumentor/guides-cli/resources/schema/guides.xsd">
-    <inventory id="manual_1" url="https://example.com/manual-1/"/>
-    <inventory id="manual_2" url="https://example.com/manual-2/"/>
-    <inventory id="manual_3" url="https://example.com/manual-3/"/>
-</guides>
-EXPECTED,
+                <guides xmlns="https://www.phpdoc.org/guides" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" links-are-relative="true" xsi:schemaLocation="https://www.phpdoc.org/guides ../vendor/phpdocumentor/guides-cli/resources/schema/guides.xsd">
+                    <inventory id="manual_1" url="https://example.com/manual-1/"/>
+                    <inventory id="manual_2" url="https://example.com/manual-2/"/>
+                    <inventory id="manual_3" url="https://example.com/manual-3/"/>
+                </guides>
+                EXPECTED,
         ];
 
         yield 'with all sections given' => [
@@ -158,12 +158,12 @@ EXPECTED,
                 ],
             ],
             'expected' => <<<EXPECTED
-<guides xmlns="https://www.phpdoc.org/guides" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" links-are-relative="true" xsi:schemaLocation="https://www.phpdoc.org/guides ../vendor/phpdocumentor/guides-cli/resources/schema/guides.xsd">
-    <extension class="\T3Docs\Typo3DocsTheme\DependencyInjection\Typo3DocsThemeExtension" project-home="https://example.org/"/>
-    <project title="Some project"/>
-    <inventory id="manual_1" url="https://example.com/manual-1/"/>
-</guides>
-EXPECTED,
+                <guides xmlns="https://www.phpdoc.org/guides" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" links-are-relative="true" xsi:schemaLocation="https://www.phpdoc.org/guides ../vendor/phpdocumentor/guides-cli/resources/schema/guides.xsd">
+                    <extension class="\T3Docs\Typo3DocsTheme\DependencyInjection\Typo3DocsThemeExtension" project-home="https://example.org/"/>
+                    <project title="Some project"/>
+                    <inventory id="manual_1" url="https://example.com/manual-1/"/>
+                </guides>
+                EXPECTED,
         ];
     }
 

--- a/packages/typo3-guides-extension/resources/config/typo3-guides.php
+++ b/packages/typo3-guides-extension/resources/config/typo3-guides.php
@@ -4,10 +4,9 @@ declare(strict_types=1);
 
 use phpDocumentor\Guides\Cli\Command\Run;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use T3Docs\GuidesExtension\Command\RunDecorator;
 
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
-
-use T3Docs\GuidesExtension\Command\RunDecorator;
 
 return static function (ContainerConfigurator $container): void {
     $container->services()

--- a/tests/Integration/IntegrationTest.php
+++ b/tests/Integration/IntegrationTest.php
@@ -4,6 +4,16 @@ declare(strict_types=1);
 
 namespace T3Docs\Typo3DocsTheme\Integration;
 
+use phpDocumentor\Guides\Cli\Command\Run;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\ExpectationFailedException;
+use RuntimeException;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Finder\Finder as SymfonyFinder;
+use T3Docs\GuidesExtension\Command\RunDecorator;
+use T3Docs\Typo3DocsTheme\ApplicationTestCase;
+
 use function array_filter;
 use function array_merge;
 use function array_walk;
@@ -13,33 +23,13 @@ use function explode;
 use function file_exists;
 use function file_get_contents;
 use function implode;
-
-use const LC_ALL;
-
-use phpDocumentor\Guides\Cli\Command\Run;
-
-use PHPUnit\Framework\Attributes\DataProvider;
-
-use PHPUnit\Framework\ExpectationFailedException;
-use RuntimeException;
-
 use function setlocale;
-
 use function str_ends_with;
 use function str_replace;
-
-use Symfony\Component\Console\Input\ArrayInput;
-
-use Symfony\Component\Console\Output\BufferedOutput;
-use Symfony\Component\Finder\Finder as SymfonyFinder;
-
 use function system;
-
-use T3Docs\GuidesExtension\Command\RunDecorator;
-
-use T3Docs\Typo3DocsTheme\ApplicationTestCase;
-
 use function trim;
+
+use const LC_ALL;
 
 final class IntegrationTest extends ApplicationTestCase
 {


### PR DESCRIPTION
This change removes the package "typo3/coding-standards" in favour of "friendsofphp/php-cs-fixer". There is no need to use this proxy package.

Instead, we define the needed rules directly. As we stick zu the PER-CS standard (the successor of PSR-12) we pin the rules to the PER-CS 1 ruleset. Additionally, we opt in for some already implemented PER-CS 2 rules to avoid too much style changes already available in the codebase.

With the pinning to defined rules we ensure that updates of php-cs-fixer does not "break" the currently used styles locally or in CI. Changes in the defined rules can therefore be done explicitly.