### PR TITLE
[DOCS] Use code blocks explicitly

### DIFF
--- a/Documentation/Developer/Building.rst
+++ b/Documentation/Developer/Building.rst
@@ -16,17 +16,21 @@ Using Docker
 A Docker image is available on `GitHub packages`_. If you want to build your own
 image you can use the following command, in the root of this repository.
 
-::
+..  code-block:: shell
 
     make docker-build
 
-Once the build is finished you can execute your own image using::
+Once the build is finished you can execute your own image using:
 
-  docker run --rm -v $(pwd):/project typo3-docs:local --progress
+..  code-block:: shell
 
-For macOS you also need to specify the argument ``user``::
+    docker run --rm -v $(pwd):/project typo3-docs:local --progress
 
-  docker run --rm -v $(pwd):/project --user=$(id -u):$(id -g) typo3-docs:local --progress
+For macOS you also need to specify the argument ``user``:
+
+..  code-block:: shell
+
+    docker run --rm -v $(pwd):/project --user=$(id -u):$(id -g) typo3-docs:local --progress
 
 Using PHP
 ---------
@@ -37,12 +41,14 @@ executable PHP file. You can run it like any other executable.
 To build the phar file we use Box_, with some wrapper script. To build the phar
 file yourself, you can run the following command.
 
-::
+..  code-block:: shell
 
     make build-phar
 
 This will create a file called :file:`guides.phar` in the build directory. You
-can execute the phar file like a PHP file using::
+can execute the phar file like a PHP file using:
+
+..  code-block:: shell
 
     php build/guides.phar
 

--- a/Documentation/Developer/Contributing.rst
+++ b/Documentation/Developer/Contributing.rst
@@ -8,7 +8,7 @@ Contributing
 
 When contributing please run all tests before committing:
 
-::
+..  code-block:: shell
 
     # Using Makefile (append ENV=local if you don't require docker)
     make pre-commit-test
@@ -23,7 +23,7 @@ When contributing please run all tests before committing:
 You can use a helper script to set this up once in your project, so that
 these checks are performed before any Git commit:
 
-::
+..  code-block:: shell
 
     # Using Makefile
     make githooks

--- a/Documentation/Developer/DirectoryStructure.rst
+++ b/Documentation/Developer/DirectoryStructure.rst
@@ -6,26 +6,28 @@
 Directory structure
 ===================
 
-The directory structure of the project is as follows::
+The directory structure of the project is as follows:
+
+..  code-block:: plaintext
 
     .
     ├── .ddev
     ├── .github
-    │   ├── workflows
-    │   │   ├── main.yml
-    │   │   ├── phar.yml
-    │   │   ├── docker.yml
+    │   ├── workflows
+    │   │   ├── main.yml
+    │   │   ├── phar.yml
+    │   │   ├── docker.yml
     ├── bin
     ├── Documentation
     ├── packages
-    │   ├── typo3-docs-theme
-    │   ├── typo3-guides-extension
+    │   ├── typo3-docs-theme
+    │   ├── typo3-guides-extension
     ├── tests
-    │   ├── Integration
+    │   ├── Integration
     ├── tools
 
 
-The :file:`.ddev` directory contains the configuration for the local development
+The :file:`.ddev/` directory contains the configuration for the local development
 environment for people using `DDEV`_.
 
 The :file:`.github/` directory contains the configuration for the GitHub workflows.

--- a/Documentation/Developer/Index.rst
+++ b/Documentation/Developer/Index.rst
@@ -18,13 +18,13 @@ build and execute development helpers, and they can be utilized by GitHub Action
 The "single source of truth" for these commands is within the `Makefile`. You can
 see all available commands via:
 
-::
+..  code-block:: shell
 
     make help
 
 The most common commands are probably:
 
-::
+..  code-block:: shell
 
     # Render documentation
     make docs
@@ -37,7 +37,7 @@ The most common commands are probably:
 
 Most `make` commands can be prepended or appended with the parameter `ENV=local`:
 
-::
+..  code-block:: shell
 
     # Render documentation
     make docs ENV=local
@@ -57,7 +57,7 @@ The :file:`Makefile` can also be executed via composer. All commands in the
 :bash:`make` range are just passed onto the `Makefile` via a composer script,
 and automatically then use the `ENV=local` scope:
 
-::
+..  code-block:: shell
 
     # Render documentation
     composer make docs
@@ -71,7 +71,7 @@ and automatically then use the `ENV=local` scope:
 If your local environment does not provide :bash:`make` you can use DDEV to wrap
 the same commands within the DDEV container:
 
-::
+..  code-block:: shell
 
     # Render documentation
     ddev composer make docs

--- a/Documentation/Developer/MonoRepository.rst
+++ b/Documentation/Developer/MonoRepository.rst
@@ -19,7 +19,7 @@ the dependencies over packages in sync.
 
 If you add a new dependency to a package, you can run
 
-::
+..  code-block:: shell
 
     make monorepo
 
@@ -27,7 +27,7 @@ This will update the root :file:`composer.json` file with the new dependency.
 
 It is recommended to run the validation check before you commit:
 
-::
+..  code-block:: shell
 
     make test-monorepo
 

--- a/Documentation/Developer/ThemeCustomization.rst
+++ b/Documentation/Developer/ThemeCustomization.rst
@@ -31,7 +31,9 @@ template.
 Build Sources
 =============
 
-To build the public assets execute the following commands::
+To build the public assets execute the following commands:
+
+..  code-block:: shell
 
     ddev ssh
     cd packages/typo3-docs-theme

--- a/Documentation/Installation/Index.rst
+++ b/Documentation/Installation/Index.rst
@@ -33,7 +33,7 @@ Docker
 The Docker image is available on GitHub packages. You can pull the image with
 the following command.
 
-::
+..  code-block:: shell
 
     docker pull ghcr.io/typo3-documentation/render-guides:main
 
@@ -41,7 +41,7 @@ For all available tags, please check the `GitHub packages page`_.
 Once you have pulled the image, you can run the image to render your project's
 documentation.
 
-::
+..  code-block:: shell
 
     docker run --rm -v $(pwd):/project ghcr.io/typo3-documentation/render-guides:main --progress --config ./Documentation
 
@@ -52,7 +52,7 @@ when files are getting generated inside the image.
 
 This may fail on macOS, in which case you need to specify the `user` argument:
 
-::
+..  code-block:: shell
 
     docker run --rm --user=$(id -u):$(id -g) -v $(pwd):/project ghcr.io/typo3-documentation/render-guides:main --progress --config ./Documentation
 
@@ -75,7 +75,7 @@ other requirement than Docker and DDEV.
 
 To render the documentation you can run
 
-::
+..  code-block:: shell
 
     ddev start
     ddev composer install
@@ -92,7 +92,7 @@ you can create documentation natively, without needing docker.
 
 You can run these commands locally:
 
-::
+..  code-block:: shell
 
     composer install
     make docs


### PR DESCRIPTION
This makes reading of the rst easier as it is explicitly visible, which language is used.