### PR TITLE
[TASK] Refactor Docker entrypoint and CLI wrapping

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,5 +14,5 @@ COPY --from=Builder /opt/guides/vendor /opt/guides/vendor
 RUN echo "memory_limit=1G" >> /usr/local/etc/php/conf.d/typo3.ini
 
 WORKDIR /project
-ENTRYPOINT [ "/opt/guides/entrypoint.sh", "/opt/guides/vendor/bin/guides"]
+ENTRYPOINT [ "/opt/guides/entrypoint.sh" ]
 CMD ["-h"]

--- a/Documentation/Developer/Building.rst
+++ b/Documentation/Developer/Building.rst
@@ -26,7 +26,7 @@ Once the build is finished you can execute your own image using:
 
     docker run --rm -v $(pwd):/project typo3-docs:local --progress
 
-For macOS you also need to specify the argument ``user``:
+For macOS you may need to specify the argument ``user``:
 
 ..  code-block:: shell
 

--- a/Documentation/Developer/Contributing.rst
+++ b/Documentation/Developer/Contributing.rst
@@ -10,10 +10,11 @@ When contributing please run all tests before committing:
 
 ..  code-block:: shell
 
-    # Using Makefile (append ENV=local if you don't require docker)
+    # Using Makefile (append ENV=local if you don't utilize docker)
     make pre-commit-test
 
-    # Using composer
+    # Using composer (also uses "make" command internally, your OS may need a
+    # package like "build-essential")
     composer make pre-commit-test
 
     # Using ddev

--- a/Documentation/Developer/DirectoryStructure.rst
+++ b/Documentation/Developer/DirectoryStructure.rst
@@ -22,6 +22,7 @@ The directory structure of the project is as follows:
     ├── packages
     │   ├── typo3-docs-theme
     │   ├── typo3-guides-extension
+    │   ├── typo3-guides-cli
     ├── tests
     │   ├── Integration
     ├── tools
@@ -42,17 +43,24 @@ The :file:`packages/` directory contains the TYPO3-specific extensions. The
 ``typo3-docs-theme`` extension contains the theme for the documentation, and
 TYPO3-specific directives. The ``typo3-guides-extension`` extension contains
 extensions on the base tool. This are customizations to make the tool fit the
-TYPO3 documentation needs.
+TYPO3 documentation needs. The ``typo3-guides-cli`` package is a collection
+of Symfony Commands for tasks like conversion or linting.
 
 The :file:`tests/` directory contains the tests for the project. The integration
 tests are located in the :file:`Integration/` directory. During the integration
 tests the tool is executed as it was run by the user.
 
 The :file:`tools/` directory contains the tools needed for the project. Like
-scripts to build the phar file, or the Docker image.
+scripts to build the phar file or adapt GIT hooks.
 
 The :file:`Documentation/` directory holds the documentation you are now
 reading. It is the default documentation being build by the project, too.
 
+The :file:`Dockerfile` and :file:`entrypoint.sh` files provide the Docker
+container support for the project.
+
+The :file:`Makefile` contains a list of all supported development commands and
+tasks that can be executed. All of them can also be executed with a composer
+wrapper script (:bash:`composer make ...`).
 
 ..  _DDEV: https://ddev.com/

--- a/Documentation/Developer/Index.rst
+++ b/Documentation/Developer/Index.rst
@@ -15,7 +15,7 @@ Under the hood this tool is based on `phpDocumentor/guides`_
 The repository ships a wide range of commands that are used to render the documentation,
 build and execute development helpers, and they can be utilized by GitHub Actions.
 
-The "single source of truth" for these commands is within the `Makefile`. You can
+The "single source of truth" for these commands is within the :file:`Makefile`. You can
 see all available commands via:
 
 ..  code-block:: shell
@@ -35,7 +35,7 @@ The most common commands are probably:
     # (Re)-Create Docker container
     make docker-build
 
-Most `make` commands can be prepended or appended with the parameter `ENV=local`:
+Most :bash:`make` commands can be prepended or appended with the parameter :bash:`ENV=local`:
 
 ..  code-block:: shell
 
@@ -49,13 +49,13 @@ Most `make` commands can be prepended or appended with the parameter `ENV=local`
     make docker-build ENV=local
 
 By default most :bash:`make` commands all utilize Docker to run within a container.
-If the parameter `ENV=local` is appended or prepended to the command, they can
+If the parameter :bash:`ENV=local` is appended or prepended to the command, they can
 also be run locally, without Docker. This can speed up processing and saves
 resources on build pipelines. This requires PHP on your host.
 
 The :file:`Makefile` can also be executed via composer. All commands in the
-:bash:`make` range are just passed onto the `Makefile` via a composer script,
-and automatically then use the `ENV=local` scope:
+:bash:`make` range are just passed onto the :file:`Makefile` via a composer script,
+and automatically then use the :file:`ENV=local` scope:
 
 ..  code-block:: shell
 
@@ -68,8 +68,8 @@ and automatically then use the `ENV=local` scope:
     # (Re)-Create Docker container
     composer make docker-build
 
-If your local environment does not provide :bash:`make` you can use DDEV to wrap
-the same commands within the DDEV container:
+If your local environment does not provide :bash:`make` (usually a package like
+:bash:`build-essential`) you can use DDEV to wrap the same commands within the DDEV container:
 
 ..  code-block:: shell
 
@@ -78,9 +78,6 @@ the same commands within the DDEV container:
 
     # Run tests
     ddev composer make test
-
-    # (Re)-Create Docker container
-    ddev composer make docker-build
 
 All these options are provided to allow for maximum convenience for any contributor
 and the GitHub pipelines, while internally only using :file:`Makefile` syntax.

--- a/Documentation/Installation/Index.rst
+++ b/Documentation/Installation/Index.rst
@@ -14,16 +14,17 @@ documentation, please check the
 Multiple methods are provided to install the project on your local machine.
 You can choose whatever is easiest for you:
 
--   Using Docker natively, with an existing image
--   Using Docker natively, with a locally-generated image
+-   Using Docker natively, with a provided official container
+-   Using Docker natively, with a locally-generated container
 -   Using DDEV (utilizing Docker)
 -   Using PHP
 
 ..  note::
 
-    The Docker image is the recommended way to use this project. It will
-    automatically set up all dependencies and will not interfere with your
-    local PHP installation.
+    The Docker container is the recommended way to use this project for
+    end-users. It will automatically set up all dependencies and will not interfere
+    with your local PHP installation or project. The container can be
+    used in any project (and in any GitHub action) without further dependencies.
 
 ..  _Setup_Docker:
 
@@ -50,11 +51,39 @@ project. This means that the files created by the Docker image will have the
 same owner as the files in your project. No more permission issues should occur,
 when files are getting generated inside the image.
 
-This may fail on macOS, in which case you need to specify the `user` argument:
+If this fail, you can resort to specifying the user:
 
 ..  code-block:: shell
 
     docker run --rm --user=$(id -u):$(id -g) -v $(pwd):/project ghcr.io/typo3-documentation/render-guides:main --progress --config ./Documentation
+
+The provided image allows you to also perform a few other actions:
+
+..  code-block:: shell
+
+    # Convert Settings.cfg to guides.xml:
+    docker run --rm -v $(pwd):/project ghcr.io/typo3-documentation/render-guides:main migrate ./Documentation
+
+    # Check guides.xml files for XML conformity
+    docker run --rm -v $(pwd):/project ghcr.io/typo3-documentation/render-guides:main lint-guides-xml
+
+    # Adapt guides.xml programmatically (work in progress)
+    docker run --rm -v $(pwd):/project ghcr.io/typo3-documentation/render-guides:main configure \
+      --project-version="2.2" \
+      --project-title="My project title" \
+      --project-release="2023" \
+      --project-copyright="2000-2023" ./Documentation
+
+In case of errors you can increase verbose output by prefixing any command with the argument
+:bash:`verbose`:
+
+..  code-block:: shell
+
+    # Execute verbose commands with inline setting
+    docker run --rm -v $(pwd):/project ghcr.io/typo3-documentation/render-guides:main verbose (render|migrate|lint-guides-xml|configure) [arguments/options]
+
+    # Execute verbose commands with inline setting, useful for i.e. external actions
+    SHELL_VERBOSITY=3 docker run --rm -v $(pwd):/project ghcr.io/typo3-documentation/render-guides:main (render|migrate|lint-guides-xml|configure) [arguments/options]
 
 Another way to utilize Docker is to create your own image/container. This is aimed at people
 who want to contribute to the underlying Documentation tool. Please see :ref:`_Building`
@@ -96,5 +125,11 @@ You can run these commands locally:
 
     composer install
     make docs
+
+The provided Symfony Commands can be executed via:
+
+..  code-block:: shell
+
+    ./packages/typo3-guides-cli/bin/typo3-guides (migrate|lint-guides-xml|configure)
 
 .. _`GitHub packages page`: https://github.com/TYPO3-Documentation/render-guides/pkgs/container/render-guides

--- a/Documentation/Migration/Index.rst
+++ b/Documentation/Migration/Index.rst
@@ -14,6 +14,18 @@ To facilitate migration the extension `t3docs/typo3-guides-cli` in this
 mono-repository comes with a Symfony console command to automatically migrate
 the outdated :file:`Settings.cfg`.
 
+After migration, you can add your :file:`guides.xml` file to your custom repository,
+and optionally also remove the old :file:`Settings.cfg` file.
+
+With official Docker container
+==============================
+
+(Work in progress)
+
+..  code-block:: sh
+
+    docker run --rm --pull always -v $(pwd):/project -it ghcr.io/typo3-documentation/render-guides:main migrate
+
 With make
 =========
 

--- a/composer.lock
+++ b/composer.lock
@@ -12,12 +12,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/brotkrueml/twig-codehighlight.git",
-                "reference": "2ebb7b8811a838cc4b17ec8d54abb530334a8eb4"
+                "reference": "0e9bb094f58060bea79fb5f76bd0b665f50bf5e1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/brotkrueml/twig-codehighlight/zipball/2ebb7b8811a838cc4b17ec8d54abb530334a8eb4",
-                "reference": "2ebb7b8811a838cc4b17ec8d54abb530334a8eb4",
+                "url": "https://api.github.com/repos/brotkrueml/twig-codehighlight/zipball/0e9bb094f58060bea79fb5f76bd0b665f50bf5e1",
+                "reference": "0e9bb094f58060bea79fb5f76bd0b665f50bf5e1",
                 "shasum": ""
             },
             "require": {
@@ -29,10 +29,10 @@
                 "brotkrueml/coding-standards": "~5.0.0",
                 "ergebnis/composer-normalize": "~2.39.0",
                 "infection/infection": "^0.27.8",
-                "phpstan/phpstan": "1.10.41",
-                "phpunit/phpunit": "^10.4",
+                "phpstan/phpstan": "1.10.47",
+                "phpunit/phpunit": "^10.5",
                 "psr/log": "^3.0",
-                "rector/rector": "0.18.7"
+                "rector/rector": "0.18.11"
             },
             "suggest": {
                 "psr/log": "Output a warning when a given language is not available"
@@ -67,7 +67,7 @@
                 "source": "https://github.com/brotkrueml/twig-codehighlight/tree/main",
                 "issues": "https://github.com/brotkrueml/twig-codehighlight/issues"
             },
-            "time": "2023-11-26T15:00:07+00:00"
+            "time": "2023-12-03T17:24:25+00:00"
         },
         {
             "name": "dflydev/dot-access-data",
@@ -3996,16 +3996,16 @@
         },
         {
             "name": "ergebnis/composer-normalize",
-            "version": "2.39.0",
+            "version": "2.40.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ergebnis/composer-normalize.git",
-                "reference": "a878360bc8cb5cb440b9381f72b0aaa125f937c7"
+                "reference": "665de8e2bbe7c3e31b0a819b4dc0165289c0d230"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ergebnis/composer-normalize/zipball/a878360bc8cb5cb440b9381f72b0aaa125f937c7",
-                "reference": "a878360bc8cb5cb440b9381f72b0aaa125f937c7",
+                "url": "https://api.github.com/repos/ergebnis/composer-normalize/zipball/665de8e2bbe7c3e31b0a819b4dc0165289c0d230",
+                "reference": "665de8e2bbe7c3e31b0a819b4dc0165289c0d230",
                 "shasum": ""
             },
             "require": {
@@ -4018,18 +4018,21 @@
                 "localheinz/diff": "^1.1.1",
                 "php": "~8.1.0 || ~8.2.0 || ~8.3.0"
             },
+            "conflict": {
+                "symfony/console": "^7.0.0"
+            },
             "require-dev": {
                 "composer/composer": "^2.6.5",
-                "ergebnis/license": "^2.2.0",
-                "ergebnis/php-cs-fixer-config": "~6.7.0",
-                "ergebnis/phpunit-slow-test-detector": "^2.3.0",
+                "ergebnis/license": "^2.4.0",
+                "ergebnis/php-cs-fixer-config": "~6.13.1",
+                "ergebnis/phpunit-slow-test-detector": "^2.7.0",
                 "fakerphp/faker": "^1.23.0",
-                "infection/infection": "~0.27.4",
-                "phpunit/phpunit": "^10.4.1",
+                "infection/infection": "~0.27.8",
+                "phpunit/phpunit": "^10.4.2",
                 "psalm/plugin-phpunit": "~0.18.4",
-                "rector/rector": "~0.18.5",
-                "symfony/filesystem": "^6.0.13",
-                "vimeo/psalm": "^5.15.0"
+                "rector/rector": "~0.18.12",
+                "symfony/filesystem": "^6.4.0",
+                "vimeo/psalm": "^5.17.0"
             },
             "type": "composer-plugin",
             "extra": {
@@ -4069,7 +4072,7 @@
                 "security": "https://github.com/ergebnis/composer-normalize/blob/main/.github/SECURITY.md",
                 "source": "https://github.com/ergebnis/composer-normalize"
             },
-            "time": "2023-10-10T15:43:27+00:00"
+            "time": "2023-12-05T16:07:43+00:00"
         },
         {
             "name": "ergebnis/json",
@@ -4408,16 +4411,16 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v3.40.0",
+            "version": "v3.40.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer.git",
-                "reference": "27d2b3265b5d550ec411b4319967ae7cfddfb2e0"
+                "reference": "4344562a516b76afe8f2d64b2e52214c30d64ed8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/27d2b3265b5d550ec411b4319967ae7cfddfb2e0",
-                "reference": "27d2b3265b5d550ec411b4319967ae7cfddfb2e0",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/4344562a516b76afe8f2d64b2e52214c30d64ed8",
+                "reference": "4344562a516b76afe8f2d64b2e52214c30d64ed8",
                 "shasum": ""
             },
             "require": {
@@ -4489,7 +4492,7 @@
             ],
             "support": {
                 "issues": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues",
-                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.40.0"
+                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.40.2"
             },
             "funding": [
                 {
@@ -4497,7 +4500,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-11-26T09:25:53+00:00"
+            "time": "2023-12-03T09:21:33+00:00"
         },
         {
             "name": "justinrainbow/json-schema",
@@ -5333,16 +5336,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "10.5.1",
+            "version": "10.5.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "d5d9dca6a902d05b34c4bcbc7c1636ce1dc25408"
+                "reference": "5aedff46afba98dddecaa12349ec044d9103d4fe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/d5d9dca6a902d05b34c4bcbc7c1636ce1dc25408",
-                "reference": "d5d9dca6a902d05b34c4bcbc7c1636ce1dc25408",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/5aedff46afba98dddecaa12349ec044d9103d4fe",
+                "reference": "5aedff46afba98dddecaa12349ec044d9103d4fe",
                 "shasum": ""
             },
             "require": {
@@ -5414,7 +5417,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.1"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.2"
             },
             "funding": [
                 {
@@ -5430,7 +5433,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-12-01T16:57:05+00:00"
+            "time": "2023-12-05T14:54:33+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,6 +13,8 @@ if [ "$MY_UID" -eq "0" ]; then
 
   if [ "$UID" -eq "0" ]; then
       echo "Run-as: root"
+      echo "Invocation: php $@"
+      php "$@"
   else
       echo "Run-as: $UID (custom invocation)"
       addgroup typo3 --gid=$GID;

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,42 +1,132 @@
 #!/usr/bin/env sh
 
-# TODO: This detection seems to fail on macOS. If no "--user" argument is specified to make Docker run
-#       as that user, it cannot deduce ownership properly. Probably the Dockerfile needs to be adapted
-#       so that a user-switch to the "typo3" user is done? This can have side-effects though.
+# INPUT ARGUMENT SPLITTING:
+#
+# By default, the entrypoint assumes that the PHP entrypoint "/opt/guides/vendor/bin/guides"
+# is executed, and all arguments passed on to that PHP script.
+#
+# When executing Docker via:
+#
+# $ docker run --rm -v $(pwd):/project -it typo3-docs:local --progress SomeDocsFolder"
+#
+# then this script receives the input "/opt/guides/vendor/bin/guides --progress SomeDocsFolder"
+# as "$@" input. This is passed on then to the PHP binary.
+#
+# Before the final destination script is executed, this entrypoint performs some basic
+# invocation checks, i.e. if Docker is run as root, or as a custom user, and if the
+# internal user needs to be changed. This is needed so that the parameters
+# "--user=X:Y" (i.e. "--user=$(id -u):$(id -g)" are not required to be passed to Docker.
+#
+# Several internal commands are allowed to be added as a prefix to alter the entrypoint:
+#
+# * render           [... arguments/options/input] (default; just as if omitted)
+# * migrate          [... arguments/options/input] (migrates Settings.cfg to guides.xml)
+# * lint-guides-xml  [... arguments/options/input] (lints all guides.xml files found in the directory)
+# * configure        [... arguments/options/input] (allows to alter guides.xml variables)
+#
+# All of the commands can be prefixed with "verbose" to trigger additional information to be shown:
+#
+# $ docker run --rm -v $(pwd):/project -it typo3-docs:local verbose migrate SomeDocsFolderWithSettings"
+#
+# Only those commands shall be provided here that users of the "official Docker container"
+# need to perform the rendering. The Container-microservice concept suggests to only have one
+# "concern" (entrypoint) per container, so this concept is bending the idea of multiple commands
+# and shall be used with care.
+#
+# ONLY PHP-SCRIPTS will (and shall) be executed by this entrypoint.
+
 MY_UID="$(id -u)"
-echo "UID: $MY_UID"
 
-if [ "$MY_UID" -eq "0" ]; then
-
-  UID=$(stat -c "%u" $(pwd))
-  GID=$(stat -c "%g" $(pwd))
-
-  if [ "$UID" -eq "0" ]; then
-      echo "Run-as: root"
-      echo "Invocation: php $@"
-      php "$@"
-  else
-      echo "Run-as: $UID (custom invocation)"
-      addgroup typo3 --gid=$GID;
-      adduser -h $(pwd) -D -G typo3 --uid=$UID typo3;
-
-      # su behaves inconsistently with -c followed by flags
-      # Workaround: run the entrypoint and commands as a standalone script
-      echo "#!/usr/bin/env sh" > /usr/local/bin/invocation.sh
-      echo >> /usr/local/bin/invocation.sh
-      echo "export SHELL_VERBOSITY=$SHELL_VERBOSITY" >> /usr/local/bin/invocation.sh
-      for ARG in "$@"; do
-          printf "${ARG} " >> /usr/local/bin/invocation.sh
-      done
-      chmod a+x /usr/local/bin/invocation.sh
-
-      echo "Invocation:"
-      cat /usr/local/bin/invocation.sh
-      echo ""
-      su - typo3 -c "/usr/local/bin/invocation.sh"
-  fi
+if [ "$1" = "verbose" ]; then
+    echo "Full input arguments:  \$ $@"
+    SHELL_VERBOSITY="3"
+    # Removes "verbose" from the input argument list
+    shift
+    echo "Parsed input:          \$ $@"
+elif [ -z "${SHELL_VERBOSITY}" ]; then
+    SHELL_VERBOSITY="0"
 else
-  echo "Run-as: Owner $MY_UID"
-  echo "Invocation: php $@"
-  php "$@"
+    # SHELL_VERBOSITY is triggered via call-time pass (i.e. `SHELL_VERBOSITY=yes docker run ...`)
+    SHELL_VERBOSITY="${SHELL_VERBOSITY}"
+fi
+
+if [ "${SHELL_VERBOSITY}" -gt 0 ]; then
+    echo "SHELL_VERBOSITY is:    ${SHELL_VERBOSITY}"
+    echo "UID of executing user: ${MY_UID}"
+fi
+
+ENTRYPOINT_DEFAULT="/opt/guides/vendor/bin/guides"
+ENTRYPOINT_SYMFONY_COMMANDS="/opt/guides/packages/typo3-guides-cli/bin/typo3-guides"
+
+# This is intentionally a specified list of allowed scripts.
+# If an allowed initial entrypoint is found, shift arguments by one.
+if [ "$1" = "migrate" ]; then
+    ENTRYPOINT="${ENTRYPOINT_SYMFONY_COMMANDS} migrate"
+    shift
+elif [ "$1" = "lint-guides-xml" ]; then
+    ENTRYPOINT="${ENTRYPOINT_SYMFONY_COMMANDS} lint-guides-xml"
+    shift
+elif [ "$1" = "configure" ]; then
+    ENTRYPOINT="${ENTRYPOINT_SYMFONY_COMMANDS} configure"
+    shift
+else
+    # Default: "render"; no shifting.
+    ENTRYPOINT="${ENTRYPOINT_DEFAULT}"
+fi
+
+if [ "${SHELL_VERBOSITY}" -gt 0 ]; then
+    # Also pass shell verbosity as a fixed argument to the execution.
+    ENTRYPOINT="${ENTRYPOINT} -vvv $@"
+    echo "ENTRYPOINT:            \$ ${ENTRYPOINT}"
+else
+    ENTRYPOINT="${ENTRYPOINT} $@"
+fi
+
+if [ "${MY_UID}" -eq "0" ]; then
+
+    UID=$(stat -c "%u" $(pwd))
+    GID=$(stat -c "%g" $(pwd))
+
+    if [ "$UID" -eq "0" ]; then
+        if [ "${SHELL_VERBOSITY}" -gt 0 ]; then
+            echo "Run-as:                root"
+            echo "Invocation:            php ${ENTRYPOINT}"
+        fi
+
+        php ${ENTRYPOINT}
+    else
+        if [ "${SHELL_VERBOSITY}" -gt 0 ]; then
+            echo "Run-as:                $UID (custom invocation)"
+        fi
+
+        addgroup typo3 --gid=$GID;
+        adduser -h $(pwd) -D -G typo3 --uid=$UID typo3;
+
+        # su behaves inconsistently with -c followed by flags
+        # Workaround: run the entrypoint and commands as a standalone script
+        echo "#!/usr/bin/env sh" > /usr/local/bin/invocation.sh
+        echo >> /usr/local/bin/invocation.sh
+        echo "export SHELL_VERBOSITY=${SHELL_VERBOSITY}" >> /usr/local/bin/invocation.sh
+        for ARG in "${ENTRYPOINT}"; do
+            printf "${ARG} " >> /usr/local/bin/invocation.sh
+        done
+
+        chmod a+x /usr/local/bin/invocation.sh
+
+        if [ "${SHELL_VERBOSITY}" -gt 0 ]; then
+            echo "Run-as:                root"
+            echo "Invocation:"
+            cat /usr/local/bin/invocation.sh
+            echo ""
+        fi
+
+        su - typo3 -c "/usr/local/bin/invocation.sh"
+    fi
+else
+    if [ "${SHELL_VERBOSITY}" -gt 0 ]; then
+        echo "Run-as:                Owner ${MY_UID}"
+        echo "Invocation:            php ${ENTRYPOINT}"
+    fi
+
+    php ${ENTRYPOINT}
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,22 +3,18 @@
 # TODO: This detection seems to fail on macOS. If no "--user" argument is specified to make Docker run
 #       as that user, it cannot deduce ownership properly. Probably the Dockerfile needs to be adapted
 #       so that a user-switch to the "typo3" user is done? This can have side-effects though.
-if [ "$(id -u)" -eq "0" ]; then
+MY_UID="$(id -u)"
+echo "UID: $MY_UID"
+
+if [ "$MY_UID" -eq "0" ]; then
 
   UID=$(stat -c "%u" $(pwd))
   GID=$(stat -c "%g" $(pwd))
 
   if [ "$UID" -eq "0" ]; then
-        echo "ERROR: Could not detect the owner of $(pwd) - did you mount your project?"
-        echo ""
-        echo "Run this container with:"
-        echo "\"docker run --rm --volume \${PWD}:/project ghcr.io/typo3-documentation/render-guides:main\""
-        echo ""
-        echo "On macOS you might need to specify the user:"
-        echo "\"docker run --rm --volume --user=\$(id -u):\$(id -g) \${PWD}:/project ghcr.io/typo3-documentation/render-guides:main\""
-        echo ""
-        exit 1
+      echo "Run-as: root"
   else
+      echo "Run-as: $UID (custom invocation)"
       addgroup typo3 --gid=$GID;
       adduser -h $(pwd) -D -G typo3 --uid=$UID typo3;
 
@@ -32,8 +28,13 @@ if [ "$(id -u)" -eq "0" ]; then
       done
       chmod a+x /usr/local/bin/invocation.sh
 
+      echo "Invocation:"
+      cat /usr/local/bin/invocation.sh
+      echo ""
       su - typo3 -c "/usr/local/bin/invocation.sh"
   fi
 else
+  echo "Run-as: Owner $MY_UID"
+  echo "Invocation: php $@"
   php "$@"
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -69,6 +69,9 @@ elif [ "$1" = "lint-guides-xml" ]; then
 elif [ "$1" = "configure" ]; then
     ENTRYPOINT="${ENTRYPOINT_SYMFONY_COMMANDS} configure"
     shift
+elif [ "$1" = "render" ]; then
+    ENTRYPOINT="${ENTRYPOINT_DEFAULT}"
+    shift
 else
     # Default: "render"; no shifting.
     ENTRYPOINT="${ENTRYPOINT_DEFAULT}"


### PR DESCRIPTION
The current logic had two main issues:

* The "--user" GID/UID information was evaluated strictly, and would fail on macOS (which runs as root) if not set.
* Current entrypoint.sh only allowed to directly and exclusively call the `opt/guides/vendor/bin/guides` PHP script. This prevented allowing to execute our bundled CLI scripts (migration)

This PR addresses it like this:

* Modified entrypoint.sh to drop the `--user` requirement. Operation as root on macos isn't an issue because the internal docker logic prevents that "root"-owned files are created on the Hosts' filesystem.
* Allow evaluation of SHELL_VERBOSITY, return extra output if set (and passes along to the script itself) to see the full command that is being executed
* Allow the entrypoint to get "modifiers" like: "render", "migrate", "configure", "lint-guides-xml" to execute further commands. All of them can be prefixed with a "verbose" argument that can enable/set SHELL_VERBOSITOY within the script (and be passed on to the helpers)
* The docker entrypoint now no longer specifies the `opt/guides/vendor/bin/guides`, but falls back to that default if no other custom entrypoint is selected. That should allow backwards compatibility to existing docker container use.
* Improved documentation on all the areas this touches
* Updated to recent composer dependencies

I verified the entrypoint.sh work like that on three OSes:

* Windows (11)
* MacOS (Sonoma)
* Linux (Ubuntu 22.04.3 LTS)

To test it, I did this:

```
# check out this repository, create docker container
git clone https://github.com/TYPO3-Documentation/render-guides.git
cd render-guides
git checkout task/docker-debug
docker build -t typo3-docs:local .
 
# default (current) behaviour
docker run --rm -v $(pwd):/project -it typo3-docs:local --progress

# explicit rendering
docker run --rm -v $(pwd):/project -it typo3-docs:local render --progress ./Documentation/

# explicit rendering, verbose
docker run --rm -v $(pwd):/project -it typo3-docs:local verbose render --progress ./Documentation/

# verbose migration
docker run --rm -v $(pwd):/project -it typo3-docs:local verbose migrate ./Documentation/

# verbose lint
docker run --rm -v $(pwd):/project -it typo3-docs:local verbose lint-guides-xml

# verbose configuration
docker run --rm -v $(pwd):/project -it typo3-docs:local verbose configure --project-version=\"2.2\" \
      --project-title=\"My project title\" \
      --project-release=\"2023\" \
      --project-copyright=\"2000-2023\" ./Documentation
```
