### PR TITLE
[TASK] Run composer update

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1236,12 +1236,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/guides-core.git",
-                "reference": "f68aa1116613557006c60c2d30649fd329ab61e2"
+                "reference": "0b1fea0d16cd7c58280e638db8e3b3fd258f9b53"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/guides-core/zipball/f68aa1116613557006c60c2d30649fd329ab61e2",
-                "reference": "f68aa1116613557006c60c2d30649fd329ab61e2",
+                "url": "https://api.github.com/repos/phpDocumentor/guides-core/zipball/0b1fea0d16cd7c58280e638db8e3b3fd258f9b53",
+                "reference": "0b1fea0d16cd7c58280e638db8e3b3fd258f9b53",
                 "shasum": ""
             },
             "require": {
@@ -1279,7 +1279,7 @@
                 "issues": "https://github.com/phpDocumentor/guides-core/issues",
                 "source": "https://github.com/phpDocumentor/guides-core/tree/main"
             },
-            "time": "2023-12-09T20:02:20+00:00"
+            "time": "2023-12-12T20:58:39+00:00"
         },
         {
             "name": "phpdocumentor/guides-cli",
@@ -1381,12 +1381,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/guides-markdown.git",
-                "reference": "6e2977449d6abce06f1f7f443d42a3c45dc78382"
+                "reference": "053c920e803de0f06f802c2d95c688bf44744848"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/guides-markdown/zipball/6e2977449d6abce06f1f7f443d42a3c45dc78382",
-                "reference": "6e2977449d6abce06f1f7f443d42a3c45dc78382",
+                "url": "https://api.github.com/repos/phpDocumentor/guides-markdown/zipball/053c920e803de0f06f802c2d95c688bf44744848",
+                "reference": "053c920e803de0f06f802c2d95c688bf44744848",
                 "shasum": ""
             },
             "require": {
@@ -1411,7 +1411,7 @@
                 "issues": "https://github.com/phpDocumentor/guides-markdown/issues",
                 "source": "https://github.com/phpDocumentor/guides-markdown/tree/main"
             },
-            "time": "2023-11-02T08:42:48+00:00"
+            "time": "2023-12-12T20:26:51+00:00"
         },
         {
             "name": "phpdocumentor/guides-restructured-text",
@@ -1419,12 +1419,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/guides-restructured-text.git",
-                "reference": "472367be6230369f9904bada5ce5c22dd6771d8f"
+                "reference": "aa801f4389952e475af6b94b33c5cad359c04e46"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/guides-restructured-text/zipball/472367be6230369f9904bada5ce5c22dd6771d8f",
-                "reference": "472367be6230369f9904bada5ce5c22dd6771d8f",
+                "url": "https://api.github.com/repos/phpDocumentor/guides-restructured-text/zipball/aa801f4389952e475af6b94b33c5cad359c04e46",
+                "reference": "aa801f4389952e475af6b94b33c5cad359c04e46",
                 "shasum": ""
             },
             "require": {
@@ -1450,7 +1450,7 @@
             "support": {
                 "source": "https://github.com/phpDocumentor/guides-restructured-text/tree/main"
             },
-            "time": "2023-12-12T20:23:03+00:00"
+            "time": "2023-12-12T20:58:39+00:00"
         },
         {
             "name": "phpdocumentor/guides-theme-bootstrap",
@@ -1458,12 +1458,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/guides-theme-bootstrap.git",
-                "reference": "a48b2e9e10cf639e29ec844f23eab210bc6de3ef"
+                "reference": "1eb8dcab3d8882fcde0c8e6504da59189cded0b0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/guides-theme-bootstrap/zipball/a48b2e9e10cf639e29ec844f23eab210bc6de3ef",
-                "reference": "a48b2e9e10cf639e29ec844f23eab210bc6de3ef",
+                "url": "https://api.github.com/repos/phpDocumentor/guides-theme-bootstrap/zipball/1eb8dcab3d8882fcde0c8e6504da59189cded0b0",
+                "reference": "1eb8dcab3d8882fcde0c8e6504da59189cded0b0",
                 "shasum": ""
             },
             "require": {
@@ -1487,7 +1487,7 @@
             "support": {
                 "source": "https://github.com/phpDocumentor/guides-theme-bootstrap/tree/main"
             },
-            "time": "2023-11-21T08:14:20+00:00"
+            "time": "2023-12-14T19:29:31+00:00"
         },
         {
             "name": "psr/clock",
@@ -3602,12 +3602,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3-Documentation/guides-php-domain.git",
-                "reference": "e92c96e23e4e319c4cf6f0dc7277fa2655ea2797"
+                "reference": "bed620cc16bb44071743c05e3f330124e3fd3e83"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-Documentation/guides-php-domain/zipball/e92c96e23e4e319c4cf6f0dc7277fa2655ea2797",
-                "reference": "e92c96e23e4e319c4cf6f0dc7277fa2655ea2797",
+                "url": "https://api.github.com/repos/TYPO3-Documentation/guides-php-domain/zipball/bed620cc16bb44071743c05e3f330124e3fd3e83",
+                "reference": "bed620cc16bb44071743c05e3f330124e3fd3e83",
                 "shasum": ""
             },
             "require": {
@@ -3642,7 +3642,7 @@
                 "issues": "https://github.com/TYPO3-Documentation/guides-php-domain/issues",
                 "source": "https://github.com/TYPO3-Documentation/guides-php-domain/tree/main"
             },
-            "time": "2023-12-12T20:07:42+00:00"
+            "time": "2023-12-13T09:48:23+00:00"
         },
         {
             "name": "twig/twig",
@@ -3996,41 +3996,39 @@
         },
         {
             "name": "ergebnis/composer-normalize",
-            "version": "2.40.0",
+            "version": "2.41.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ergebnis/composer-normalize.git",
-                "reference": "665de8e2bbe7c3e31b0a819b4dc0165289c0d230"
+                "reference": "01eb2d9b8623828ec2264f54d7782a25558d27b2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ergebnis/composer-normalize/zipball/665de8e2bbe7c3e31b0a819b4dc0165289c0d230",
-                "reference": "665de8e2bbe7c3e31b0a819b4dc0165289c0d230",
+                "url": "https://api.github.com/repos/ergebnis/composer-normalize/zipball/01eb2d9b8623828ec2264f54d7782a25558d27b2",
+                "reference": "01eb2d9b8623828ec2264f54d7782a25558d27b2",
                 "shasum": ""
             },
             "require": {
                 "composer-plugin-api": "^2.0.0",
                 "ergebnis/json": "^1.1.0",
-                "ergebnis/json-normalizer": "^4.3.0",
+                "ergebnis/json-normalizer": "^4.4.1",
                 "ergebnis/json-printer": "^3.4.0",
                 "ext-json": "*",
                 "justinrainbow/json-schema": "^5.2.12",
                 "localheinz/diff": "^1.1.1",
                 "php": "~8.1.0 || ~8.2.0 || ~8.3.0"
             },
-            "conflict": {
-                "symfony/console": "^7.0.0"
-            },
             "require-dev": {
-                "composer/composer": "^2.6.5",
+                "composer/composer": "^2.6.6",
                 "ergebnis/license": "^2.4.0",
-                "ergebnis/php-cs-fixer-config": "~6.13.1",
+                "ergebnis/php-cs-fixer-config": "~6.14.0",
                 "ergebnis/phpunit-slow-test-detector": "^2.7.0",
                 "fakerphp/faker": "^1.23.0",
-                "infection/infection": "~0.27.8",
-                "phpunit/phpunit": "^10.4.2",
+                "infection/infection": "~0.27.9",
+                "phpunit/phpunit": "^10.5.3",
                 "psalm/plugin-phpunit": "~0.18.4",
                 "rector/rector": "~0.18.12",
+                "roave/backward-compatibility-check": "^8.4.0",
                 "symfony/filesystem": "^6.4.0",
                 "vimeo/psalm": "^5.17.0"
             },
@@ -4072,7 +4070,7 @@
                 "security": "https://github.com/ergebnis/composer-normalize/blob/main/.github/SECURITY.md",
                 "source": "https://github.com/ergebnis/composer-normalize"
             },
-            "time": "2023-12-05T16:07:43+00:00"
+            "time": "2023-12-14T09:37:52+00:00"
         },
         {
             "name": "ergebnis/json",
@@ -4141,16 +4139,16 @@
         },
         {
             "name": "ergebnis/json-normalizer",
-            "version": "4.3.0",
+            "version": "4.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ergebnis/json-normalizer.git",
-                "reference": "716fa0a5dcc75fbcb2c1c2e0542b2f56732460bd"
+                "reference": "d28f36af9763ee6bc4e2a2390c0348963df7881b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ergebnis/json-normalizer/zipball/716fa0a5dcc75fbcb2c1c2e0542b2f56732460bd",
-                "reference": "716fa0a5dcc75fbcb2c1c2e0542b2f56732460bd",
+                "url": "https://api.github.com/repos/ergebnis/json-normalizer/zipball/d28f36af9763ee6bc4e2a2390c0348963df7881b",
+                "reference": "d28f36af9763ee6bc4e2a2390c0348963df7881b",
                 "shasum": ""
             },
             "require": {
@@ -4164,18 +4162,19 @@
             },
             "require-dev": {
                 "composer/semver": "^3.4.0",
-                "ergebnis/data-provider": "^3.0.0",
-                "ergebnis/license": "^2.2.0",
-                "ergebnis/php-cs-fixer-config": "~6.7.0",
-                "ergebnis/phpunit-slow-test-detector": "^2.3.0",
+                "ergebnis/data-provider": "^3.2.0",
+                "ergebnis/license": "^2.4.0",
+                "ergebnis/php-cs-fixer-config": "~6.14.0",
+                "ergebnis/phpunit-slow-test-detector": "^2.7.0",
                 "fakerphp/faker": "^1.23.0",
-                "infection/infection": "~0.27.4",
-                "phpunit/phpunit": "^10.4.1",
+                "infection/infection": "~0.27.9",
+                "phpunit/phpunit": "^10.5.3",
                 "psalm/plugin-phpunit": "~0.18.4",
-                "rector/rector": "~0.18.5",
-                "symfony/filesystem": "^6.3.1",
-                "symfony/finder": "^6.3.5",
-                "vimeo/psalm": "^5.15.0"
+                "rector/rector": "~0.18.12",
+                "roave/backward-compatibility-check": "^8.4.0",
+                "symfony/filesystem": "^6.4.0",
+                "symfony/finder": "^6.4.0",
+                "vimeo/psalm": "^5.17.0"
             },
             "suggest": {
                 "composer/semver": "If you want to use ComposerJsonNormalizer or VersionConstraintNormalizer"
@@ -4208,7 +4207,7 @@
                 "security": "https://github.com/ergebnis/json-normalizer/blob/main/.github/SECURITY.md",
                 "source": "https://github.com/ergebnis/json-normalizer"
             },
-            "time": "2023-10-10T15:15:03+00:00"
+            "time": "2023-12-14T09:30:24+00:00"
         },
         {
             "name": "ergebnis/json-pointer",
@@ -4902,16 +4901,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.10.49",
+            "version": "1.10.50",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "9367ba4c4f6ad53e9efb594d74a8941563caccf6"
+                "reference": "06a98513ac72c03e8366b5a0cb00750b487032e4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/9367ba4c4f6ad53e9efb594d74a8941563caccf6",
-                "reference": "9367ba4c4f6ad53e9efb594d74a8941563caccf6",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/06a98513ac72c03e8366b5a0cb00750b487032e4",
+                "reference": "06a98513ac72c03e8366b5a0cb00750b487032e4",
                 "shasum": ""
             },
             "require": {
@@ -4960,7 +4959,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-12-12T10:05:12+00:00"
+            "time": "2023-12-13T10:59:42+00:00"
         },
         {
             "name": "phpstan/phpstan-strict-rules",


### PR DESCRIPTION
This resolves issues with named references on documents and bootstrap tabs

 Upgrading ergebnis/composer-normalize (2.40.0 => 2.41.1)
   - Upgrading ergebnis/json-normalizer (4.3.0 => 4.4.1)
   - Upgrading phpdocumentor/guides (dev-main f68aa11 => dev-main 0b1fea0)
   - Upgrading phpdocumentor/guides-markdown (dev-main 6e29774 => dev-main 053c920)
   - Upgrading phpdocumentor/guides-restructured-text (dev-main 472367b => dev-main aa801f4)
   - Upgrading phpdocumentor/guides-theme-bootstrap (dev-main a48b2e9 => dev-main efced4c)
   - Upgrading phpstan/phpstan (1.10.49 => 1.10.50)
   - Upgrading t3docs/guides-php-domain (dev-main e92c96e => dev-main bed620c)