### PR TITLE
[TASK] Add subtree-split configuration

### DIFF
--- a/.github/workflows/split-repositories.yaml
+++ b/.github/workflows/split-repositories.yaml
@@ -1,0 +1,41 @@
+name: "Sub-split Publishing"
+
+on: # yamllint disable-line rule:truthy
+  create:
+    tags:
+      - "*.*.*"
+  delete:
+    tags:
+      - "*.*.*"
+  push:
+    paths:
+      - "packages/**/*"
+    branches:
+      - "main"
+
+jobs:
+  publish_sub_splits:
+    runs-on: "ubuntu-latest"
+    name: "Publish Sub-split"
+    steps:
+      - uses: "actions/checkout@v4"
+        with:
+          fetch-depth: "0"
+          persist-credentials: "false"
+      - uses: "frankdejonge/use-github-token@1.0.2"
+        with:
+          authentication: "garvinhicking-bot:${{ secrets.BOT_TOKEN_TEST }}"
+          user_name: "TYPO3 Documentation Team"
+          user_email: "documentation-automation@typo3.com"
+      - name: "Cache splitsh-lite"
+        id: "splitsh-cache"
+        uses: "actions/cache@v3.3.2"
+        with:
+          path: "./.splitsh"
+          key: "${{ runner.os }}-splitsh-d-101"
+      - uses: "frankdejonge/use-subsplit-publish@1.0.0"
+        with:
+          source-branch: "main"
+          config-path: "./config.subsplit-publish.json"
+          splitsh-path: "./.splitsh/splitsh-lite"
+          splitsh-version: "v1.0.1"

--- a/.github/workflows/split-repositories.yaml
+++ b/.github/workflows/split-repositories.yaml
@@ -24,7 +24,7 @@ jobs:
           persist-credentials: "false"
       - uses: "frankdejonge/use-github-token@1.0.2"
         with:
-          authentication: "garvinhicking-bot:${{ secrets.BOT_TOKEN_TEST }}"
+          authentication: "typo3-documentation-team:${{ secrets.BOT_TOKEN }}"
           user_name: "TYPO3 Documentation Team"
           user_email: "documentation-automation@typo3.com"
       - name: "Cache splitsh-lite"

--- a/config.subsplit-publish.json
+++ b/config.subsplit-publish.json
@@ -1,0 +1,19 @@
+{
+  "sub-splits": [
+    {
+      "name": "t3docs-typo3-guides-cli",
+      "directory": "packages/typo3-guides-cli",
+      "target": "git@github.com:TYPO3-Documentation/t3docs-typo3-guides-cli.git"
+    },
+    {
+      "name": "t3docs-typo3-guides-extension",
+      "directory": "packages/typo3-guides-extension",
+      "target": "git@github.com:TYPO3-Documentation/t3docs-typo3-guides-extension.git"
+    },
+    {
+      "name": "t3docs-typo3-docs-theme",
+      "directory": "packages/typo3-docs-theme",
+      "target": "git@github.com:TYPO3-Documentation/t3docs-typo3-docs-theme.git"
+    }
+  ]
+}


### PR DESCRIPTION
This adds:

* A GitHub workflow `.github/workflows/split-repositories.yaml` which is triggered on either any commit on `packages/` (subtree split packages) or whenever a new git tag is added
* A subtree configuration on `/config.subsplit-publish.json` that defines, which repositories are split-off into which subdirectories

This uses the `typo3-documentation-team` bot user to push commits (using `secrets.BOT_TOKEN` I have configured).