### PR TITLE
[BUGFIX] Uses getenv('GITHUB_ACTIONS') instead of getenv('CI')

### DIFF
--- a/packages/typo3-docs-theme/src/Twig/TwigExtension.php
+++ b/packages/typo3-docs-theme/src/Twig/TwigExtension.php
@@ -27,7 +27,7 @@ final class TwigExtension extends AbstractExtension
         private readonly Typo3DocsThemeSettings $themeSettings,
         private readonly DocumentNameResolverInterface $documentNameResolver,
     ) {
-        if (strlen((string)getenv('CI')) > 0 && strlen((string)getenv('TYPO3AZUREEDGEURIVERSION')) > 0 && !isset($_ENV['CI_PHPUNIT'])) {
+        if (strlen((string)getenv('GITHUB_ACTIONS')) > 0 && strlen((string)getenv('TYPO3AZUREEDGEURIVERSION')) > 0 && !isset($_ENV['CI_PHPUNIT'])) {
             // CI gets special treatment, then we use a fixed URI for assets.
             // The environment variable 'TYPO3AZUREEDGEURIVERSION' is set during
             // the creation of our Docker image, and holds the last pushed version


### PR DESCRIPTION
This should hopefully properly evaluate whether being called from within a github action and enable using the CDN.