### PR TITLE
[TASK] Add alias for code language "rst" to "plaintext"

### DIFF
--- a/packages/typo3-docs-theme/resources/config/typo3-docs-theme.php
+++ b/packages/typo3-docs-theme/resources/config/typo3-docs-theme.php
@@ -40,6 +40,7 @@ return static function (ContainerConfigurator $container): void {
         ->set(CodeHighlight::class)
         ->arg('$languageAliases', [
             'none' => 'plaintext',
+            'rst' => 'plaintext',
             'text' => 'plaintext',
         ])
         ->arg('$additionalLanguages', [


### PR DESCRIPTION
To avoid warnings when rendering the docs until the `highlight.php` language for restructured text is available.

Related: #173