### PR TITLE
[TASK] Adjust structure of versionchange directives

### DIFF
--- a/packages/typo3-docs-theme/resources/template/body/version-change.html.twig
+++ b/packages/typo3-docs-theme/resources/template/body/version-change.html.twig
@@ -1,16 +1,15 @@
-<div class="versionchange {{ node.type }}">
-    <p class="versionmodified">
+<section class="versionchange {{ node.type }}">
+    <header class="versionmodified">
         <span class="versionicon">
-        {%- if node.type=="deprecated" -%}
-            <i class="fa-solid fa-ban"></i>
-        {%- elseif node.type=="versionadded" -%}
-            <i class="fa-solid fa-rocket"></i>
-        {%- elseif node.type=="versionchanged" -%}
-            <i class="fa-solid fa-arrows-rotate"></i>
-        {%- endif -%}
+            {%- if node.type=="deprecated" -%}
+                <i class="fa-solid fa-ban"></i>
+            {%- elseif node.type=="versionadded" -%}
+                <i class="fa-solid fa-rocket"></i>
+            {%- elseif node.type=="versionchanged" -%}
+                <i class="fa-solid fa-arrows-rotate"></i>
+            {%- endif -%}
         </span>
-        {{ node.versionLabel }}</p>
-    <article>
-        {{ renderNode(node.value) }}
-    </article>
-</div>
+        {{ node.versionLabel }}
+    </header>
+    {{ renderNode(node.value) }}
+</section>


### PR DESCRIPTION
The overall `<section>` groups the whole part. The `<header>` element holds then the heading of the element, which is "Deprecated in version x.y", etc. The text content is then just a paragraph, not a separate article like before.