### PR TITLE
[TASK] Refine TypoScript highlighting

### DIFF
--- a/packages/typo3-docs-theme/resources/languages/typoscript.json
+++ b/packages/typo3-docs-theme/resources/languages/typoscript.json
@@ -3,12 +3,37 @@
         "tsconfig"
     ],
     "case_insensitive": false,
-    "keywords": "ADJUST BOX CASE COA COA_INT CONTENT CROP EFFECT ELLIPSE EMBOSS EXTBASEPLUGIN FILES FLUIDTEMPLATE HMENU IMAGE IMG_RESOURCE LOAD_REGISTER OUTLINE PAGE RECORDS RESTORE_REGISTER SCALE SHADOW SVG TEXT TMENU TMENUITEM USER USER_INT WORKAREA",
+    "keywords": "ACT ACTIFSUB ADJUST BOX CASE COA COA_INT CONTENT CROP CUR CURIFSUB EFFECT ELLIPSE EMBOSS EXTBASEPLUGIN FILES FLUIDTEMPLATE GIFBUILDER HMENU IFSUB IMAGE IMG_RESOURCE LOAD_REGISTER NO OUTLINE PAGE RECORDS RESTORE_REGISTER SCALE SHADOW SPC SVG TEXT TMENU USER USER_INT USERDEF1 USERDEF2 USR WORKAREA",
     "contains": [
         {
             "__comment": "EXT: paths: `EXT:my_extension/Configuration/TypoScript/bar.typoscript` or `FILE:EXT:my_extension/Configuration/TypoScript/myMenu.typoscript`",
             "className": "bullet",
-            "begin": "(FILE:)?EXT:[A-Za-z0-9_\\-\\/\\.]+"
+            "begin": "(EXT:|FILE:EXT:|DIR:)[A-Za-z0-9_\\-\\/\\.\\*]+"
+        },
+        {
+            "__comment": "fileadmin paths: `fileadmin/logo.gif`",
+            "className": "bullet",
+            "begin": "fileadmin\\/[A-Za-z0-9_\\-\\/\\.]+"
+        },
+        {
+            "__comment": "A constant: {$foo.bar}",
+            "className": "name",
+            "begin": "\\{[$[A-Za-z0-9\\._]+\\}"
+        },
+        {
+            "__comment": "A register: `{register:ulClass}`",
+            "className": "name",
+            "begin": "\\{register\\:[A-Za-z0-9_]+\\}"
+        },
+        {
+        "__comment": "Quoting of SQL fields - must be before the comments!",
+            "className": "name",
+            "begin": "\\{#[a-zA-Z0-9_%]+\\}"
+        },
+        {
+            "__comment": "Color: `#123` and `#abcdef` - must be before the comments!",
+            "className": "number",
+            "begin": "#([0-9a-f]{3}|[0-9a-f]{6})$"
         },
         {
             "__comment": "One-line comment: `# Some comment` or `10 = TEXT # Some comment`",
@@ -57,6 +82,11 @@
             "contains": [
                 {
                     "$ref": "#contains.0"
+                },
+                {
+                    "__comment": "Path: `./subDirectory/*.setup.typoscript`",
+                    "className": "bullet",
+                    "begin": "[A-Za-z0-9\\.\\/\\*]+"
                 }
             ]
         },
@@ -68,13 +98,13 @@
             "contains": [
                 {
                     "$ref": "#contains.0"
+                },
+                {
+                    "__comment": "Condition: `condition=\"[frontend.user.isLoggedIn]\"`",
+                    "className": "meta",
+                    "begin": "(?<=condition=\\\").*?(?=\\\")"
                 }
             ]
-        },
-        {
-            "__comment": "An ordinary number",
-            "className": "number",
-            "begin": "[0-9]+"
         }
     ]
 }

--- a/tests/Integration/tests/code-block/with-language-typoscript/expected/index.html
+++ b/tests/Integration/tests/code-block/with-language-typoscript/expected/index.html
@@ -1,0 +1,141 @@
+<!-- content start -->
+                <section class="section" id="with-language-typoscript">
+    <h1>With language &quot;typoscript&quot;<a class="headerlink" href="#with-language-typoscript" title="Permalink to this headline">¶</a></h1>
+
+            <section class="section" id="imports">
+    <h2>Imports<a class="headerlink" href="#imports" title="Permalink to this headline">¶</a></h2>
+
+            <div class="code-block-wrapper" translate="no">
+
+        <pre class="code-block"><code class="hljs typoscript"><span class="hljs-name">@import '<span class="hljs-bullet">EXT:myproject/Configuration/TypoScript/*.typoscript</span>'</span>
+<span class="hljs-name">@import '<span class="hljs-bullet">./userIsLoggedIn.typoscript</span>'</span>
+<span class="hljs-name">@import "<span class="hljs-bullet">./subDirectory/*.setup.typoscript</span>"</span>
+
+<span class="hljs-name">&lt;INCLUDE_TYPOSCRIPT: source="<span class="hljs-bullet">FILE:EXT:my_extension/Configuration/TypoScript/myMenu.typoscript</span>"&gt;</span>
+<span class="hljs-name">&lt;INCLUDE_TYPOSCRIPT: source="<span class="hljs-bullet">DIR:fileadmin/templates/</span>" extensions="typoscript"&gt;</span>
+<span class="hljs-name">&lt;INCLUDE_TYPOSCRIPT: source="<span class="hljs-bullet">FILE:EXT:my_extension/Configuration/TypoScript/user.typoscript</span>" condition="<span class="hljs-meta">[frontend.user.isLoggedIn]</span>"&gt;</span></code></pre>
+        <button class="code-block-copy" title="Copy to clipboard"><svg class="code-block-copy-icon" width="24" height="24"><title>Copy to clipboard</title><rect x="8" y="8" width="12" height="12" rx="2"></rect><path d="M16 8v-2a2 2 0 0 0 -2 -2h-8a2 2 0 0 0 -2 2v8a2 2 0 0 0 2 2h2"></path></svg></button>
+    </div>
+    </section>
+
+            <section class="section" id="conditions">
+    <h2>Conditions<a class="headerlink" href="#conditions" title="Permalink to this headline">¶</a></h2>
+
+            <div class="code-block-wrapper" translate="no">
+
+        <pre class="code-block"><code class="hljs typoscript"><span class="hljs-meta">[date("j") == 9]</span>
+    <span class="hljs-comment"># ...</span>
+<span class="hljs-meta">[END]</span>
+
+<span class="hljs-meta">[date("j") == {$foo.bar}]</span>
+    <span class="hljs-comment"># ...</span>
+<span class="hljs-meta">[ELSE]</span>
+    <span class="hljs-comment"># ...</span>
+<span class="hljs-meta">[GLOBAL]</span></code></pre>
+        <button class="code-block-copy" title="Copy to clipboard"><svg class="code-block-copy-icon" width="24" height="24"><title>Copy to clipboard</title><rect x="8" y="8" width="12" height="12" rx="2"></rect><path d="M16 8v-2a2 2 0 0 0 -2 -2h-8a2 2 0 0 0 -2 2v8a2 2 0 0 0 2 2h2"></path></svg></button>
+    </div>
+    </section>
+
+            <section class="section" id="quoting-of-sql-identifiers">
+    <h2>Quoting of SQL identifiers<a class="headerlink" href="#quoting-of-sql-identifiers" title="Permalink to this headline">¶</a></h2>
+
+            <div class="code-block-wrapper" translate="no">
+
+        <pre class="code-block"><code class="hljs typoscript">select.where = (<span class="hljs-name">{#title}</span> LIKE <span class="hljs-name">{#%SOMETHING%}</span> AND NOT <span class="hljs-name">{#doktype}</span>)</code></pre>
+        <button class="code-block-copy" title="Copy to clipboard"><svg class="code-block-copy-icon" width="24" height="24"><title>Copy to clipboard</title><rect x="8" y="8" width="12" height="12" rx="2"></rect><path d="M16 8v-2a2 2 0 0 0 -2 -2h-8a2 2 0 0 0 -2 2v8a2 2 0 0 0 2 2h2"></path></svg></button>
+    </div>
+    </section>
+
+            <section class="section" id="variables">
+    <h2>Variables<a class="headerlink" href="#variables" title="Permalink to this headline">¶</a></h2>
+
+            <div class="code-block-wrapper" translate="no">
+
+        <pre class="code-block"><code class="hljs typoscript">something = <span class="hljs-name">{$foo.bar}</span></code></pre>
+        <button class="code-block-copy" title="Copy to clipboard"><svg class="code-block-copy-icon" width="24" height="24"><title>Copy to clipboard</title><rect x="8" y="8" width="12" height="12" rx="2"></rect><path d="M16 8v-2a2 2 0 0 0 -2 -2h-8a2 2 0 0 0 -2 2v8a2 2 0 0 0 2 2h2"></path></svg></button>
+    </div>
+    </section>
+
+            <section class="section" id="comments">
+    <h2>Comments<a class="headerlink" href="#comments" title="Permalink to this headline">¶</a></h2>
+
+            <div class="code-block-wrapper" translate="no">
+
+        <pre class="code-block"><code class="hljs typoscript"><span class="hljs-comment"># Some comment</span>
+
+something = 42 <span class="hljs-comment"># Some comment</span>
+
+<span class="hljs-comment">// Another comment</span>
+
+something = 42 <span class="hljs-comment">// Another comment</span>
+
+<span class="hljs-comment">/* Some
+multiline
+comment */</span>
+
+something = 42 <span class="hljs-comment">/* some
+multiline
+comment */</span> and more</code></pre>
+        <button class="code-block-copy" title="Copy to clipboard"><svg class="code-block-copy-icon" width="24" height="24"><title>Copy to clipboard</title><rect x="8" y="8" width="12" height="12" rx="2"></rect><path d="M16 8v-2a2 2 0 0 0 -2 -2h-8a2 2 0 0 0 -2 2v8a2 2 0 0 0 2 2h2"></path></svg></button>
+    </div>
+    </section>
+
+            <section class="section" id="register">
+    <h2>Register<a class="headerlink" href="#register" title="Permalink to this headline">¶</a></h2>
+
+            <div class="code-block-wrapper" translate="no">
+
+        <pre class="code-block"><code class="hljs typoscript">dataWrap = &lt;ul class="<span class="hljs-name">{register:ulClass}</span>"&gt;|&lt;/ul&gt;</code></pre>
+        <button class="code-block-copy" title="Copy to clipboard"><svg class="code-block-copy-icon" width="24" height="24"><title>Copy to clipboard</title><rect x="8" y="8" width="12" height="12" rx="2"></rect><path d="M16 8v-2a2 2 0 0 0 -2 -2h-8a2 2 0 0 0 -2 2v8a2 2 0 0 0 2 2h2"></path></svg></button>
+    </div>
+    </section>
+
+            <section class="section" id="colors">
+    <h2>Colors<a class="headerlink" href="#colors" title="Permalink to this headline">¶</a></h2>
+
+            <div class="code-block-wrapper" translate="no">
+
+        <pre class="code-block"><code class="hljs typoscript">something = <span class="hljs-number">#123</span>
+
+something = <span class="hljs-number">#abcdef</span>
+
+something = 1234 <span class="hljs-comment"># not recognized as color</span></code></pre>
+        <button class="code-block-copy" title="Copy to clipboard"><svg class="code-block-copy-icon" width="24" height="24"><title>Copy to clipboard</title><rect x="8" y="8" width="12" height="12" rx="2"></rect><path d="M16 8v-2a2 2 0 0 0 -2 -2h-8a2 2 0 0 0 -2 2v8a2 2 0 0 0 2 2h2"></path></svg></button>
+    </div>
+    </section>
+
+            <section class="section" id="array-numbers">
+    <h2>Array numbers<a class="headerlink" href="#array-numbers" title="Permalink to this headline">¶</a></h2>
+
+            <div class="code-block-wrapper" translate="no">
+
+        <pre class="code-block"><code class="hljs typoscript"><span class="hljs-title">10</span> = <span class="hljs-keyword">TEXT</span>
+<span class="hljs-title">10</span>.value = something
+
+<span class="hljs-title">10</span> = <span class="hljs-keyword">TEXT</span>
+<span class="hljs-title">10</span> {
+    value = something
+}</code></pre>
+        <button class="code-block-copy" title="Copy to clipboard"><svg class="code-block-copy-icon" width="24" height="24"><title>Copy to clipboard</title><rect x="8" y="8" width="12" height="12" rx="2"></rect><path d="M16 8v-2a2 2 0 0 0 -2 -2h-8a2 2 0 0 0 -2 2v8a2 2 0 0 0 2 2h2"></path></svg></button>
+    </div>
+    </section>
+
+            <section class="section" id="keywords">
+    <h2>Keywords<a class="headerlink" href="#keywords" title="Permalink to this headline">¶</a></h2>
+
+            <div class="code-block-wrapper" translate="no">
+
+        <pre class="code-block"><code class="hljs typoscript"><span class="hljs-title">10</span> = <span class="hljs-keyword">TEXT</span>
+
+<span class="hljs-title">10</span> = <span class="hljs-keyword">GIFBUILDER</span>
+
+<span class="hljs-title">10</span> = <span class="hljs-keyword">TMENU</span>
+
+<span class="hljs-title">10</span> = <span class="hljs-keyword">NO</span></code></pre>
+        <button class="code-block-copy" title="Copy to clipboard"><svg class="code-block-copy-icon" width="24" height="24"><title>Copy to clipboard</title><rect x="8" y="8" width="12" height="12" rx="2"></rect><path d="M16 8v-2a2 2 0 0 0 -2 -2h-8a2 2 0 0 0 -2 2v8a2 2 0 0 0 2 2h2"></path></svg></button>
+    </div>
+    </section>
+
+    </section>
+
+<!-- content end -->

--- a/tests/Integration/tests/code-block/with-language-typoscript/input/index.rst
+++ b/tests/Integration/tests/code-block/with-language-typoscript/input/index.rst
@@ -1,0 +1,118 @@
+==========================
+With language "typoscript"
+==========================
+
+Imports
+=======
+
+..  code-block:: typoscript
+
+    @import 'EXT:myproject/Configuration/TypoScript/*.typoscript'
+    @import './userIsLoggedIn.typoscript'
+    @import "./subDirectory/*.setup.typoscript"
+
+    <INCLUDE_TYPOSCRIPT: source="FILE:EXT:my_extension/Configuration/TypoScript/myMenu.typoscript">
+    <INCLUDE_TYPOSCRIPT: source="DIR:fileadmin/templates/" extensions="typoscript">
+    <INCLUDE_TYPOSCRIPT: source="FILE:EXT:my_extension/Configuration/TypoScript/user.typoscript" condition="[frontend.user.isLoggedIn]">
+
+
+Conditions
+==========
+
+..  code-block:: typoscript
+
+    [date("j") == 9]
+        # ...
+    [END]
+
+    [date("j") == {$foo.bar}]
+        # ...
+    [ELSE]
+        # ...
+    [GLOBAL]
+
+
+Quoting of SQL identifiers
+==========================
+
+..  code-block:: typoscript
+
+    select.where = ({#title} LIKE {#%SOMETHING%} AND NOT {#doktype})
+
+
+Variables
+=========
+
+..  code-block:: typoscript
+
+    something = {$foo.bar}
+
+
+Comments
+========
+
+..  code-block:: typoscript
+
+    # Some comment
+
+    something = 42 # Some comment
+
+    // Another comment
+
+    something = 42 // Another comment
+
+    /* Some
+    multiline
+    comment */
+
+    something = 42 /* some
+    multiline
+    comment */ and more
+
+
+Register
+========
+
+..  code-block:: typoscript
+
+    dataWrap = <ul class="{register:ulClass}">|</ul>
+
+
+Colors
+======
+
+..  code-block:: typoscript
+
+    something = #123
+
+    something = #abcdef
+
+    something = 1234 # not recognized as color
+
+
+Array numbers
+=============
+
+..  code-block:: typoscript
+
+    10 = TEXT
+    10.value = something
+
+    10 = TEXT
+    10 {
+        value = something
+    }
+
+
+Keywords
+========
+
+..  code-block:: typoscript
+
+    10 = TEXT
+
+    10 = GIFBUILDER
+
+    10 = TMENU
+
+    10 = NO


### PR DESCRIPTION
- Remove number recognition as it has no real value
- Add missing keywords
- Enhance path recognition
- Handle constants (`{$foo.bar}`)
- Distinct between RGB color and comments (`#000` and `#000000`)
- Distinct between SQL quotes and comments ('#fieldname')
- Add tests