### PR TITLE
[FEATURE] Automatic interlinks to Core manuals

### DIFF
--- a/Documentation/Developer/Index.rst
+++ b/Documentation/Developer/Index.rst
@@ -91,6 +91,7 @@ and the GitHub pipelines, while internally only using :file:`Makefile` syntax.
     Building
     Contributing
     ThemeCustomization
+    InterlinkInventories
 
 
 ..  _phpDocumentor/guides: https://github.com/phpDocumentor/guides

--- a/Documentation/Developer/InterlinkInventories.rst
+++ b/Documentation/Developer/InterlinkInventories.rst
@@ -1,0 +1,102 @@
+..  include:: /Includes.rst.txt
+
+..  _InterlinkRepositories:
+
+=====================
+Interlink Inventories
+=====================
+
+Sections in other manuals than the current one can be linked during rendering
+by prefixing an anchor link or page link with the name of the manual.
+By using suffixes the version of the manual to be linked can be
+specified:
+
+..  code-block:: rst
+
+    *   :ref:`TYPO3 Explained, preferred version <t3coreapi:start>`
+    *   :ref:`TYPO3 Explained, main version (development) <t3coreapi_dev:start>`
+    *   :ref:`TYPO3 Explained, stable version (for example 12.4) <t3coreapi_stable:start>`
+    *   :ref:`TYPO3 Explained, old stable version (for example 11.5) <t3coreapi_oldstable:start>`
+
+This would output:
+
+*   :ref:`TYPO3 Explained, preferred version <t3coreapi:start>`
+*   :ref:`TYPO3 Explained, main version (development) <t3coreapi_dev:start>`
+*   :ref:`TYPO3 Explained, stable version (for example 12.4) <t3coreapi_stable:start>`
+*   :ref:`TYPO3 Explained, old stable version (for example 11.5) <t3coreapi_oldstable:start>`
+
+The preferred version can be set in the guides.xml to `dev`, `stable`,
+`oldstable` or a specific minor version, for example `8.7`.
+
+..  code-block:: xml
+    :caption: Documentation/guides.xml
+
+    <?xml version="1.0" encoding="UTF-8" ?>
+    <guides
+        xmlns="https://www.phpdoc.org/guides"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://www.phpdoc.org/guides vendor/phpdocumentor/guides-cli/resources/schema/guides.xsd"
+    >
+        <project title="Render guides"/>
+        <extension
+            class="\T3Docs\Typo3DocsTheme\DependencyInjection\Typo3DocsThemeExtension"
+            typo3-core-preferred="stable"
+        />
+    </guides>
+
+or
+
+..  code-block:: xml
+    :caption: Documentation/guides.xml, excerpt
+
+    <extension
+        class="\T3Docs\Typo3DocsTheme\DependencyInjection\Typo3DocsThemeExtension"
+        typo3-core-preferred="8.7"
+
+It is not necessary anymore to list each of the standard inventories in the
+guides.xml anymore. If desired you can override or redefine standard interlink
+inventories or define new ones:
+
+..  code-block:: xml
+    :caption: Documentation/guides.xml
+
+    <?xml version="1.0" encoding="UTF-8" ?>
+    <guides
+        xmlns="https://www.phpdoc.org/guides"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://www.phpdoc.org/guides vendor/phpdocumentor/guides-cli/resources/schema/guides.xsd"
+    >
+        <project title="Render guides"/>
+        <extension
+            class="\T3Docs\Typo3DocsTheme\DependencyInjection\Typo3DocsThemeExtension"
+            typo3-core-preferred="stable"
+        />
+        <!-- explicitly link to version 8.7 of TYPO3 Explained -->
+        <inventory id="t3coreapi_v8" url="https://docs.typo3.org/m/typo3/reference-coreapi/8.7/en-us/"/>
+        <!-- ext_sys_note and ext_sys_note_stable should always link to main-->
+        <inventory id="ext_sys_note" url="https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/"/>
+        <inventory id="ext_sys_note_stable" url="https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/"/>
+    </guides>
+
+The following links:
+
+..  code-block:: rst
+
+    *   :ref:`TYPO3 Explained, always version 8.7 <t3coreapi_v8:start>`
+    *   :ref:`Sys note always goes to main <ext_sys_note:start>`
+    *   :ref:`Sys note always goes to main <ext_sys_note_stable:start>`
+
+*   :ref:`TYPO3 Explained, always version 8.7 <t3coreapi_v8:start>`
+*   :ref:`Sys note always goes to main <ext_sys_note:start>`
+*   :ref:`Sys note always goes to main <ext_sys_note_stable:start>`
+
+
+Adding a new TYPO3 version or manual
+====================================
+
+In the event of a change in long-term support, adjustments to the corresponding
+TYPO3 versions can be made directly in the theme within the enum
+:php:`\T3Docs\Typo3DocsTheme\Inventory\Typo3VersionMapping`.
+
+The default manuals to be supported can be managed in enum
+:php:`\T3Docs\Typo3DocsTheme\Inventory\DefaultInventories`.

--- a/Documentation/guides.xml
+++ b/Documentation/guides.xml
@@ -10,6 +10,12 @@
         edit-on-github="TYPO3-Documentation/render-guides"
         edit-on-github-branch="main"
         interlink-shortcode="t3docsRenderGuides"
+        typo3-core-preferred="stable"
     />
-    <inventory id="h2document" url="https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/" />
+    <!-- The following inventories are used as examples in the chapter `Developer/InterlinkInventories` -->
+    <!-- explicitly link to version 8.7 of TYPO3 Explained -->
+    <inventory id="t3coreapi_v8" url="https://docs.typo3.org/m/typo3/reference-coreapi/8.7/en-us/"/>
+    <!-- ext_sys_note and ext_sys_note_stable should always link to main-->
+    <inventory id="ext_sys_note" url="https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/"/>
+    <inventory id="ext_sys_note_stable" url="https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/"/>
 </guides>

--- a/packages/typo3-docs-theme/resources/config/typo3-docs-theme.php
+++ b/packages/typo3-docs-theme/resources/config/typo3-docs-theme.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Brotkrueml\TwigCodeHighlight\Extension as CodeHighlight;
 use phpDocumentor\Guides\Event\PostRenderProcess;
+use phpDocumentor\Guides\Interlink\InventoryRepository;
 use phpDocumentor\Guides\RestructuredText\Directives\BaseDirective;
 use phpDocumentor\Guides\RestructuredText\Directives\SubDirective;
 use phpDocumentor\Guides\RestructuredText\Parser\Productions\DirectiveContentRule;
@@ -14,9 +15,11 @@ use T3Docs\Typo3DocsTheme\Directives\GroupTabDirective;
 
 use T3Docs\Typo3DocsTheme\Directives\T3FieldListTableDirective;
 use T3Docs\Typo3DocsTheme\Directives\YoutubeDirective;
+use T3Docs\Typo3DocsTheme\Inventory\Typo3InventoryRepository;
 use T3Docs\Typo3DocsTheme\TextRoles\IssueReferenceTextRole;
 use T3Docs\Typo3DocsTheme\Twig\TwigExtension;
 
+use function Symfony\Component\DependencyInjection\Loader\Configurator\param;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 
 return static function (ContainerConfigurator $container): void {

--- a/packages/typo3-docs-theme/src/Inventory/DefaultInventories.php
+++ b/packages/typo3-docs-theme/src/Inventory/DefaultInventories.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace T3Docs\Typo3DocsTheme\Inventory;
+
+enum DefaultInventories: string
+{
+    // Changelog, it is only deployed to main
+    case ext_core = 'https://docs.typo3.org/c/typo3/cms-core/main/en-us/';
+
+    // Core Manuals
+    case t3coreapi = 'https://docs.typo3.org/m/typo3/reference-coreapi/{typo3_version}/en-us/';
+    case t3tca = 'https://docs.typo3.org/m/typo3/reference-tca/{typo3_version}/en-us/';
+    case t3tsconfig = 'https://docs.typo3.org/m/typo3/reference-tsconfig/{typo3_version}/en-us/';
+    case t3tsref = 'https://docs.typo3.org/m/typo3/reference-typoscript/{typo3_version}/en-us/';
+    case t3viewhelper = 'https://docs.typo3.org/other/typo3/view-helper-reference/{typo3_version}/en-us/';
+
+    // Official Core Tutorials and Guides
+    case t3editors = 'https://docs.typo3.org/m/typo3/tutorial-editors/{typo3_version}/en-us/';
+    case t3install = 'https://docs.typo3.org/m/typo3/guide-installation/{typo3_version}/en-us/';
+    case t3sitepackage = 'https://docs.typo3.org/m/typo3/tutorial-sitepackage/{typo3_version}/en-us/';
+    case t3start = 'https://docs.typo3.org/m/typo3/tutorial-getting-started/{typo3_version}/en-us/';
+    case t3translate = 'https://docs.typo3.org/m/typo3/guide-frontendlocalization/{typo3_version}/en-us/';
+    case t3ts45 = 'https://docs.typo3.org/m/typo3/tutorial-typoscript-in-45-minutes/{typo3_version}/en-us/';
+
+    // Team Guides, they are commonly not versioned
+    case h2document = 'https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/';
+    case t3content = 'https://docs.typo3.org/m/typo3/guide-contentandmarketing/main/en-us/';
+    case t3contribute = 'https://docs.typo3.org/m/typo3/guide-contributionworkflow/main/en-us/';
+
+    // System Extensions
+    case ext_adminpanel = 'https://docs.typo3.org/c/typo3/cms-adminpanel/{typo3_version}/en-us/';
+    case ext_dashboard = 'https://docs.typo3.org/c/typo3/cms-dashboard/{typo3_version}/en-us/';
+    case ext_felogin = 'https://docs.typo3.org/c/typo3/cms-felogin/{typo3_version}/en-us/';
+    case ext_form = 'https://docs.typo3.org/c/typo3/cms-form/{typo3_version}/en-us/';
+    case ext_fsc = 'https://docs.typo3.org/c/typo3/cms-fluid-styled-content/{typo3_version}/en-us/';
+    case ext_impexp = 'https://docs.typo3.org/c/typo3/cms-impexp/{typo3_version}/en-us/';
+    case ext_indexed_search = 'https://docs.typo3.org/c/typo3/cms-indexed-search/{typo3_version}/en-us/';
+    case ext_linkvalidator = 'https://docs.typo3.org/c/typo3/cms-linkvalidator/{typo3_version}/en-us/';
+    case ext_lowlevel = 'https://docs.typo3.org/c/typo3/cms-lowlevel/{typo3_version}/en-us/';
+    case ext_reactions = 'https://docs.typo3.org/c/typo3/cms-reactions/{typo3_version}/en-us/';
+    case ext_reports = 'https://docs.typo3.org/c/typo3/cms-reports/{typo3_version}/en-us/';
+    case ext_rte_ckeditor = 'https://docs.typo3.org/c/typo3/cms-rte-ckeditor/{typo3_version}/en-us/';
+    case ext_scheduler = 'https://docs.typo3.org/c/typo3/cms-scheduler/{typo3_version}/en-us/';
+    case ext_seo = 'https://docs.typo3.org/c/typo3/cms-seo/{typo3_version}/en-us/';
+    case ext_sys_note = 'https://docs.typo3.org/c/typo3/cms-sys-note/{typo3_version}/en-us/';
+    case ext_workspaces = 'https://docs.typo3.org/c/typo3/cms-workspaces/{typo3_version}/en-us/';
+
+    // Other
+    case fluid = 'https://docs.typo3.org/other/typo3fluid/fluid/{typo3_version}/en-us/';
+
+}

--- a/packages/typo3-docs-theme/src/Inventory/Typo3InventoryRepository.php
+++ b/packages/typo3-docs-theme/src/Inventory/Typo3InventoryRepository.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace T3Docs\Typo3DocsTheme\Inventory;
+
+use phpDocumentor\Guides\Interlink\Inventory;
+use phpDocumentor\Guides\Interlink\InventoryLoader;
+use phpDocumentor\Guides\Interlink\InventoryRepository;
+use phpDocumentor\Guides\ReferenceResolvers\AnchorReducer;
+use RuntimeException;
+use T3Docs\Typo3DocsTheme\Settings\Typo3DocsThemeSettings;
+
+final class Typo3InventoryRepository implements InventoryRepository
+{
+    /** @var array<string, Inventory>  */
+    private array $inventories = [];
+
+    /** @param array<int, array<string, string>> $inventoryConfigs */
+    public function __construct(
+        private readonly AnchorReducer $anchorReducer,
+        private readonly InventoryLoader $inventoryLoader,
+        Typo3DocsThemeSettings $settings,
+        array $inventoryConfigs,
+    ) {
+        foreach ($inventoryConfigs as $inventory) {
+            $this->inventories[$this->anchorReducer->reduceAnchor($inventory['id'])] = new Inventory($inventory['url']);
+        }
+        foreach (DefaultInventories::cases() as $defaultInventory) {
+            $id = $this->anchorReducer->reduceAnchor($defaultInventory->name);
+            $url = $defaultInventory->value;
+            if (!str_contains($url, '{typo3_version}')) {
+                $this->addInventory($id, $url, false);
+                continue;
+            }
+            foreach (Typo3VersionMapping::cases() as $versionMapping) {
+                $mappedUrl = str_replace('{typo3_version}', $versionMapping->getVersion(), $url);
+                $this->addInventory($id . '-' . $versionMapping->value, $mappedUrl, false);
+            }
+            if ($settings->hasSettings('typo3_core_preferred')) {
+                $preferred = $settings->getSettings('typo3_core_preferred');
+                $preferred = Typo3VersionMapping::tryFrom($preferred)?->getVersion() ?? $preferred;
+            } else {
+                $preferred = Typo3VersionMapping::getDefault()->getVersion();
+            }
+            $this->addInventory($id, str_replace('{typo3_version}', $preferred, $url), false);
+        }
+    }
+
+    private function addInventory(string $key, string $url, bool $overrideExisting): void
+    {
+        $reducedKey = $this->anchorReducer->reduceAnchor($key);
+        if ($overrideExisting || !isset($this->inventories[$reducedKey])) {
+            $this->inventories[$reducedKey] = new Inventory($url);
+        }
+    }
+
+    public function hasInventory(string $key): bool
+    {
+        $reducedKey = $this->anchorReducer->reduceAnchor($key);
+
+        return isset($this->inventories[$reducedKey]);
+    }
+
+    public function getInventory(string $key): Inventory
+    {
+        $reducedKey = $this->anchorReducer->reduceAnchor($key);
+        if (!$this->hasInventory($reducedKey)) {
+            throw new RuntimeException('Inventory with key ' . $reducedKey . ' not found. ', 1_671_398_986);
+        }
+
+        $this->inventoryLoader->loadInventory($this->inventories[$reducedKey]);
+
+        return $this->inventories[$reducedKey];
+    }
+}

--- a/packages/typo3-docs-theme/src/Inventory/Typo3VersionMapping.php
+++ b/packages/typo3-docs-theme/src/Inventory/Typo3VersionMapping.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace T3Docs\Typo3DocsTheme\Inventory;
+
+enum Typo3VersionMapping: string
+{
+    case Dev = 'dev';
+    case Stable = 'stable';
+    case OldStable = 'oldstable';
+
+    public function getVersion(): string
+    {
+        return match ($this) {
+            Typo3VersionMapping::Dev => 'main',
+            Typo3VersionMapping::Stable => '12.4',
+            Typo3VersionMapping::OldStable => '11.5',
+        };
+    }
+
+    public static function getDefault(): Typo3VersionMapping
+    {
+        return Typo3VersionMapping::Stable;
+    }
+}

--- a/packages/typo3-docs-theme/src/Settings/Typo3DocsThemeSettings.php
+++ b/packages/typo3-docs-theme/src/Settings/Typo3DocsThemeSettings.php
@@ -15,6 +15,7 @@ class Typo3DocsThemeSettings
     {
         return isset($this->settings[$key]);
     }
+
     public function getSettings(string $key, string $default = ''): string
     {
         if (!$this->hasSettings($key)) {

--- a/packages/typo3-docs-theme/tests/unit/Inventory/Typo3InventoryRepositoryTest.php
+++ b/packages/typo3-docs-theme/tests/unit/Inventory/Typo3InventoryRepositoryTest.php
@@ -1,0 +1,112 @@
+<?php
+
+use phpDocumentor\Guides\Interlink\InventoryLoader;
+use phpDocumentor\Guides\ReferenceResolvers\SluggerAnchorReducer;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use T3Docs\Typo3DocsTheme\Inventory\Typo3InventoryRepository;
+use T3Docs\Typo3DocsTheme\Settings\Typo3DocsThemeSettings;
+
+final class Typo3InventoryRepositoryTest extends TestCase
+{
+    private Typo3InventoryRepository $subject;
+    private Typo3DocsThemeSettings $settings;
+
+    /** @var array<int, array<string, string>> $inventoryConfigs */
+    private array $inventoryConfigs;
+
+    protected function setUp(): void
+    {
+        $this->settings = new Typo3DocsThemeSettings(
+            [
+            ]
+        );
+        $this->inventoryConfigs = [
+        ];
+        $this->subject = $this->getInventoryRepository($this->settings, $this->inventoryConfigs);
+    }
+
+    #[Test]
+    #[DataProvider('providerForInventoryKeysWithVersions')]
+    public function versionInventoriesAreAdded(string $inventoryKey, bool $expected): void
+    {
+        self::assertEquals($this->subject->hasInventory($inventoryKey), $expected);
+    }
+    public static function providerForInventoryKeysWithVersions(): \Generator
+    {
+        yield "preferred" => [
+            'inventoryKey' => 't3coreapi',
+            'expected' => true,
+        ];
+        yield "stable" => [
+          'inventoryKey' => 't3coreapi-stable',
+            'expected' => true,
+        ];
+        yield "oldstable" => [
+            'inventoryKey' => 't3coreapi-oldstable',
+            'expected' => true,
+        ];
+        yield "dev" => [
+            'inventoryKey' => 't3coreapi-dev',
+            'expected' => true,
+        ];
+        yield "whatever" => [
+            'inventoryKey' => 't3coreapi-whatever',
+            'expected' => false,
+        ];
+        yield "preferred-non-versioned" => [
+            'inventoryKey' => 'h2document',
+            'expected' => true,
+        ];
+        yield "stable-non-versioned" => [
+            'inventoryKey' => 'h2document-stable',
+            'expected' => false,
+        ];
+        yield "whatever-non-versioned" => [
+            'inventoryKey' => 't3coreapi-whatever',
+            'expected' => false,
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('providerForInventoryKeysWithVersionsAndUrl')]
+    public function versionInventoryCreatesVersionedUrl(string $inventoryKey, string $expected): void
+    {
+        self::assertEquals($this->subject->getInventory($inventoryKey)->getBaseUrl(), $expected);
+    }
+
+    public static function providerForInventoryKeysWithVersionsAndUrl(): \Generator
+    {
+        yield "preferred" => [
+            'inventoryKey' => 't3coreapi',
+            'expected' => "https://docs.typo3.org/m/typo3/reference-coreapi/12.4/en-us/",
+        ];
+        yield "stable" => [
+            'inventoryKey' => 't3coreapi-stable',
+            'expected' => "https://docs.typo3.org/m/typo3/reference-coreapi/12.4/en-us/",
+        ];
+        yield "oldstable" => [
+            'inventoryKey' => 't3coreapi-oldstable',
+            'expected' => "https://docs.typo3.org/m/typo3/reference-coreapi/11.5/en-us/",
+        ];
+        yield "dev" => [
+            'inventoryKey' => 't3coreapi-dev',
+            'expected' => "https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/",
+        ];
+        yield "preferred-non-versioned" => [
+            'inventoryKey' => 'h2document',
+            'expected' => "https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/",
+        ];
+    }
+
+    private function getInventoryRepository(Typo3DocsThemeSettings $settings, array $inventoryConfigs)
+    {
+        return new Typo3InventoryRepository(
+            new SluggerAnchorReducer(),
+            $this->createMock(InventoryLoader::class),
+            $settings,
+            $inventoryConfigs,
+        );
+    }
+}

--- a/packages/typo3-guides-extension/resources/config/typo3-guides.php
+++ b/packages/typo3-guides-extension/resources/config/typo3-guides.php
@@ -3,12 +3,17 @@
 declare(strict_types=1);
 
 use phpDocumentor\Guides\Cli\Command\Run;
+use phpDocumentor\Guides\Interlink\InventoryRepository;
 use phpDocumentor\Guides\Renderer\UrlGenerator\UrlGeneratorInterface;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use T3Docs\GuidesExtension\Command\RunDecorator;
 
+use T3Docs\Typo3DocsTheme\Inventory\Typo3InventoryRepository;
+
 use T3Docs\GuidesExtension\Renderer\UrlGenerator\RenderOutputUrlGenerator;
 use T3Docs\GuidesExtension\Renderer\UrlGenerator\SingleHtmlUrlGenerator;
+
+use function Symfony\Component\DependencyInjection\Loader\Configurator\param;
 
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 
@@ -30,6 +35,9 @@ return static function (ContainerConfigurator $container): void {
         )
         ->set(\T3Docs\GuidesExtension\Renderer\NodeRenderer\SinglePageDocumentRenderer::class)
         ->tag('phpdoc.guides.noderenderer.singlepage')
+
+        ->set(InventoryRepository::class, Typo3InventoryRepository::class)
+        ->arg('$inventoryConfigs', param('phpdoc.guides.inventories'))
 
         ->set(SingleHtmlUrlGenerator::class)
         ->set(UrlGeneratorInterface::class, RenderOutputUrlGenerator::class)


### PR DESCRIPTION
I will deal with third party extensions in a follow up

Now all common core manuals are predefined. You can call to them without prefix which gives you the preferred version

t3coreapi

If no preferred version is set, stable is used.

You can call also with different prefixes

t3coreapi_dev
t3coreapi_stable
t3coreapi_oldstable
t3coreapi_latest

What versions these go to is defined in Typo3DocsThemeSettings

The prefixes work for any manual that supports versions.

As Interlink inventories are only querried the first time they are used unused inventories, even in a large number should not influence performance notably.

If a version did not exist yet, for example sys_note in version oldstable the normal warning like for a miss configured manual inventory is displayed and the link not expressed.