### PR TITLE
[CI] Let dependabot create PRs for updating dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "16:00"
+      timezone: "Europe/Berlin"
+    allow:
+      - dependency-type: "development"
+    versioning-strategy: "increase"
+    commit-message:
+      prefix: "[TASK]"
+    labels:
+      - "dependencies"
+      - "composer"
+
+  - package-ecosystem: "npm"
+    directory: "/packages/typo3-docs-theme/"
+    schedule:
+      interval: "daily"
+      time: "16:00"
+      timezone: "Europe/Berlin"
+    versioning-strategy: "increase"
+    commit-message:
+      prefix: "[TASK]"
+    labels:
+      - "dependencies"
+      - "npm"


### PR DESCRIPTION
Composer and npm updates can be created automatically using dependabot. Updates are checked on a daily basis at 16:00. For each pull request created by dependabot the labels "dependencies", and "composer" (for a Composer-related update) and "npm" for a (npm-related update) are added.

Development branched are also considered for Composer-related updates for the time being.

Updates of requirements can also be done manually at any time.