### PR TITLE
[BUGFIX] Override link handling

### DIFF
--- a/packages/typo3-guides-extension/resources/config/typo3-guides.php
+++ b/packages/typo3-guides-extension/resources/config/typo3-guides.php
@@ -3,8 +3,12 @@
 declare(strict_types=1);
 
 use phpDocumentor\Guides\Cli\Command\Run;
+use phpDocumentor\Guides\Renderer\UrlGenerator\UrlGeneratorInterface;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use T3Docs\GuidesExtension\Command\RunDecorator;
+
+use T3Docs\GuidesExtension\Renderer\UrlGenerator\RenderOutputUrlGenerator;
+use T3Docs\GuidesExtension\Renderer\UrlGenerator\SingleHtmlUrlGenerator;
 
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 
@@ -26,6 +30,9 @@ return static function (ContainerConfigurator $container): void {
         )
         ->set(\T3Docs\GuidesExtension\Renderer\NodeRenderer\SinglePageDocumentRenderer::class)
         ->tag('phpdoc.guides.noderenderer.singlepage')
+
+        ->set(SingleHtmlUrlGenerator::class)
+        ->set(UrlGeneratorInterface::class, RenderOutputUrlGenerator::class)
 
         ->set(\phpDocumentor\Guides\NodeRenderers\DelegatingNodeRenderer::class)
         ->call('setNodeRendererFactory', [service('phpdoc.guides.noderenderer.factory.html')])

--- a/packages/typo3-guides-extension/src/Renderer/UrlGenerator/RenderOutputUrlGenerator.php
+++ b/packages/typo3-guides-extension/src/Renderer/UrlGenerator/RenderOutputUrlGenerator.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link https://phpdoc.org
+ */
+
+namespace T3Docs\GuidesExtension\Renderer\UrlGenerator;
+
+use phpDocumentor\Guides\ReferenceResolvers\DocumentNameResolverInterface;
+use phpDocumentor\Guides\RenderContext;
+use phpDocumentor\Guides\Renderer\UrlGenerator\AbsoluteUrlGenerator;
+use phpDocumentor\Guides\Renderer\UrlGenerator\AbstractUrlGenerator;
+use phpDocumentor\Guides\Renderer\UrlGenerator\RelativeUrlGenerator;
+use phpDocumentor\Guides\Settings\SettingsManager;
+
+final class RenderOutputUrlGenerator extends AbstractUrlGenerator
+{
+    public function __construct(
+        private readonly RelativeUrlGenerator $relativeUrlGenerator,
+        private readonly SingleHtmlUrlGenerator $singleHtmlUrlGenerator,
+        DocumentNameResolverInterface $documentNameResolver,
+    ) {
+        parent::__construct($documentNameResolver);
+    }
+
+    public function generateInternalPathFromRelativeUrl(
+        RenderContext $renderContext,
+        string $canonicalUrl,
+    ): string {
+        if ($renderContext->getOutputFormat() === 'singlepage') {
+            return $this->singleHtmlUrlGenerator->generateInternalPathFromRelativeUrl($renderContext, $canonicalUrl);
+        }
+
+        return $this->relativeUrlGenerator->generateInternalPathFromRelativeUrl($renderContext, $canonicalUrl);
+    }
+}

--- a/packages/typo3-guides-extension/src/Renderer/UrlGenerator/SingleHtmlUrlGenerator.php
+++ b/packages/typo3-guides-extension/src/Renderer/UrlGenerator/SingleHtmlUrlGenerator.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link https://phpdoc.org
+ */
+
+namespace T3Docs\GuidesExtension\Renderer\UrlGenerator;
+
+use phpDocumentor\Guides\ReferenceResolvers\DocumentNameResolverInterface;
+use phpDocumentor\Guides\RenderContext;
+
+use phpDocumentor\Guides\Renderer\UrlGenerator\AbstractUrlGenerator;
+use phpDocumentor\Guides\Renderer\UrlGenerator\RelativeUrlGenerator;
+
+use function rtrim;
+
+final class SingleHtmlUrlGenerator extends AbstractUrlGenerator
+{
+    public function __construct(
+        private readonly RelativeUrlGenerator $relativeUrlGenerator,
+        DocumentNameResolverInterface $documentNameResolver,
+    ) {
+        parent::__construct($documentNameResolver);
+    }
+    public function generateInternalPathFromRelativeUrl(
+        RenderContext $renderContext,
+        string $canonicalUrl,
+    ): string {
+        $parsedUrl = parse_url($canonicalUrl);
+        $anchor = $parsedUrl['fragment'] ?? '';
+        $fileInfo = pathinfo($canonicalUrl);
+        $dirname = $fileInfo['dirname'] ?? '.';
+        if ($dirname === '.') {
+            // if no directory is set $fileInfo['dirname'] returns "."
+            $dirname = '';
+        } else {
+            $dirname = $dirname . '/';
+        }
+        $filename = $fileInfo['filename'] ?? '';
+        if ($renderContext->getProjectNode()->findDocumentEntry($dirname . $filename) === null) {
+            // this is not a link to a rendered document, therefore to an asset
+            return $this->relativeUrlGenerator->generateInternalPathFromRelativeUrl($renderContext, $canonicalUrl);
+        }
+        return '#' . $anchor;
+    }
+}

--- a/tests/Integration/tests-full/index/expected/index.html
+++ b/tests/Integration/tests-full/index/expected/index.html
@@ -14,9 +14,9 @@
     <meta content="2023-01-01T12:00:00+00:00" property="article:modified_time">
     <title>Document Title — Example Project 12.4 documentation</title>
 
-    <link href="/_resources/css/theme.css" rel="stylesheet">
+    <link href="_resources/css/theme.css" rel="stylesheet">
     <link href="https://docs.typo3.org/search/" rel="search" title="Search">
-                        <link href="/index.html" rel="top" title="Document Title"/>
+                        <link href="#" rel="top" title="Document Title"/>
         <!-- extrahead --><!-- /extrahead -->
     <!-- UNIVERSE BAR START -->
     <script src="https://typo3.azureedge.net/typo3infrastructure/universe/dist/webcomponents-loader.js"></script>
@@ -39,7 +39,7 @@
             <div class="page-header-inner">
                 <!-- pageheader -->
                 <a class="logo" href="https://docs.typo3.org/" title="TYPO3 Documentation">
-                    <img alt="TYPO3 Logo" class="logo-image" src="/_resources/img/typo3-logo.svg" width="484" height="130">
+                    <img alt="TYPO3 Logo" class="logo-image" src="_resources/img/typo3-logo.svg" width="484" height="130">
                 </a>
                 <!-- /pageheader -->
             </div>
@@ -89,7 +89,7 @@
                 <li aria-current="page"  class="breadcrumb-item  active">Document Title</li>
         </ol>
 
-        <div class="breadcrumb-additions">    <a class="btn btn-sm btn-light" href="/_sources/index.rst.txt" rel="nofollow noopener" target="_blank">
+        <div class="breadcrumb-additions">    <a class="btn btn-sm btn-light" href="_sources/index.rst.txt" rel="nofollow noopener" target="_blank">
         <span class="btn-icon"><span class="fas fa-code"></span></span>
         <span class="btn-text">View source</span>
     </a>
@@ -209,10 +209,10 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         HAS_SOURCE: true
     };
 </script>
-<script src="/_resources/js/jquery.min.js"></script>
-<script src="/_resources/js/popper.min.js"></script>
-<script src="/_resources/js/bootstrap.min.js"></script>
-<script src="/_resources/js/theme.min.js"></script>
+<script src="_resources/js/jquery.min.js"></script>
+<script src="_resources/js/popper.min.js"></script>
+<script src="_resources/js/bootstrap.min.js"></script>
+<script src="_resources/js/theme.min.js"></script>
 
 <script id="R9wBKTwzv" src="https://app.usercentrics.eu/latest/main.js"></script>
 <script data-usercentrics="Matomo" src="/js/piwik.js" type="text/plain"></script>

--- a/tests/Integration/tests-full/next-prev/expected/index.html
+++ b/tests/Integration/tests-full/next-prev/expected/index.html
@@ -14,10 +14,10 @@
     <meta content="2023-01-01T12:00:00+00:00" property="article:modified_time">
     <title>Document Title documentation</title>
 
-    <link href="/_resources/css/theme.css" rel="stylesheet">
+    <link href="_resources/css/theme.css" rel="stylesheet">
     <link href="https://docs.typo3.org/search/" rel="search" title="Search">
-                        <link href="/page.html" rel="next" title="Page"/>
-            <link href="/index.html" rel="top" title="Document Title"/>
+                        <link href="page.html" rel="next" title="Page"/>
+            <link href="#" rel="top" title="Document Title"/>
         <!-- extrahead --><!-- /extrahead -->
     <!-- UNIVERSE BAR START -->
     <script src="https://typo3.azureedge.net/typo3infrastructure/universe/dist/webcomponents-loader.js"></script>
@@ -40,7 +40,7 @@
             <div class="page-header-inner">
                 <!-- pageheader -->
                 <a class="logo" href="https://docs.typo3.org/" title="TYPO3 Documentation">
-                    <img alt="TYPO3 Logo" class="logo-image" src="/_resources/img/typo3-logo.svg" width="484" height="130">
+                    <img alt="TYPO3 Logo" class="logo-image" src="_resources/img/typo3-logo.svg" width="484" height="130">
                 </a>
                 <!-- /pageheader -->
             </div>
@@ -82,7 +82,7 @@
                 <li aria-current="page"  class="breadcrumb-item  active">Document Title</li>
         </ol>
 
-        <div class="breadcrumb-additions">    <a class="btn btn-sm btn-light" href="/_sources/index.rst.txt" rel="nofollow noopener" target="_blank">
+        <div class="breadcrumb-additions">    <a class="btn btn-sm btn-light" href="_sources/index.rst.txt" rel="nofollow noopener" target="_blank">
         <span class="btn-icon"><span class="fas fa-code"></span></span>
         <span class="btn-text">View source</span>
     </a>
@@ -108,7 +108,7 @@
                         
             <nav aria-label="Page navigation">
             <ul class="pagination justify-content-center"><li class="page-item">
-                            <a class="page-link" href="/page.html"
+                            <a class="page-link" href="page.html"
                                title="Accesskey Alt(+Shift)+n">
                                 Next
                             </a>
@@ -206,10 +206,10 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         HAS_SOURCE: true
     };
 </script>
-<script src="/_resources/js/jquery.min.js"></script>
-<script src="/_resources/js/popper.min.js"></script>
-<script src="/_resources/js/bootstrap.min.js"></script>
-<script src="/_resources/js/theme.min.js"></script>
+<script src="_resources/js/jquery.min.js"></script>
+<script src="_resources/js/popper.min.js"></script>
+<script src="_resources/js/bootstrap.min.js"></script>
+<script src="_resources/js/theme.min.js"></script>
 
 <script id="R9wBKTwzv" src="https://app.usercentrics.eu/latest/main.js"></script>
 <script data-usercentrics="Matomo" src="/js/piwik.js" type="text/plain"></script>

--- a/tests/Integration/tests-full/next-prev/expected/page.html
+++ b/tests/Integration/tests-full/next-prev/expected/page.html
@@ -14,11 +14,11 @@
     <meta content="2023-01-01T12:00:00+00:00" property="article:modified_time">
     <title>Page documentation</title>
 
-    <link href="/_resources/css/theme.css" rel="stylesheet">
+    <link href="_resources/css/theme.css" rel="stylesheet">
     <link href="https://docs.typo3.org/search/" rel="search" title="Search">
-                        <link href="/index.html" rel="prev" title="Document Title"/>
-            <link href="/yetAnotherPage.html" rel="next" title="Another Page"/>
-            <link href="/index.html" rel="top" title="Document Title"/>
+                        <link href="index.html" rel="prev" title="Document Title"/>
+            <link href="yetAnotherPage.html" rel="next" title="Another Page"/>
+            <link href="index.html" rel="top" title="Document Title"/>
         <!-- extrahead --><!-- /extrahead -->
     <!-- UNIVERSE BAR START -->
     <script src="https://typo3.azureedge.net/typo3infrastructure/universe/dist/webcomponents-loader.js"></script>
@@ -41,7 +41,7 @@
             <div class="page-header-inner">
                 <!-- pageheader -->
                 <a class="logo" href="https://docs.typo3.org/" title="TYPO3 Documentation">
-                    <img alt="TYPO3 Logo" class="logo-image" src="/_resources/img/typo3-logo.svg" width="484" height="130">
+                    <img alt="TYPO3 Logo" class="logo-image" src="_resources/img/typo3-logo.svg" width="484" height="130">
                 </a>
                 <!-- /pageheader -->
             </div>
@@ -80,11 +80,11 @@
                 <div class="rst-content">                        <nav aria-label="breadcrumbs navigation" class="breadcrumb-bar" role="navigation">
         
 <ol class="breadcrumb">
-    <li class="breadcrumb-item"><a href="/index.html">Document Title</a></li>
+    <li class="breadcrumb-item"><a href="index.html">Document Title</a></li>
                     <li aria-current="page"  class="breadcrumb-item  active">Page</li>
         </ol>
 
-        <div class="breadcrumb-additions">    <a class="btn btn-sm btn-light" href="/_sources/page.rst.txt" rel="nofollow noopener" target="_blank">
+        <div class="breadcrumb-additions">    <a class="btn btn-sm btn-light" href="_sources/page.rst.txt" rel="nofollow noopener" target="_blank">
         <span class="btn-icon"><span class="fas fa-code"></span></span>
         <span class="btn-text">View source</span>
     </a>
@@ -110,13 +110,13 @@
                         
             <nav aria-label="Page navigation">
             <ul class="pagination justify-content-center"><li class="page-item">
-                            <a class="page-link" href="/index.html"
+                            <a class="page-link" href="index.html"
                                title="Accesskey Alt(+Shift)+p">
                                 Previous
                             </a>
                         </li>
                     <li class="page-item">
-                            <a class="page-link" href="/yetAnotherPage.html"
+                            <a class="page-link" href="yetAnotherPage.html"
                                title="Accesskey Alt(+Shift)+n">
                                 Next
                             </a>
@@ -214,10 +214,10 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         HAS_SOURCE: true
     };
 </script>
-<script src="/_resources/js/jquery.min.js"></script>
-<script src="/_resources/js/popper.min.js"></script>
-<script src="/_resources/js/bootstrap.min.js"></script>
-<script src="/_resources/js/theme.min.js"></script>
+<script src="_resources/js/jquery.min.js"></script>
+<script src="_resources/js/popper.min.js"></script>
+<script src="_resources/js/bootstrap.min.js"></script>
+<script src="_resources/js/theme.min.js"></script>
 
 <script id="R9wBKTwzv" src="https://app.usercentrics.eu/latest/main.js"></script>
 <script data-usercentrics="Matomo" src="/js/piwik.js" type="text/plain"></script>

--- a/tests/Integration/tests-full/next-prev/expected/yetAnotherPage.html
+++ b/tests/Integration/tests-full/next-prev/expected/yetAnotherPage.html
@@ -14,10 +14,10 @@
     <meta content="2023-01-01T12:00:00+00:00" property="article:modified_time">
     <title>Another Page documentation</title>
 
-    <link href="/_resources/css/theme.css" rel="stylesheet">
+    <link href="_resources/css/theme.css" rel="stylesheet">
     <link href="https://docs.typo3.org/search/" rel="search" title="Search">
-                        <link href="/page.html" rel="prev" title="Page"/>
-            <link href="/index.html" rel="top" title="Document Title"/>
+                        <link href="page.html" rel="prev" title="Page"/>
+            <link href="index.html" rel="top" title="Document Title"/>
         <!-- extrahead --><!-- /extrahead -->
     <!-- UNIVERSE BAR START -->
     <script src="https://typo3.azureedge.net/typo3infrastructure/universe/dist/webcomponents-loader.js"></script>
@@ -40,7 +40,7 @@
             <div class="page-header-inner">
                 <!-- pageheader -->
                 <a class="logo" href="https://docs.typo3.org/" title="TYPO3 Documentation">
-                    <img alt="TYPO3 Logo" class="logo-image" src="/_resources/img/typo3-logo.svg" width="484" height="130">
+                    <img alt="TYPO3 Logo" class="logo-image" src="_resources/img/typo3-logo.svg" width="484" height="130">
                 </a>
                 <!-- /pageheader -->
             </div>
@@ -79,11 +79,11 @@
                 <div class="rst-content">                        <nav aria-label="breadcrumbs navigation" class="breadcrumb-bar" role="navigation">
         
 <ol class="breadcrumb">
-    <li class="breadcrumb-item"><a href="/index.html">Document Title</a></li>
+    <li class="breadcrumb-item"><a href="index.html">Document Title</a></li>
                     <li aria-current="page"  class="breadcrumb-item  active">Another Page</li>
         </ol>
 
-        <div class="breadcrumb-additions">    <a class="btn btn-sm btn-light" href="/_sources/yetAnotherPage.rst.txt" rel="nofollow noopener" target="_blank">
+        <div class="breadcrumb-additions">    <a class="btn btn-sm btn-light" href="_sources/yetAnotherPage.rst.txt" rel="nofollow noopener" target="_blank">
         <span class="btn-icon"><span class="fas fa-code"></span></span>
         <span class="btn-text">View source</span>
     </a>
@@ -109,7 +109,7 @@
                         
             <nav aria-label="Page navigation">
             <ul class="pagination justify-content-center"><li class="page-item">
-                            <a class="page-link" href="/page.html"
+                            <a class="page-link" href="page.html"
                                title="Accesskey Alt(+Shift)+p">
                                 Previous
                             </a>
@@ -207,10 +207,10 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         HAS_SOURCE: true
     };
 </script>
-<script src="/_resources/js/jquery.min.js"></script>
-<script src="/_resources/js/popper.min.js"></script>
-<script src="/_resources/js/bootstrap.min.js"></script>
-<script src="/_resources/js/theme.min.js"></script>
+<script src="_resources/js/jquery.min.js"></script>
+<script src="_resources/js/popper.min.js"></script>
+<script src="_resources/js/bootstrap.min.js"></script>
+<script src="_resources/js/theme.min.js"></script>
 
 <script id="R9wBKTwzv" src="https://app.usercentrics.eu/latest/main.js"></script>
 <script data-usercentrics="Matomo" src="/js/piwik.js" type="text/plain"></script>

--- a/tests/Integration/tests-full/page-with-subpages/expected/singlehtml/Index.html
+++ b/tests/Integration/tests-full/page-with-subpages/expected/singlehtml/Index.html
@@ -74,10 +74,10 @@
             <section class="section" id="root-index">
             <h1>Root index<a class="headerlink" href="#root-index" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
 
-            <p>Lorem Ipsum Dolor. See <a href="sub/index.singlepage#sub-index">Sub index</a>.</p>
+            <p>Lorem Ipsum Dolor. See <a href="#sub-index">Sub index</a>.</p>
             <div class="toctree-wrapper compound">
     <ul class="menu-level">
-    <li class="toc-item"><a href="sub/index.singlepage#sub-index">Sub index</a></li>
+    <li class="toc-item"><a href="#sub-index">Sub index</a></li>
 
     </ul>
 </div>
@@ -90,7 +90,7 @@
             <section class="section" id="sub-index">
             <h1>Sub index<a class="headerlink" href="#sub-index" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
 
-            <p>Lorem Ipsum Dolor.  See <a href="../index.singlepage#root-index">Root index</a>.</p>
+            <p>Lorem Ipsum Dolor.  See <a href="#root-index">Root index</a>.</p>
     </section>
 
 

--- a/tests/Integration/tests-full/sitemap/expected/Sitemap.html
+++ b/tests/Integration/tests-full/sitemap/expected/Sitemap.html
@@ -14,11 +14,11 @@
     <meta content="2023-01-01T12:00:00+00:00" property="article:modified_time">
     <title>Sitemap documentation</title>
 
-    <link href="/_resources/css/theme.css" rel="stylesheet">
+    <link href="_resources/css/theme.css" rel="stylesheet">
     <link href="https://docs.typo3.org/search/" rel="search" title="Search">
-                        <link href="/page1.html" rel="prev" title="Page 1"/>
-            <link href="/subpages/index.html" rel="next" title="Subpages"/>
-            <link href="/index.html" rel="top" title="Document Title"/>
+                        <link href="page1.html" rel="prev" title="Page 1"/>
+            <link href="subpages/index.html" rel="next" title="Subpages"/>
+            <link href="index.html" rel="top" title="Document Title"/>
         <!-- extrahead --><!-- /extrahead -->
     <!-- UNIVERSE BAR START -->
     <script src="https://typo3.azureedge.net/typo3infrastructure/universe/dist/webcomponents-loader.js"></script>
@@ -41,7 +41,7 @@
             <div class="page-header-inner">
                 <!-- pageheader -->
                 <a class="logo" href="https://docs.typo3.org/" title="TYPO3 Documentation">
-                    <img alt="TYPO3 Logo" class="logo-image" src="/_resources/img/typo3-logo.svg" width="484" height="130">
+                    <img alt="TYPO3 Logo" class="logo-image" src="_resources/img/typo3-logo.svg" width="484" height="130">
                 </a>
                 <!-- /pageheader -->
             </div>
@@ -70,26 +70,26 @@
     <div aria-label="main navigation" class="toc" role="navigation">
             <ul>
     <li class="toctree-l1">
-    <a href="/page1.html"
+    <a href="page1.html"
        class="reference internal">
         Page 1
     </a></li>
     <li class="toctree-l1 current active">
-    <a href="/Sitemap.html"
+    <a href="#"
        class="reference internal active">
         Sitemap
     </a></li>
     <li class="toctree-l1">
-    <a href="/subpages/index.html"
+    <a href="subpages/index.html"
        class="reference internal">
         Subpages
     </a>        <ul><li class="toctree-l2">
-    <a href="/subpages/subpage1.html"
+    <a href="subpages/subpage1.html"
        class="reference internal">
         Subpage 1
     </a></li>
 <li class="toctree-l2">
-    <a href="/subpages/subpage2.html"
+    <a href="subpages/subpage2.html"
        class="reference internal">
         Subpage 2
     </a></li>
@@ -107,11 +107,11 @@
                 <div class="rst-content">                        <nav aria-label="breadcrumbs navigation" class="breadcrumb-bar" role="navigation">
         
 <ol class="breadcrumb">
-    <li class="breadcrumb-item"><a href="/index.html">Document Title</a></li>
+    <li class="breadcrumb-item"><a href="index.html">Document Title</a></li>
                     <li aria-current="page"  class="breadcrumb-item  active">Sitemap</li>
         </ol>
 
-        <div class="breadcrumb-additions">    <a class="btn btn-sm btn-light" href="/_sources/Sitemap.rst.txt" rel="nofollow noopener" target="_blank">
+        <div class="breadcrumb-additions">    <a class="btn btn-sm btn-light" href="_sources/Sitemap.rst.txt" rel="nofollow noopener" target="_blank">
         <span class="btn-icon"><span class="fas fa-code"></span></span>
         <span class="btn-text">View source</span>
     </a>
@@ -135,26 +135,26 @@
         <div class="sitemap">
     <ul>
         <li class="toctree-l1">
-    <a href="/page1.html"
+    <a href="page1.html"
        class="reference internal">
         Page 1
     </a></li>
         <li class="toctree-l1">
-    <a href="/Sitemap.html"
+    <a href="#"
        class="reference internal">
         Sitemap
     </a></li>
         <li class="toctree-l1">
-    <a href="/subpages/index.html"
+    <a href="subpages/index.html"
        class="reference internal">
         Subpages
     </a>        <ul><li class="toctree-l2">
-    <a href="/subpages/subpage1.html"
+    <a href="subpages/subpage1.html"
        class="reference internal">
         Subpage 1
     </a></li>
 <li class="toctree-l2">
-    <a href="/subpages/subpage2.html"
+    <a href="subpages/subpage2.html"
        class="reference internal">
         Subpage 2
     </a></li>
@@ -170,13 +170,13 @@
                         
             <nav aria-label="Page navigation">
             <ul class="pagination justify-content-center"><li class="page-item">
-                            <a class="page-link" href="/page1.html"
+                            <a class="page-link" href="page1.html"
                                title="Accesskey Alt(+Shift)+p">
                                 Previous
                             </a>
                         </li>
                     <li class="page-item">
-                            <a class="page-link" href="/subpages/index.html"
+                            <a class="page-link" href="subpages/index.html"
                                title="Accesskey Alt(+Shift)+n">
                                 Next
                             </a>
@@ -274,10 +274,10 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         HAS_SOURCE: true
     };
 </script>
-<script src="/_resources/js/jquery.min.js"></script>
-<script src="/_resources/js/popper.min.js"></script>
-<script src="/_resources/js/bootstrap.min.js"></script>
-<script src="/_resources/js/theme.min.js"></script>
+<script src="_resources/js/jquery.min.js"></script>
+<script src="_resources/js/popper.min.js"></script>
+<script src="_resources/js/bootstrap.min.js"></script>
+<script src="_resources/js/theme.min.js"></script>
 
 <script id="R9wBKTwzv" src="https://app.usercentrics.eu/latest/main.js"></script>
 <script data-usercentrics="Matomo" src="/js/piwik.js" type="text/plain"></script>

--- a/tests/Integration/tests-full/sitemap/expected/index.html
+++ b/tests/Integration/tests-full/sitemap/expected/index.html
@@ -14,10 +14,10 @@
     <meta content="2023-01-01T12:00:00+00:00" property="article:modified_time">
     <title>Document Title documentation</title>
 
-    <link href="/_resources/css/theme.css" rel="stylesheet">
+    <link href="_resources/css/theme.css" rel="stylesheet">
     <link href="https://docs.typo3.org/search/" rel="search" title="Search">
-                        <link href="/page1.html" rel="next" title="Page 1"/>
-            <link href="/index.html" rel="top" title="Document Title"/>
+                        <link href="page1.html" rel="next" title="Page 1"/>
+            <link href="#" rel="top" title="Document Title"/>
         <!-- extrahead --><!-- /extrahead -->
     <!-- UNIVERSE BAR START -->
     <script src="https://typo3.azureedge.net/typo3infrastructure/universe/dist/webcomponents-loader.js"></script>
@@ -40,7 +40,7 @@
             <div class="page-header-inner">
                 <!-- pageheader -->
                 <a class="logo" href="https://docs.typo3.org/" title="TYPO3 Documentation">
-                    <img alt="TYPO3 Logo" class="logo-image" src="/_resources/img/typo3-logo.svg" width="484" height="130">
+                    <img alt="TYPO3 Logo" class="logo-image" src="_resources/img/typo3-logo.svg" width="484" height="130">
                 </a>
                 <!-- /pageheader -->
             </div>
@@ -69,26 +69,26 @@
     <div aria-label="main navigation" class="toc" role="navigation">
             <ul>
     <li class="toctree-l1">
-    <a href="/page1.html"
+    <a href="page1.html"
        class="reference internal">
         Page 1
     </a></li>
     <li class="toctree-l1">
-    <a href="/Sitemap.html"
+    <a href="Sitemap.html"
        class="reference internal">
         Sitemap
     </a></li>
     <li class="toctree-l1">
-    <a href="/subpages/index.html"
+    <a href="subpages/index.html"
        class="reference internal">
         Subpages
     </a>        <ul><li class="toctree-l2">
-    <a href="/subpages/subpage1.html"
+    <a href="subpages/subpage1.html"
        class="reference internal">
         Subpage 1
     </a></li>
 <li class="toctree-l2">
-    <a href="/subpages/subpage2.html"
+    <a href="subpages/subpage2.html"
        class="reference internal">
         Subpage 2
     </a></li>
@@ -109,7 +109,7 @@
                 <li aria-current="page"  class="breadcrumb-item  active">Document Title</li>
         </ol>
 
-        <div class="breadcrumb-additions">    <a class="btn btn-sm btn-light" href="/_sources/index.rst.txt" rel="nofollow noopener" target="_blank">
+        <div class="breadcrumb-additions">    <a class="btn btn-sm btn-light" href="_sources/index.rst.txt" rel="nofollow noopener" target="_blank">
         <span class="btn-icon"><span class="fas fa-code"></span></span>
         <span class="btn-text">View source</span>
     </a>
@@ -129,14 +129,14 @@
             <p>Lorem Ipsum Dolor.</p>
             <div class="toctree-wrapper compound">
     <ul class="menu-level">
-    <li class="toc-item"><a href="/page1.html#page-1">Page 1</a></li>
+    <li class="toc-item"><a href="page1.html#page-1">Page 1</a></li>
 
-    <li class="toc-item"><a href="/Sitemap.html#sitemap">Sitemap</a></li>
+    <li class="toc-item"><a href="Sitemap.html#sitemap">Sitemap</a></li>
 
-    <li class="toc-item"><a href="/subpages/index.html#subpages">Subpages</a>        <ul class="menu-level-1">
-            <li class="toc-item"><a href="/subpages/subpage1.html#subpage-1">Subpage 1</a></li>
+    <li class="toc-item"><a href="subpages/index.html#subpages">Subpages</a>        <ul class="menu-level-1">
+            <li class="toc-item"><a href="subpages/subpage1.html#subpage-1">Subpage 1</a></li>
 
-            <li class="toc-item"><a href="/subpages/subpage2.html#subpage-2">Subpage 2</a></li>
+            <li class="toc-item"><a href="subpages/subpage2.html#subpage-2">Subpage 2</a></li>
 
                     </ul></li>
 
@@ -151,7 +151,7 @@
                         
             <nav aria-label="Page navigation">
             <ul class="pagination justify-content-center"><li class="page-item">
-                            <a class="page-link" href="/page1.html"
+                            <a class="page-link" href="page1.html"
                                title="Accesskey Alt(+Shift)+n">
                                 Next
                             </a>
@@ -249,10 +249,10 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         HAS_SOURCE: true
     };
 </script>
-<script src="/_resources/js/jquery.min.js"></script>
-<script src="/_resources/js/popper.min.js"></script>
-<script src="/_resources/js/bootstrap.min.js"></script>
-<script src="/_resources/js/theme.min.js"></script>
+<script src="_resources/js/jquery.min.js"></script>
+<script src="_resources/js/popper.min.js"></script>
+<script src="_resources/js/bootstrap.min.js"></script>
+<script src="_resources/js/theme.min.js"></script>
 
 <script id="R9wBKTwzv" src="https://app.usercentrics.eu/latest/main.js"></script>
 <script data-usercentrics="Matomo" src="/js/piwik.js" type="text/plain"></script>

--- a/tests/Integration/tests/php-domain/expected/index.html
+++ b/tests/Integration/tests/php-domain/expected/index.html
@@ -35,8 +35,8 @@
     </dd>
 </dl>
 
-            <p>See also <a href="/index.html#typo3-cms-core-testinterface">\TYPO3\CMS\Core\TestInterface</a>,
-for short <a href="/index.html#typo3-cms-core-testinterface">TestInterface</a>!</p>
+            <p>See also <a href="#typo3-cms-core-testinterface">\TYPO3\CMS\Core\TestInterface</a>,
+for short <a href="#typo3-cms-core-testinterface">TestInterface</a>!</p>
     </section>
 
         <!-- content end -->

--- a/tests/Integration/tests/sidebar/expected/index.html
+++ b/tests/Integration/tests/sidebar/expected/index.html
@@ -9,11 +9,11 @@
     <p class="sidebar-title">reST content elements</p>
 
 <ul>
-    <li><a href="/index.html#rest-cards">Cards</a></li>
+    <li><a href="#rest-cards">Cards</a></li>
 
-    <li><a href="/index.html#rest-tabs">Tabs</a></li>
+    <li><a href="#rest-tabs">Tabs</a></li>
 
-    <li><a href="/index.html#rest-confval">Configuration values</a></li>
+    <li><a href="#rest-confval">Configuration values</a></li>
 
 </ul>
 

--- a/tests/Integration/tests/singlepage-by-toctree/expected/singlehtml/Index.html
+++ b/tests/Integration/tests/singlepage-by-toctree/expected/singlehtml/Index.html
@@ -6,18 +6,18 @@
             <p>Lorem Ipsum Dolor.</p>
             <div class="toctree-wrapper compound">
     <ul class="menu-level">
-    <li class="toc-item"><a href="one.singlepage#one">One</a></li>
+    <li class="toc-item"><a href="#one">One</a></li>
 
-    <li class="toc-item"><a href="two.singlepage#two">Two</a></li>
+    <li class="toc-item"><a href="#two">Two</a></li>
 
-    <li class="toc-item"><a href="three/index.singlepage#three-point-something">Three point something</a>        <ul class="menu-level-1">
-            <li class="toc-item"><a href="three/three.singlepage#three">Three</a></li>
+    <li class="toc-item"><a href="#three-point-something">Three point something</a>        <ul class="menu-level-1">
+            <li class="toc-item"><a href="#three">Three</a></li>
 
-            <li class="toc-item"><a href="three/threepointfive.singlepage#3-5">3.5</a></li>
+            <li class="toc-item"><a href="#3-5">3.5</a></li>
 
                     </ul></li>
 
-    <li class="toc-item"><a href="four.singlepage#four">Four</a></li>
+    <li class="toc-item"><a href="#four">Four</a></li>
 
     </ul>
 </div>
@@ -51,9 +51,9 @@
             <p>Lorem Ipsum Dolor.</p>
             <div class="toctree-wrapper compound">
     <ul class="menu-level">
-    <li class="toc-item"><a href="three.singlepage#three">Three</a></li>
+    <li class="toc-item"><a href="#three">Three</a></li>
 
-    <li class="toc-item"><a href="threepointfive.singlepage#3-5">3.5</a></li>
+    <li class="toc-item"><a href="#3-5">3.5</a></li>
 
     </ul>
 </div>


### PR DESCRIPTION
Make links in html always relative and in singlehtml links to documents stay within the document.
Links to resources are always relative

All tests are changed as before now the default
was absolute links, which we overrode in the guides.xml. However absolute links are not usefull for our scenario anyway so I dropped support of them. This does not change the behaviour of our rendered documents

resolves https://github.com/TYPO3-Documentation/render-guides/issues/238