### PR TITLE
[BUGFIX] Fix mobile menu header

### DIFF
--- a/packages/typo3-docs-theme/assets/sass/_component_page.scss
+++ b/packages/typo3-docs-theme/assets/sass/_component_page.scss
@@ -49,8 +49,8 @@
 .page-main-navigation {
     flex-grow: 0;
     margin-left: calc(#{$grid-gutter-width} / 2 * -1);
-    margin-right: calc(#{grid-gutter-width} / 2 * -1);
-    padding: calc(#{grid-gutter-width} / 2);
+    margin-right: calc(#{$grid-gutter-width} / 2 * -1);
+    padding: calc(#{$grid-gutter-width} / 2);
     border-bottom: 1px solid rgba(0, 0, 0, .15);
     @include media-breakpoint-up(lg) {
         padding: ($spacer * 2) 0;
@@ -58,7 +58,6 @@
         width: 15rem;
         margin: 0;
         margin-right: $grid-gutter-width;
-        padding-right: calc(#{$grid-gutter-width} / 2);
         padding-right: calc(#{$grid-gutter-width} / 2);
         border-bottom: none;
         border-right: 1px solid rgba(0, 0, 0, .15);

--- a/packages/typo3-docs-theme/resources/public/css/theme.css
+++ b/packages/typo3-docs-theme/resources/public/css/theme.css
@@ -23832,8 +23832,8 @@ article *:hover > a.headerlink:after, article *:hover > a.permalink:after {
 .page-main-navigation {
   flex-grow: 0;
   margin-left: calc(40px / 2 * -1);
-  margin-right: calc(grid-gutter-width / 2 * -1);
-  padding: calc(grid-gutter-width / 2);
+  margin-right: calc(40px / 2 * -1);
+  padding: calc(40px / 2);
   border-bottom: 1px solid rgba(0, 0, 0, 0.15);
 }
 @media (min-width: 992px) {
@@ -23843,7 +23843,6 @@ article *:hover > a.headerlink:after, article *:hover > a.permalink:after {
     width: 15rem;
     margin: 0;
     margin-right: 40px;
-    padding-right: calc(40px / 2);
     padding-right: calc(40px / 2);
     border-bottom: none;
     border-right: 1px solid rgba(0, 0, 0, 0.15);


### PR DESCRIPTION
No idea when this got broken, but right now it looks like this:
![image](https://github.com/TYPO3-Documentation/render-guides/assets/48202465/b66e3971-055f-497b-9e02-e0988c46f904)

After the change the margins and paddings are calculated like before:

![image](https://github.com/TYPO3-Documentation/render-guides/assets/48202465/d8a90124-f8b8-4ba9-b9c2-895cc56dfaeb)
