### PR TITLE
[TASK] Move processing logic out of MigrateSettingsCommand

### DIFF
--- a/packages/typo3-guides-cli/src/Migration/Exception/ProcessingException.php
+++ b/packages/typo3-guides-cli/src/Migration/Exception/ProcessingException.php
@@ -2,9 +2,7 @@
 
 declare(strict_types=1);
 
-
 namespace T3Docs\GuidesCli\Migration\Exception;
-
 
 final class ProcessingException extends \RuntimeException
 {

--- a/packages/typo3-guides-cli/src/Migration/Exception/ProcessingException.php
+++ b/packages/typo3-guides-cli/src/Migration/Exception/ProcessingException.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+
+namespace T3Docs\GuidesCli\Migration\Exception;
+
+
+final class ProcessingException extends \RuntimeException
+{
+    public static function fileCannotBeCreated(string $path): self
+    {
+        return new self(
+            \sprintf(
+                'Could not create file "%s"',
+                $path
+            )
+        );
+    }
+
+    public static function xmlCannotBeGenerated(): self
+    {
+        return new self('The XML file cannot be generated');
+    }
+}

--- a/packages/typo3-guides-cli/src/Migration/Processor.php
+++ b/packages/typo3-guides-cli/src/Migration/Processor.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace T3Docs\GuidesCli\Migration;
+
+use T3Docs\GuidesCli\Migration\Exception\ProcessingException;
+use T3Docs\GuidesCli\Repository\LegacySettingsRepository;
+
+class Processor
+{
+    private readonly LegacySettingsRepository $legacySettingsRepository;
+    private readonly SettingsMigrator $settingsMigrator;
+
+    /**
+     * Arguments for testing only!
+     */
+    public function __construct(
+        ?LegacySettingsRepository $legacySettingsRepository = null,
+        ?SettingsMigrator $settingsMigrator = null,
+    ) {
+        $this->legacySettingsRepository = $legacySettingsRepository ?? new LegacySettingsRepository();
+        $this->settingsMigrator = $settingsMigrator ?? new SettingsMigrator();
+    }
+
+    /**
+     * @return array{0: int, 1: list<string>}
+     */
+    public function process(string $inputFile, string $outputFile): array
+    {
+        $legacySettings = $this->legacySettingsRepository->get($inputFile);
+        [$xmlDocument, $convertedSettings, $migrationMessages]
+            = $this->settingsMigrator->migrate($legacySettings);
+
+        $fp = @fopen($outputFile, 'w') ?: throw ProcessingException::fileCannotBeCreated($outputFile);
+        $xmlString = $xmlDocument->saveXML() ?: throw ProcessingException::xmlCannotBeGenerated();
+        fwrite($fp, $xmlString);
+        fclose($fp);
+
+        return [$convertedSettings, $migrationMessages];
+    }
+}

--- a/packages/typo3-guides-cli/tests/unit/Command/MigrateSettingsCommandTest.php
+++ b/packages/typo3-guides-cli/tests/unit/Command/MigrateSettingsCommandTest.php
@@ -2,7 +2,6 @@
 
 declare(strict_types=1);
 
-
 namespace T3Docs\GuidesCli\Tests\Command;
 
 use PHPUnit\Framework\Attributes\Test;
@@ -38,16 +37,16 @@ final class MigrateSettingsCommandTest extends TestCase
             ->willReturn([21, ['first message', 'second message']]);
 
         $this->commandTester->execute([
-            'input' => $tmpFolder
+            'input' => $tmpFolder,
         ]);
 
         $this->commandTester->assertCommandIsSuccessful();
         self::assertSame(<<< EXPECTED
-Migrating /tmp/Settings.cfg to /tmp/guides.xml ...
-first message
-second message
-21 settings converted. You can now delete Settings.cfg and add guides.xml to your repository.
-EXPECTED, trim($this->commandTester->getDisplay()));
+            Migrating /tmp/Settings.cfg to /tmp/guides.xml ...
+            first message
+            second message
+            21 settings converted. You can now delete Settings.cfg and add guides.xml to your repository.
+            EXPECTED, trim($this->commandTester->getDisplay()));
     }
 
     #[Test]

--- a/packages/typo3-guides-cli/tests/unit/Command/MigrateSettingsCommandTest.php
+++ b/packages/typo3-guides-cli/tests/unit/Command/MigrateSettingsCommandTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+
+namespace T3Docs\GuidesCli\Tests\Command;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\Stub;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use T3Docs\GuidesCli\Command\MigrateSettingsCommand;
+use PHPUnit\Framework\TestCase;
+use T3Docs\GuidesCli\Migration\Exception\ProcessingException;
+use T3Docs\GuidesCli\Migration\Processor;
+
+final class MigrateSettingsCommandTest extends TestCase
+{
+    private CommandTester $commandTester;
+    private Processor&Stub $processorStub;
+
+    protected function setUp(): void
+    {
+        $this->processorStub = self::createStub(Processor::class);
+
+        $command = new MigrateSettingsCommand($this->processorStub);
+        $this->commandTester = new CommandTester($command);
+    }
+
+    #[Test]
+    public function executeReturnsWithSuccessWhenNoGuidesXmlIsAlreadyAvailable(): void
+    {
+        $tmpFolder = sys_get_temp_dir();
+
+        $this->processorStub
+            ->method('process')
+            ->with($tmpFolder . '/Settings.cfg', $tmpFolder . '/guides.xml')
+            ->willReturn([21, ['first message', 'second message']]);
+
+        $this->commandTester->execute([
+            'input' => $tmpFolder
+        ]);
+
+        $this->commandTester->assertCommandIsSuccessful();
+        self::assertSame(<<< EXPECTED
+Migrating /tmp/Settings.cfg to /tmp/guides.xml ...
+first message
+second message
+21 settings converted. You can now delete Settings.cfg and add guides.xml to your repository.
+EXPECTED, trim($this->commandTester->getDisplay()));
+    }
+
+    #[Test]
+    public function executeReturnsWithErrorWhenGuidesXmlIsAlreadyAvailable(): void
+    {
+        $tmpFolder = $this->prepareFileStructure();
+        touch($tmpFolder . '/guides.xml');
+
+        $this->commandTester->execute([
+            'input' => $tmpFolder,
+        ]);
+
+        self::assertSame(Command::FAILURE, $this->commandTester->getStatusCode());
+        self::assertStringStartsWith('Target file already exists in specified directory (/tmp/', trim($this->commandTester->getDisplay()));
+    }
+
+    #[Test]
+    public function executeReturnsWithSuccessWhenGuidesXmlIsAlreadyAvailableAndForceOptionIsSet(): void
+    {
+        $tmpFolder = $this->prepareFileStructure();
+        touch($tmpFolder . '/guides.xml');
+
+        $this->processorStub
+            ->method('process')
+            ->with($tmpFolder . '/Settings.cfg', $tmpFolder . '/guides.xml')
+            ->willReturn([1, []]);
+
+        $this->commandTester->execute([
+            'input' => $tmpFolder,
+            '--force' => true,
+        ]);
+
+        $this->commandTester->assertCommandIsSuccessful();
+    }
+
+    #[Test]
+    public function executeReturnsWithErrorWhenProcessorThrowsException(): void
+    {
+        $tmpFolder = sys_get_temp_dir();
+
+        $this->processorStub
+            ->method('process')
+            ->willThrowException(ProcessingException::xmlCannotBeGenerated());
+
+        $this->commandTester->execute([
+            'input' => $tmpFolder,
+        ]);
+
+        self::assertSame(Command::FAILURE, $this->commandTester->getStatusCode());
+        self::assertStringContainsString('The XML file cannot be generated', $this->commandTester->getDisplay());
+    }
+
+    private function prepareFileStructure(): string
+    {
+        $folder = sys_get_temp_dir() . '/guides-cli-' . uniqid();
+        mkdir($folder);
+
+        return $folder;
+    }
+}

--- a/packages/typo3-guides-cli/tests/unit/Migration/ProcessingExceptionTest.php
+++ b/packages/typo3-guides-cli/tests/unit/Migration/ProcessingExceptionTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+
+namespace T3Docs\GuidesCli\Tests\Migration;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use T3Docs\GuidesCli\Migration\Exception\ProcessingException;
+
+final class ProcessingExceptionTest extends TestCase
+{
+    #[Test]
+    public function fileCannotBeCreated(): void
+    {
+        $actual = ProcessingException::fileCannotBeCreated('/path/to/some/file.xml');
+
+        self::assertInstanceOf(ProcessingException::class, $actual);
+        self::assertSame('Could not create file "/path/to/some/file.xml"', $actual->getMessage());
+    }
+
+    #[Test]
+    public function xmlCannotBeGenerated(): void
+    {
+        $actual = ProcessingException::xmlCannotBeGenerated();
+
+        self::assertInstanceOf(ProcessingException::class, $actual);
+        self::assertSame('The XML file cannot be generated', $actual->getMessage());
+    }
+}

--- a/packages/typo3-guides-cli/tests/unit/Migration/ProcessingExceptionTest.php
+++ b/packages/typo3-guides-cli/tests/unit/Migration/ProcessingExceptionTest.php
@@ -2,7 +2,6 @@
 
 declare(strict_types=1);
 
-
 namespace T3Docs\GuidesCli\Tests\Migration;
 
 use PHPUnit\Framework\Attributes\Test;

--- a/packages/typo3-guides-cli/tests/unit/Migration/ProcessorTest.php
+++ b/packages/typo3-guides-cli/tests/unit/Migration/ProcessorTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace T3Docs\GuidesCli\Tests\Migration;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\Stub;
+use T3Docs\GuidesCli\Migration\Exception\ProcessingException;
+use T3Docs\GuidesCli\Migration\Processor;
+use PHPUnit\Framework\TestCase;
+use T3Docs\GuidesCli\Migration\SettingsMigrator;
+use T3Docs\GuidesCli\Repository\LegacySettingsRepository;
+
+final class ProcessorTest extends TestCase
+{
+    private Processor $subject;
+
+    protected function setUp(): void
+    {
+        $legacySettingsRepositoryStub = self::createStub(LegacySettingsRepository::class);
+        $legacySettingsRepositoryStub
+            ->method('get')
+            ->with('/path/to/Settings.cfg')
+            ->willReturn(['section' => ['key' => 'value']]);
+
+        $xmlDocument = new \DOMDocument('1.0', 'UTF-8');
+        $xmlDocument->appendChild($xmlDocument->createElement('guidesForTesting'));
+        $settingsMigratorStub = self::createStub(SettingsMigrator::class);
+        $settingsMigratorStub
+            ->method('migrate')
+            ->with(['section' => ['key' => 'value']])
+            ->willReturn([
+                $xmlDocument,
+                42,
+                [
+                    'some message',
+                    'another message',
+                ],
+            ]);
+
+        $this->subject = new Processor($legacySettingsRepositoryStub, $settingsMigratorStub);
+    }
+
+    #[Test]
+    public function xmlFileIsWrittenCorrectly(): void
+    {
+        $outputFile = tempnam(sys_get_temp_dir(), 'guides-cli-');
+        $actual = $this->subject->process('/path/to/Settings.cfg', $outputFile);
+
+        self::assertXmlStringEqualsXmlString('<?xml version="1.0"?><guidesForTesting/>', file_get_contents($outputFile));
+        self::assertSame(42, $actual[0]);
+        self::assertSame(['some message', 'another message'], $actual[1]);
+    }
+
+    #[Test]
+    public function exceptionIsThrownWhenFileCannotBeCreated(): void
+    {
+        $this->expectException(ProcessingException::class);
+        $this->expectExceptionMessage('Could not create file "/tmp/non-existing/guides-cli.tmp"');
+
+        $outputFile = sys_get_temp_dir() . '/non-existing/guides-cli.tmp';
+
+        $this->subject->process('/path/to/Settings.cfg', $outputFile);
+    }
+}


### PR DESCRIPTION
The command can be seen as a controller, it should not hold logic outside controlling. Therefore, the processing is moved into a dedicated class.

Now we can also test the command class easily.