### PR TITLE
[BUGFIX] Declare property to LegacySettingsRepositoryTest

### DIFF
--- a/packages/typo3-guides-cli/tests/unit/Repository/LegacySettingsRepositoryTest.php
+++ b/packages/typo3-guides-cli/tests/unit/Repository/LegacySettingsRepositoryTest.php
@@ -11,6 +11,8 @@ use T3Docs\GuidesCli\Repository\LegacySettingsRepository;
 
 final class LegacySettingsRepositoryTest extends TestCase
 {
+    private LegacySettingsRepository $subject;
+
     protected function setUp(): void
     {
         $this->subject = new LegacySettingsRepository();


### PR DESCRIPTION
This avoids deprecation messages about creation of dynamic property.