### PR TITLE
[TASK] Return DTO instead of array as processing result of migration

### DIFF
--- a/packages/typo3-guides-cli/src/Command/MigrateSettingsCommand.php
+++ b/packages/typo3-guides-cli/src/Command/MigrateSettingsCommand.php
@@ -68,8 +68,8 @@ final class MigrateSettingsCommand extends Command
         $output->writeln('Migrating ' . $settingsFile . ' to ' . $guidesFile . ' ...');
 
         try {
-            [$convertedSettings, $migrationMessages] = $this->processor->process($settingsFile, $guidesFile);
-            foreach ($migrationMessages as $message) {
+            $actual = $this->processor->process($settingsFile, $guidesFile);
+            foreach ($actual->migrationMessages as $message) {
                 $output->writeln($message);
             }
         } catch (\Exception $e) {
@@ -80,7 +80,7 @@ final class MigrateSettingsCommand extends Command
         $output->writeln(
             \sprintf(
                 '%d settings converted. You can now delete Settings.cfg and add guides.xml to your repository.',
-                $convertedSettings,
+                $actual->numberOfConvertedSettings
             )
         );
 

--- a/packages/typo3-guides-cli/src/Migration/Dto/ProcessingResult.php
+++ b/packages/typo3-guides-cli/src/Migration/Dto/ProcessingResult.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace T3Docs\GuidesCli\Migration\Dto;
+
+final class ProcessingResult
+{
+    /**
+     * @param list<string> $migrationMessages
+     */
+    public function __construct(
+        public readonly int $numberOfConvertedSettings,
+        public readonly array $migrationMessages,
+    ) {}
+}

--- a/packages/typo3-guides-cli/src/Migration/Processor.php
+++ b/packages/typo3-guides-cli/src/Migration/Processor.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace T3Docs\GuidesCli\Migration;
 
+use T3Docs\GuidesCli\Migration\Dto\ProcessingResult;
 use T3Docs\GuidesCli\Migration\Exception\ProcessingException;
 use T3Docs\GuidesCli\Repository\LegacySettingsRepository;
 
@@ -23,13 +24,10 @@ class Processor
         $this->settingsMigrator = $settingsMigrator ?? new SettingsMigrator();
     }
 
-    /**
-     * @return array{0: int, 1: list<string>}
-     */
-    public function process(string $inputFile, string $outputFile): array
+    public function process(string $inputFile, string $outputFile): ProcessingResult
     {
         $legacySettings = $this->legacySettingsRepository->get($inputFile);
-        [$xmlDocument, $convertedSettings, $migrationMessages]
+        [$xmlDocument, $numberOfConvertedSettings, $migrationMessages]
             = $this->settingsMigrator->migrate($legacySettings);
 
         $fp = @fopen($outputFile, 'w') ?: throw ProcessingException::fileCannotBeCreated($outputFile);
@@ -37,6 +35,6 @@ class Processor
         fwrite($fp, $xmlString);
         fclose($fp);
 
-        return [$convertedSettings, $migrationMessages];
+        return new ProcessingResult($numberOfConvertedSettings, $migrationMessages);
     }
 }

--- a/packages/typo3-guides-cli/tests/unit/Command/MigrateSettingsCommandTest.php
+++ b/packages/typo3-guides-cli/tests/unit/Command/MigrateSettingsCommandTest.php
@@ -10,6 +10,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\CommandTester;
 use T3Docs\GuidesCli\Command\MigrateSettingsCommand;
 use PHPUnit\Framework\TestCase;
+use T3Docs\GuidesCli\Migration\Dto\ProcessingResult;
 use T3Docs\GuidesCli\Migration\Exception\ProcessingException;
 use T3Docs\GuidesCli\Migration\Processor;
 
@@ -34,7 +35,7 @@ final class MigrateSettingsCommandTest extends TestCase
         $this->processorStub
             ->method('process')
             ->with($tmpFolder . '/Settings.cfg', $tmpFolder . '/guides.xml')
-            ->willReturn([21, ['first message', 'second message']]);
+            ->willReturn(new ProcessingResult(21, ['first message', 'second message']));
 
         $this->commandTester->execute([
             'input' => $tmpFolder,
@@ -72,7 +73,7 @@ final class MigrateSettingsCommandTest extends TestCase
         $this->processorStub
             ->method('process')
             ->with($tmpFolder . '/Settings.cfg', $tmpFolder . '/guides.xml')
-            ->willReturn([1, []]);
+            ->willReturn(new ProcessingResult(1, []));
 
         $this->commandTester->execute([
             'input' => $tmpFolder,

--- a/packages/typo3-guides-cli/tests/unit/Migration/ProcessorTest.php
+++ b/packages/typo3-guides-cli/tests/unit/Migration/ProcessorTest.php
@@ -49,8 +49,8 @@ final class ProcessorTest extends TestCase
         $actual = $this->subject->process('/path/to/Settings.cfg', $outputFile);
 
         self::assertXmlStringEqualsXmlString('<?xml version="1.0"?><guidesForTesting/>', file_get_contents($outputFile));
-        self::assertSame(42, $actual[0]);
-        self::assertSame(['some message', 'another message'], $actual[1]);
+        self::assertSame(42, $actual->numberOfConvertedSettings);
+        self::assertSame(['some message', 'another message'], $actual->migrationMessages);
     }
 
     #[Test]


### PR DESCRIPTION
This produces better readable code and type safety.