### PR TITLE
[TASK] Return DTO instead of array as migration result

### DIFF
--- a/packages/typo3-guides-cli/src/Migration/Dto/MigrationResult.php
+++ b/packages/typo3-guides-cli/src/Migration/Dto/MigrationResult.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace T3Docs\GuidesCli\Migration\Dto;
+
+final class MigrationResult
+{
+    /**
+     * @param list<string> $messages
+     */
+    public function __construct(
+        public readonly \DOMDocument $xmlDocument,
+        public readonly int $numberOfConvertedSettings,
+        public readonly array $messages,
+    ) {}
+}

--- a/packages/typo3-guides-cli/src/Migration/Processor.php
+++ b/packages/typo3-guides-cli/src/Migration/Processor.php
@@ -27,14 +27,13 @@ class Processor
     public function process(string $inputFile, string $outputFile): ProcessingResult
     {
         $legacySettings = $this->legacySettingsRepository->get($inputFile);
-        [$xmlDocument, $numberOfConvertedSettings, $migrationMessages]
-            = $this->settingsMigrator->migrate($legacySettings);
+        $migrationResult = $this->settingsMigrator->migrate($legacySettings);
 
         $fp = @fopen($outputFile, 'w') ?: throw ProcessingException::fileCannotBeCreated($outputFile);
-        $xmlString = $xmlDocument->saveXML() ?: throw ProcessingException::xmlCannotBeGenerated();
+        $xmlString = $migrationResult->xmlDocument->saveXML() ?: throw ProcessingException::xmlCannotBeGenerated();
         fwrite($fp, $xmlString);
         fclose($fp);
 
-        return new ProcessingResult($numberOfConvertedSettings, $migrationMessages);
+        return new ProcessingResult($migrationResult->numberOfConvertedSettings, $migrationResult->messages);
     }
 }

--- a/packages/typo3-guides-cli/src/Migration/SettingsMigrator.php
+++ b/packages/typo3-guides-cli/src/Migration/SettingsMigrator.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace T3Docs\GuidesCli\Migration;
 
+use T3Docs\GuidesCli\Migration\Dto\MigrationResult;
+
 class SettingsMigrator
 {
     private \DOMDocument $xmlDocument;
@@ -22,9 +24,8 @@ class SettingsMigrator
      * a list of messages for output
      *
      * @param array<string, array<string, string>> $legacySettings
-     * @return array{0: \DOMDocument, 1: int, 2: list<string>}
      */
-    public function migrate(array $legacySettings): array
+    public function migrate(array $legacySettings): MigrationResult
     {
         $this->legacySettings = $legacySettings;
         $this->unmigratedSettings = $legacySettings;
@@ -43,7 +44,7 @@ class SettingsMigrator
         // Attach the <guides> element to the root XML
         $this->xmlDocument->appendChild($guides);
 
-        return [$this->xmlDocument, $this->convertedSettings, $messages];
+        return new MigrationResult($this->xmlDocument, $this->convertedSettings, $messages);
     }
 
     private function createRootElement(): \DOMElement

--- a/packages/typo3-guides-cli/tests/unit/Migration/ProcessorTest.php
+++ b/packages/typo3-guides-cli/tests/unit/Migration/ProcessorTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace T3Docs\GuidesCli\Tests\Migration;
 
 use PHPUnit\Framework\Attributes\Test;
-use PHPUnit\Framework\MockObject\Stub;
+use T3Docs\GuidesCli\Migration\Dto\MigrationResult;
 use T3Docs\GuidesCli\Migration\Exception\ProcessingException;
 use T3Docs\GuidesCli\Migration\Processor;
 use PHPUnit\Framework\TestCase;
@@ -30,14 +30,16 @@ final class ProcessorTest extends TestCase
         $settingsMigratorStub
             ->method('migrate')
             ->with(['section' => ['key' => 'value']])
-            ->willReturn([
-                $xmlDocument,
-                42,
-                [
-                    'some message',
-                    'another message',
-                ],
-            ]);
+            ->willReturn(
+                new MigrationResult(
+                    $xmlDocument,
+                    42,
+                    [
+                        'some message',
+                        'another message',
+                    ],
+                )
+            );
 
         $this->subject = new Processor($legacySettingsRepositoryStub, $settingsMigratorStub);
     }

--- a/packages/typo3-guides-cli/tests/unit/Migration/SettingsMigratorTest.php
+++ b/packages/typo3-guides-cli/tests/unit/Migration/SettingsMigratorTest.php
@@ -25,7 +25,7 @@ final class SettingsMigratorTest extends TestCase
     #[DataProvider('providerForMigrateReturnsXmlDocumentCorrectly')]
     public function migrateReturnsXmlDocumentCorrectly(array $legacySettings, string $expected): void
     {
-        $actual = $this->subject->migrate($legacySettings)[0]->saveXML() ?: '';
+        $actual = $this->subject->migrate($legacySettings)->xmlDocument->saveXML() ?: '';
 
         self::assertXmlStringEqualsXmlString($expected, $actual);
     }
@@ -186,7 +186,7 @@ final class SettingsMigratorTest extends TestCase
             ],
         ];
 
-        $actual = $this->subject->migrate($legacySettings)[1];
+        $actual = $this->subject->migrate($legacySettings)->numberOfConvertedSettings;
 
         self::assertSame(6, $actual);
     }
@@ -199,7 +199,7 @@ final class SettingsMigratorTest extends TestCase
     #[DataProvider('providerForMigrateReturnsMessagesCorrectly')]
     public function migrateReturnsMessagesCorrectly(array $legacySettings, array $expected): void
     {
-        $actual = $this->subject->migrate($legacySettings)[2];
+        $actual = $this->subject->migrate($legacySettings)->messages;
 
         self::assertSame($expected, $actual);
     }


### PR DESCRIPTION
This produces better readable code.