### PR TITLE
[BUGFIX] Remove non-existant entries from docs menu

### DIFF
--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -42,15 +42,6 @@ to extend the tool.
 
     Introduction/Index
     Installation/Index
-    Configuration/Index
     Developer/Index
     Migration/Index
     KnownProblems/Index
-
-..  Meta Menu
-
-..  toctree::
-    :hidden:
-
-    Sitemap
-    genindex


### PR DESCRIPTION
Until the last update they caused neither warnings nor errors, so we didn't note them