### PR TITLE
[BUGFIX] Deactivate PlantUmlServer calls for tests

### DIFF
--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -45,3 +45,32 @@ to extend the tool.
     Developer/Index
     Migration/Index
     KnownProblems/Index
+
+..  uml::
+
+    class Foo1 {
+        You can use
+        several lines
+        ..
+        as you want
+        and group
+        ==
+        things together.
+        __
+        You can have as many groups
+        as you want
+        --
+        End of class
+    }
+
+    class User {
+        ..  Simple Getter ..
+        + getName()
+        + getAddress()
+        ..  Some setter ..
+        + setName()
+        __ private data __
+        int age
+        -- encrypted --
+        String password
+        }

--- a/packages/typo3-docs-theme/composer.json
+++ b/packages/typo3-docs-theme/composer.json
@@ -11,6 +11,7 @@
     },
     "require": {
         "brotkrueml/twig-codehighlight": "dev-main",
+        "phpdocumentor/guides-graphs": "dev-main",
         "phpdocumentor/guides-theme-bootstrap": "dev-main",
         "t3docs/typo3-version-handling": "self.version"
     },

--- a/packages/typo3-docs-theme/resources/config/typo3-docs-theme.php
+++ b/packages/typo3-docs-theme/resources/config/typo3-docs-theme.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 use Brotkrueml\TwigCodeHighlight\Extension as CodeHighlight;
 use phpDocumentor\Guides\Event\PostRenderProcess;
+use phpDocumentor\Guides\Event\PreParseProcess;
+use phpDocumentor\Guides\Graphs\Renderer\DiagramRenderer;
+use phpDocumentor\Guides\Graphs\Renderer\PlantumlServerRenderer;
 use phpDocumentor\Guides\RestructuredText\Directives\BaseDirective;
 use phpDocumentor\Guides\RestructuredText\Directives\SubDirective;
 use phpDocumentor\Guides\RestructuredText\Parser\Interlink\InterlinkParser;
@@ -15,7 +18,9 @@ use T3Docs\Typo3DocsTheme\Directives\GroupTabDirective;
 
 use T3Docs\Typo3DocsTheme\Directives\T3FieldListTableDirective;
 use T3Docs\Typo3DocsTheme\Directives\YoutubeDirective;
+use T3Docs\Typo3DocsTheme\EventListeners\TestingModeActivator;
 use T3Docs\Typo3DocsTheme\Parser\ExtendedInterlinkParser;
+use T3Docs\Typo3DocsTheme\Renderer\DecoratingPlantumlRenderer;
 use T3Docs\Typo3DocsTheme\TextRoles\IssueReferenceTextRole;
 use T3Docs\Typo3DocsTheme\TextRoles\PhpTextRole;
 use T3Docs\Typo3DocsTheme\Twig\TwigExtension;
@@ -41,6 +46,10 @@ return static function (ContainerConfigurator $container): void {
         ->set(PhpTextRole::class)
         ->tag('phpdoc.guides.parser.rst.text_role')
 
+        ->set(DecoratingPlantumlRenderer::class)
+        ->decorate(PlantumlServerRenderer::class)
+        ->public()
+
         ->set(GroupTabDirective::class)
         ->set(T3FieldListTableDirective::class)
         ->set(YoutubeDirective::class)
@@ -58,5 +67,8 @@ return static function (ContainerConfigurator $container): void {
         ->autowire()
 
         ->set(CopyResources::class)
-        ->tag('event_listener', ['event' => PostRenderProcess::class]);
+        ->tag('event_listener', ['event' => PostRenderProcess::class])
+
+        ->set(TestingModeActivator::class)
+        ->tag('event_listener', ['event' => PreParseProcess::class]);
 };

--- a/packages/typo3-docs-theme/src/EventListeners/TestingModeActivator.php
+++ b/packages/typo3-docs-theme/src/EventListeners/TestingModeActivator.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace T3Docs\Typo3DocsTheme\EventListeners;
+
+use phpDocumentor\Guides\Event\PreParseProcess;
+use phpDocumentor\Guides\Settings\SettingsManager;
+use Psr\Log\LoggerInterface;
+use T3Docs\Typo3DocsTheme\Renderer\DecoratingPlantumlRenderer;
+
+/**
+ * Disables HTTP calls that can fail tests
+ */
+final class TestingModeActivator
+{
+    public function __construct(
+        private readonly SettingsManager $settingsManager,
+        private readonly DecoratingPlantumlRenderer $decoratingPlantumlRenderer
+    ) {}
+
+    public function __invoke(PreParseProcess $event): void
+    {
+        // We are in test mode
+        if ($this->settingsManager->getProjectSettings()->isFailOnError()) {
+            $this->decoratingPlantumlRenderer->setDisabled(true);
+        }
+    }
+}

--- a/packages/typo3-docs-theme/src/Renderer/DecoratingPlantumlRenderer.php
+++ b/packages/typo3-docs-theme/src/Renderer/DecoratingPlantumlRenderer.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace T3Docs\Typo3DocsTheme\Renderer;
+
+use phpDocumentor\Guides\Graphs\Renderer\DiagramRenderer;
+use phpDocumentor\Guides\Graphs\Renderer\PlantumlServerRenderer;
+
+final class DecoratingPlantumlRenderer implements DiagramRenderer
+{
+    private bool $disabled = false;
+
+
+    public function __construct(private readonly PlantumlServerRenderer $innerRenderer) {}
+
+    public function render(string $diagram): string|null
+    {
+        if ($this->disabled) {
+            return 'The PlantUML renderer is not available in test mode.';
+        }
+        return $this->innerRenderer->render($diagram);
+    }
+
+    public function isDisabled(): bool
+    {
+        return $this->disabled;
+    }
+
+    public function setDisabled(bool $disabled): void
+    {
+        $this->disabled = $disabled;
+    }
+}

--- a/tests/ApplicationTestCase.php
+++ b/tests/ApplicationTestCase.php
@@ -7,6 +7,7 @@ namespace T3Docs\Typo3DocsTheme;
 use phpDocumentor\Guides\Bootstrap\DependencyInjection\BootstrapExtension;
 use phpDocumentor\Guides\Cli\DependencyInjection\ApplicationExtension;
 use phpDocumentor\Guides\Cli\DependencyInjection\ContainerFactory;
+use phpDocumentor\Guides\Graphs\DependencyInjection\GraphsExtension;
 use phpDocumentor\Guides\Markdown\DependencyInjection\MarkdownExtension;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Container;
@@ -45,6 +46,7 @@ abstract class ApplicationTestCase extends TestCase
             new Typo3DocsThemeExtension(),
             new Typo3GuidesExtension(),
             new GuidesPhpDomainExtension(),
+            new GraphsExtension(),
             ...$extraExtensions,
         ]);
 

--- a/tests/Integration/IntegrationTest.php
+++ b/tests/Integration/IntegrationTest.php
@@ -14,6 +14,8 @@ use Symfony\Component\Finder\Finder as SymfonyFinder;
 use T3Docs\GuidesExtension\Command\RunDecorator;
 use T3Docs\Typo3DocsTheme\ApplicationTestCase;
 
+use T3Docs\Typo3DocsTheme\Renderer\DecoratingPlantumlRenderer;
+
 use function array_filter;
 use function array_merge;
 use function array_walk;
@@ -61,6 +63,10 @@ final class IntegrationTest extends ApplicationTestCase
             $this->prepareContainer($configurationFile);
             $command = $this->getContainer()->get(Run::class);
             assert($command instanceof Run || $command instanceof RunDecorator);
+
+            $plantuml = $this->getContainer()->get(DecoratingPlantumlRenderer::class);
+            assert($plantuml instanceof DecoratingPlantumlRenderer);
+            $plantuml->setDisabled(true);
 
             $input = new ArrayInput(
                 [

--- a/tests/Integration/tests/directive-uml/expected/index.html
+++ b/tests/Integration/tests/directive-uml/expected/index.html
@@ -2,23 +2,11 @@
                 <section class="section" id="uml-directive">
             <h1>UML-directive<a class="headerlink" href="#uml-directive" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
 
-            artifact Foo1 {
-    folder Foo2
-}
-
-folder Foo3 {
-    artifact Foo4
-}
-
-frame Foo5 {
-    database Foo6
-}
-
-cloud vpc {
-    node ec2 {
-        stack stack
-    }
-}
+            <figure
+        class="uml-diagram"
+            >
+        The PlantUML renderer is not available in test mode.
+        </figure>
     </section>
 
         <!-- content end -->


### PR DESCRIPTION
When the docker container is used in testing pipelines
to test if documentation renders without warnings,
the plantuml server sometimes makes the tests fail by not being available.

This PR disables the plantuml server calls in testing-mode
that is when option --fail-on-log is set or in the integration tests