### PR TITLE
[BUGFIX] Restore image shadows

### DIFF
--- a/packages/typo3-docs-theme/assets/sass/components/_images.scss
+++ b/packages/typo3-docs-theme/assets/sass/components/_images.scss
@@ -1,0 +1,17 @@
+img.with-shadow, figure.with-shadow {
+    @extend .shadow;
+    @extend .p-3;
+    @extend .mb-4;
+}
+
+figure {
+    @extend .figure;
+    figcaption {
+        @extend .pt-2;
+        @extend .figure-caption;
+
+        p:last-child {
+            margin-bottom: 0;
+        }
+    }
+}

--- a/packages/typo3-docs-theme/assets/sass/theme.scss
+++ b/packages/typo3-docs-theme/assets/sass/theme.scss
@@ -26,6 +26,7 @@
 @import 'components/card';
 @import 'components/code';
 @import 'components/frame';
+@import 'components/images';
 @import 'components/math';
 @import 'components/panel';
 @import 'components/permalink';

--- a/packages/typo3-docs-theme/resources/public/css/theme.css
+++ b/packages/typo3-docs-theme/resources/public/css/theme.css
@@ -11156,7 +11156,7 @@ progress {
   height: auto;
 }
 
-.figure {
+.figure, figure {
   display: inline-block;
 }
 
@@ -11165,7 +11165,7 @@ progress {
   line-height: 1;
 }
 
-.figure-caption {
+.figure-caption, figure figcaption {
   font-size: 0.875em;
   color: var(--bs-secondary-color);
 }
@@ -18123,7 +18123,7 @@ textarea.form-control-lg {
   display: none !important;
 }
 
-.shadow {
+.shadow, img.with-shadow, figure.with-shadow {
   box-shadow: var(--bs-box-shadow) !important;
 }
 
@@ -18873,7 +18873,7 @@ textarea.form-control-lg {
   margin-bottom: 1rem !important;
 }
 
-.mb-4 {
+.mb-4, img.with-shadow, figure.with-shadow {
   margin-bottom: 1.5rem !important;
 }
 
@@ -18925,7 +18925,7 @@ textarea.form-control-lg {
   padding: 0.5rem !important;
 }
 
-.p-3 {
+.p-3, img.with-shadow, figure.with-shadow {
   padding: 1rem !important;
 }
 
@@ -19005,7 +19005,7 @@ textarea.form-control-lg {
   padding-top: 0.25rem !important;
 }
 
-.pt-2 {
+.pt-2, figure figcaption {
   padding-top: 0.5rem !important;
 }
 
@@ -23753,6 +23753,10 @@ article h3, article .h3 {
   visibility: visible;
 }
 
+figure figcaption p:last-child {
+  margin-bottom: 0;
+}
+
 span[id*=MathJax-Span] {
   color: #333333;
 }
@@ -23870,12 +23874,14 @@ article *:hover > a.headerlink:after, article *:hover > a.permalink:after {
 .rst-content .plantuml object {
   height: auto !important;
 }
-.rst-content .figure,
+.rst-content .figure, .rst-content figure,
 .rst-content .figure > img,
-.rst-content .figure > a > img {
+.rst-content figure > img,
+.rst-content .figure > a > img,
+.rst-content figure > a > img {
   display: block;
 }
-.rst-content .figure .caption,
+.rst-content .figure .caption, .rst-content figure .caption,
 .rst-content .figure > img .caption,
 .rst-content .figure > a > img .caption {
   font-size: 0.875rem;

--- a/packages/typo3-docs-theme/resources/template/body/figure.html.twig
+++ b/packages/typo3-docs-theme/resources/template/body/figure.html.twig
@@ -1,0 +1,14 @@
+<figure
+    {%- if node.classesString %} class="{{ node.classesString }}"{% endif -%}
+    {%- if node.hasOption('figwidth') %} style="{% if node.hasOption('figwidth') %}width: {{ node.option('figwidth') }};{% endif %}"{% endif -%}
+>
+    {{ renderNode(node.image) }}
+
+    {% if node.document %}
+        {% set caption = renderNode(node.document) %}
+
+        {% if caption|trim %}
+            <figcaption>{{ caption|raw }}</figcaption>
+        {% endif %}
+    {% endif %}
+</figure>

--- a/tests/Integration/tests/images/Both-Folder-Image-Index/expected/Folder/index.html
+++ b/tests/Integration/tests/images/Both-Folder-Image-Index/expected/Folder/index.html
@@ -3,7 +3,7 @@
             <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
 
             <p>Lorem Ipsum Dolor.</p>
-            <figure>
+            <figure class="with-shadow">
     <img
     src="../Images/typo3-logo.png"
                 alt="Content element wizard with the new content element"        />

--- a/tests/Integration/tests/images/No-Folders/expected/index.html
+++ b/tests/Integration/tests/images/No-Folders/expected/index.html
@@ -3,7 +3,7 @@
             <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
 
             <p>Lorem Ipsum Dolor.</p>
-            <figure>
+            <figure class="with-shadow">
     <img
     src="typo3-logo.png"
                 alt="Content element wizard with the new content element"        />

--- a/tests/Integration/tests/images/Only-Image-Folder/expected/index.html
+++ b/tests/Integration/tests/images/Only-Image-Folder/expected/index.html
@@ -3,7 +3,7 @@
             <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
 
             <p>Lorem Ipsum Dolor.</p>
-            <figure>
+            <figure class="with-shadow">
     <img
     src="Images/typo3-logo.png"
                 alt="Content element wizard with the new content element"        />

--- a/tests/Integration/tests/images/Only-Index-Folder/expected/Folder/index.html
+++ b/tests/Integration/tests/images/Only-Index-Folder/expected/Folder/index.html
@@ -3,7 +3,7 @@
             <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
 
             <p>Lorem Ipsum Dolor.</p>
-            <figure>
+            <figure class="with-shadow">
     <img
     src="../typo3-logo.png"
                 alt="Content element wizard with the new content element"        />


### PR DESCRIPTION
This restores the shadow, usefull for images who are white:

![image](https://github.com/TYPO3-Documentation/render-guides/assets/48202465/b50ccd84-9c0f-4e25-9ac4-0b64e9b37c45)

the shadow is applied if the image was defined with class "with-shadow":

```
..  image:: some-image.png
    :class: with-shadow
```

Additionally restored styles for figures with and without shadows:

![image](https://github.com/TYPO3-Documentation/render-guides/assets/48202465/4dddcc44-1f0a-4209-ad43-c01766e81b52)

```

..  figure:: typo3-logo.svg
    :class: with-shadow

    Some Caption



..  figure:: typo3-logo.svg

    Some Caption
```


resolves https://github.com/TYPO3-Documentation/render-guides/issues/289