### PR TITLE
[BUGFIX] Remove attribute cz-shortcut-listen from body

### DIFF
--- a/packages/typo3-docs-theme/resources/template/structure/layout.html.twig
+++ b/packages/typo3-docs-theme/resources/template/structure/layout.html.twig
@@ -13,7 +13,7 @@
     {% block headerLinks %}
     {% endblock %}
 </head>
-<body cz-shortcut-listen="true">
+<body>
 <div class="page">
     {% include "structure/layoutParts/pageHeader.html.twig" %}
     <main class="page-main">

--- a/tests/Integration/tests-full/edit-on-github/expected/index.html
+++ b/tests/Integration/tests-full/edit-on-github/expected/index.html
@@ -23,7 +23,7 @@
                         <link href="page1.html" rel="next" title="Page 1"/>
             <link href="#" rel="top" title="Document Title"/>
     </head>
-<body cz-shortcut-listen="true">
+<body>
 <div class="page">
     
 <header>

--- a/tests/Integration/tests-full/edit-on-github/expected/page1.html
+++ b/tests/Integration/tests-full/edit-on-github/expected/page1.html
@@ -24,7 +24,7 @@
             <link href="subpages/index.html" rel="next" title="Subpages"/>
             <link href="index.html" rel="top" title="Document Title"/>
     </head>
-<body cz-shortcut-listen="true">
+<body>
 <div class="page">
     
 <header>

--- a/tests/Integration/tests-full/edit-on-github/expected/subpages/index.html
+++ b/tests/Integration/tests-full/edit-on-github/expected/subpages/index.html
@@ -24,7 +24,7 @@
             <link href="subpage1.html" rel="next" title="Subpage 1"/>
             <link href="../index.html" rel="top" title="Document Title"/>
     </head>
-<body cz-shortcut-listen="true">
+<body>
 <div class="page">
     
 <header>

--- a/tests/Integration/tests-full/index/expected/index.html
+++ b/tests/Integration/tests-full/index/expected/index.html
@@ -22,7 +22,7 @@
 
                         <link href="#" rel="top" title="Document Title"/>
     </head>
-<body cz-shortcut-listen="true">
+<body>
 <div class="page">
     
 <header>

--- a/tests/Integration/tests-full/link-wizard/expected/index.html
+++ b/tests/Integration/tests-full/link-wizard/expected/index.html
@@ -22,7 +22,7 @@
 
                         <link href="#" rel="top" title="Document Title"/>
     </head>
-<body cz-shortcut-listen="true">
+<body>
 <div class="page">
     
 <header>

--- a/tests/Integration/tests-full/menu-subpages-max-1/expected/index.html
+++ b/tests/Integration/tests-full/menu-subpages-max-1/expected/index.html
@@ -23,7 +23,7 @@
                         <link href="someDirectory/index.html" rel="next" title="Some Page"/>
             <link href="#" rel="top" title="Document Title"/>
     </head>
-<body cz-shortcut-listen="true">
+<body>
 <div class="page">
     
 <header>

--- a/tests/Integration/tests-full/menu-subpages-no-titlesonly-maxdepth-1/expected/index.html
+++ b/tests/Integration/tests-full/menu-subpages-no-titlesonly-maxdepth-1/expected/index.html
@@ -23,7 +23,7 @@
                         <link href="someDirectory/index.html" rel="next" title="Some Page"/>
             <link href="#" rel="top" title="Document Title"/>
     </head>
-<body cz-shortcut-listen="true">
+<body>
 <div class="page">
     
 <header>

--- a/tests/Integration/tests-full/menu-subpages-no-titlesonly-maxdepth-2/expected/index.html
+++ b/tests/Integration/tests-full/menu-subpages-no-titlesonly-maxdepth-2/expected/index.html
@@ -23,7 +23,7 @@
                         <link href="someDirectory/index.html" rel="next" title="Some Page"/>
             <link href="#" rel="top" title="Document Title"/>
     </head>
-<body cz-shortcut-listen="true">
+<body>
 <div class="page">
     
 <header>

--- a/tests/Integration/tests-full/menu-subpages/expected/index.html
+++ b/tests/Integration/tests-full/menu-subpages/expected/index.html
@@ -23,7 +23,7 @@
                         <link href="someDirectory/index.html" rel="next" title="Some Page"/>
             <link href="#" rel="top" title="Document Title"/>
     </head>
-<body cz-shortcut-listen="true">
+<body>
 <div class="page">
     
 <header>

--- a/tests/Integration/tests-full/meta-data/expected/index.html
+++ b/tests/Integration/tests-full/meta-data/expected/index.html
@@ -22,7 +22,7 @@
 
                         <link href="#" rel="top" title="Document Title"/>
     </head>
-<body cz-shortcut-listen="true">
+<body>
 <div class="page">
     
 <header>

--- a/tests/Integration/tests-full/next-prev-by-toctree/expected/four.html
+++ b/tests/Integration/tests-full/next-prev-by-toctree/expected/four.html
@@ -24,7 +24,7 @@
             <link href="i.html" rel="next" title="i (sqrt(-1))"/>
             <link href="index.html" rel="top" title="Root index"/>
     </head>
-<body cz-shortcut-listen="true">
+<body>
 <div class="page">
     
 <header>

--- a/tests/Integration/tests-full/next-prev-by-toctree/expected/i.html
+++ b/tests/Integration/tests-full/next-prev-by-toctree/expected/i.html
@@ -24,7 +24,7 @@
             <link href="three/pi.html" rel="next" title="Pi"/>
             <link href="index.html" rel="top" title="Root index"/>
     </head>
-<body cz-shortcut-listen="true">
+<body>
 <div class="page">
     
 <header>

--- a/tests/Integration/tests-full/next-prev-by-toctree/expected/index.html
+++ b/tests/Integration/tests-full/next-prev-by-toctree/expected/index.html
@@ -23,7 +23,7 @@
                         <link href="one.html" rel="next" title="One"/>
             <link href="#" rel="top" title="Root index"/>
     </head>
-<body cz-shortcut-listen="true">
+<body>
 <div class="page">
     
 <header>

--- a/tests/Integration/tests-full/next-prev-by-toctree/expected/one.html
+++ b/tests/Integration/tests-full/next-prev-by-toctree/expected/one.html
@@ -24,7 +24,7 @@
             <link href="two.html" rel="next" title="Two"/>
             <link href="index.html" rel="top" title="Root index"/>
     </head>
-<body cz-shortcut-listen="true">
+<body>
 <div class="page">
     
 <header>

--- a/tests/Integration/tests-full/next-prev-by-toctree/expected/three/index.html
+++ b/tests/Integration/tests-full/next-prev-by-toctree/expected/three/index.html
@@ -24,7 +24,7 @@
             <link href="three.html" rel="next" title="Three"/>
             <link href="../index.html" rel="top" title="Root index"/>
     </head>
-<body cz-shortcut-listen="true">
+<body>
 <div class="page">
     
 <header>

--- a/tests/Integration/tests-full/next-prev-by-toctree/expected/three/pi.html
+++ b/tests/Integration/tests-full/next-prev-by-toctree/expected/three/pi.html
@@ -23,7 +23,7 @@
                         <link href="../i.html" rel="prev" title="i (sqrt(-1))"/>
             <link href="../index.html" rel="top" title="Root index"/>
     </head>
-<body cz-shortcut-listen="true">
+<body>
 <div class="page">
     
 <header>

--- a/tests/Integration/tests-full/next-prev-by-toctree/expected/three/three.html
+++ b/tests/Integration/tests-full/next-prev-by-toctree/expected/three/three.html
@@ -24,7 +24,7 @@
             <link href="threepointfive.html" rel="next" title="3.5"/>
             <link href="../index.html" rel="top" title="Root index"/>
     </head>
-<body cz-shortcut-listen="true">
+<body>
 <div class="page">
     
 <header>

--- a/tests/Integration/tests-full/next-prev-by-toctree/expected/three/threepointfive.html
+++ b/tests/Integration/tests-full/next-prev-by-toctree/expected/three/threepointfive.html
@@ -24,7 +24,7 @@
             <link href="../four.html" rel="next" title="Four"/>
             <link href="../index.html" rel="top" title="Root index"/>
     </head>
-<body cz-shortcut-listen="true">
+<body>
 <div class="page">
     
 <header>

--- a/tests/Integration/tests-full/next-prev-by-toctree/expected/two.html
+++ b/tests/Integration/tests-full/next-prev-by-toctree/expected/two.html
@@ -24,7 +24,7 @@
             <link href="three/index.html" rel="next" title="Three point something"/>
             <link href="index.html" rel="top" title="Root index"/>
     </head>
-<body cz-shortcut-listen="true">
+<body>
 <div class="page">
     
 <header>

--- a/tests/Integration/tests-full/next-prev/expected/index.html
+++ b/tests/Integration/tests-full/next-prev/expected/index.html
@@ -23,7 +23,7 @@
                         <link href="page.html" rel="next" title="Page"/>
             <link href="#" rel="top" title="Document Title"/>
     </head>
-<body cz-shortcut-listen="true">
+<body>
 <div class="page">
     
 <header>

--- a/tests/Integration/tests-full/next-prev/expected/page.html
+++ b/tests/Integration/tests-full/next-prev/expected/page.html
@@ -24,7 +24,7 @@
             <link href="yetAnotherPage.html" rel="next" title="Another Page"/>
             <link href="index.html" rel="top" title="Document Title"/>
     </head>
-<body cz-shortcut-listen="true">
+<body>
 <div class="page">
     
 <header>

--- a/tests/Integration/tests-full/next-prev/expected/yetAnotherPage.html
+++ b/tests/Integration/tests-full/next-prev/expected/yetAnotherPage.html
@@ -23,7 +23,7 @@
                         <link href="page.html" rel="prev" title="Page"/>
             <link href="index.html" rel="top" title="Document Title"/>
     </head>
-<body cz-shortcut-listen="true">
+<body>
 <div class="page">
     
 <header>

--- a/tests/Integration/tests-full/page-with-subpages/expected/index.html
+++ b/tests/Integration/tests-full/page-with-subpages/expected/index.html
@@ -23,7 +23,7 @@
                         <link href="sub/index.html" rel="next" title="Sub index"/>
             <link href="#" rel="top" title="Root index"/>
     </head>
-<body cz-shortcut-listen="true">
+<body>
 <div class="page">
     
 <header>

--- a/tests/Integration/tests-full/page-with-subpages/expected/singlehtml/Index.html
+++ b/tests/Integration/tests-full/page-with-subpages/expected/singlehtml/Index.html
@@ -21,7 +21,7 @@
 <script src="https://typo3.azureedge.net/typo3infrastructure/universe/dist/typo3-universe.js" type="module"></script>
 
                 </head>
-<body cz-shortcut-listen="true">
+<body>
 <div class="page">
     
 <header>

--- a/tests/Integration/tests-full/page-with-subpages/expected/sub/index.html
+++ b/tests/Integration/tests-full/page-with-subpages/expected/sub/index.html
@@ -23,7 +23,7 @@
                         <link href="../index.html" rel="prev" title="Root index"/>
             <link href="../index.html" rel="top" title="Root index"/>
     </head>
-<body cz-shortcut-listen="true">
+<body>
 <div class="page">
     
 <header>

--- a/tests/Integration/tests-full/two-toctrees/expected/index.html
+++ b/tests/Integration/tests-full/two-toctrees/expected/index.html
@@ -23,7 +23,7 @@
                         <link href="page1.html" rel="next" title="Page 1"/>
             <link href="#" rel="top" title="Document Title"/>
     </head>
-<body cz-shortcut-listen="true">
+<body>
 <div class="page">
     
 <header>


### PR DESCRIPTION
This attribute is usually set locally by color zilla in the browser. Someone must have copy-pasted it in the past. it can be safely removed.