### PR TITLE
[TASK] Update to phpdocumentor/guides (0.3.3 => 0.3.4)

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1227,16 +1227,16 @@
         },
         {
             "name": "phpdocumentor/guides",
-            "version": "0.3.3",
+            "version": "0.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/guides-core.git",
-                "reference": "98c1de4557b3f7cfd2c3b5c57b32030281f2425a"
+                "reference": "c34adaf43cf694a43077174d747888d4d3441474"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/guides-core/zipball/98c1de4557b3f7cfd2c3b5c57b32030281f2425a",
-                "reference": "98c1de4557b3f7cfd2c3b5c57b32030281f2425a",
+                "url": "https://api.github.com/repos/phpDocumentor/guides-core/zipball/c34adaf43cf694a43077174d747888d4d3441474",
+                "reference": "c34adaf43cf694a43077174d747888d4d3441474",
                 "shasum": ""
             },
             "require": {
@@ -1271,13 +1271,13 @@
             "homepage": "https://www.phpdoc.org",
             "support": {
                 "issues": "https://github.com/phpDocumentor/guides-core/issues",
-                "source": "https://github.com/phpDocumentor/guides-core/tree/0.3.3"
+                "source": "https://github.com/phpDocumentor/guides-core/tree/0.3.4"
             },
-            "time": "2024-01-31T20:23:41+00:00"
+            "time": "2024-02-17T11:43:45+00:00"
         },
         {
             "name": "phpdocumentor/guides-cli",
-            "version": "0.3.3",
+            "version": "0.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/guides-cli.git",
@@ -1320,13 +1320,13 @@
             ],
             "description": "Allows you to run phpDocumentor Guides as a stand alone application as console command",
             "support": {
-                "source": "https://github.com/phpDocumentor/guides-cli/tree/0.3.3"
+                "source": "https://github.com/phpDocumentor/guides-cli/tree/0.3.4"
             },
             "time": "2024-02-08T20:51:50+00:00"
         },
         {
             "name": "phpdocumentor/guides-graphs",
-            "version": "0.3.3",
+            "version": "0.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/guides-graphs.git",
@@ -1363,22 +1363,22 @@
             "homepage": "https://www.phpdoc.org",
             "support": {
                 "issues": "https://github.com/phpDocumentor/guides-graphs/issues",
-                "source": "https://github.com/phpDocumentor/guides-graphs/tree/0.3.3"
+                "source": "https://github.com/phpDocumentor/guides-graphs/tree/0.3.4"
             },
             "time": "2024-01-21T19:16:47+00:00"
         },
         {
             "name": "phpdocumentor/guides-markdown",
-            "version": "0.3.3",
+            "version": "0.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/guides-markdown.git",
-                "reference": "c2c0725f7de8fcd4e1c4b6f7662f9515b6cfe2a0"
+                "reference": "01daab513a3bf254b1e1a2c86c903e0c322ae749"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/guides-markdown/zipball/c2c0725f7de8fcd4e1c4b6f7662f9515b6cfe2a0",
-                "reference": "c2c0725f7de8fcd4e1c4b6f7662f9515b6cfe2a0",
+                "url": "https://api.github.com/repos/phpDocumentor/guides-markdown/zipball/01daab513a3bf254b1e1a2c86c903e0c322ae749",
+                "reference": "01daab513a3bf254b1e1a2c86c903e0c322ae749",
                 "shasum": ""
             },
             "require": {
@@ -1400,22 +1400,22 @@
             "homepage": "https://www.phpdoc.org",
             "support": {
                 "issues": "https://github.com/phpDocumentor/guides-markdown/issues",
-                "source": "https://github.com/phpDocumentor/guides-markdown/tree/0.3.3"
+                "source": "https://github.com/phpDocumentor/guides-markdown/tree/0.3.4"
             },
-            "time": "2024-01-21T19:16:47+00:00"
+            "time": "2024-02-17T08:51:09+00:00"
         },
         {
             "name": "phpdocumentor/guides-restructured-text",
-            "version": "0.3.3",
+            "version": "0.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/guides-restructured-text.git",
-                "reference": "e26e3a9109fbb425ffc90affeef5556c62fccb3f"
+                "reference": "c01ea7d267346d245b83dadab0be3489cd4eca4e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/guides-restructured-text/zipball/e26e3a9109fbb425ffc90affeef5556c62fccb3f",
-                "reference": "e26e3a9109fbb425ffc90affeef5556c62fccb3f",
+                "url": "https://api.github.com/repos/phpDocumentor/guides-restructured-text/zipball/c01ea7d267346d245b83dadab0be3489cd4eca4e",
+                "reference": "c01ea7d267346d245b83dadab0be3489cd4eca4e",
                 "shasum": ""
             },
             "require": {
@@ -1438,13 +1438,13 @@
             "description": "Adds reStructuredText Markup support to the phpDocumentor's Guides library.",
             "homepage": "https://www.phpdoc.org",
             "support": {
-                "source": "https://github.com/phpDocumentor/guides-restructured-text/tree/0.3.3"
+                "source": "https://github.com/phpDocumentor/guides-restructured-text/tree/0.3.4"
             },
-            "time": "2024-01-30T06:50:46+00:00"
+            "time": "2024-02-17T11:43:45+00:00"
         },
         {
             "name": "phpdocumentor/guides-theme-bootstrap",
-            "version": "0.3.3",
+            "version": "0.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/guides-theme-bootstrap.git",
@@ -1474,7 +1474,7 @@
             "description": "A theme for phpdocumentor/guides based on Bootstrap",
             "homepage": "https://www.phpdoc.org",
             "support": {
-                "source": "https://github.com/phpDocumentor/guides-theme-bootstrap/tree/0.3.3"
+                "source": "https://github.com/phpDocumentor/guides-theme-bootstrap/tree/0.3.4"
             },
             "time": "2024-01-21T19:16:47+00:00"
         },


### PR DESCRIPTION
This will give us warnings of documents not included in toctrees,

resolves https://github.com/TYPO3-Documentation/render-guides/issues/332