### PR TITLE
[TASK] Adjust font size of inline code

### DIFF
--- a/packages/typo3-docs-theme/assets/sass/components/_code.scss
+++ b/packages/typo3-docs-theme/assets/sass/components/_code.scss
@@ -90,7 +90,7 @@
  */
 .code-inline {
     font-family: $font-family-monospace;
-    font-size: 75%;
+    font-size: 90%;
     border-radius: $border-radius;
     border: 1px solid #fff;
 

--- a/packages/typo3-docs-theme/resources/public/css/theme.css
+++ b/packages/typo3-docs-theme/resources/public/css/theme.css
@@ -23088,7 +23088,7 @@ article h3, article .h3 {
  */
 .code-inline {
   font-family: "Source Code Pro", monospace;
-  font-size: 75%;
+  font-size: 90%;
   border-radius: 0.375rem;
   border: 1px solid #fff;
 }


### PR DESCRIPTION
The font size of inline code (for example, `:file:`, `:php:`, etc) is too small in comparison with the surrounding text. It is now increased for better readability.