### PR TITLE
[BUGFIX] Avoid long code block lines run into copy button

### DIFF
--- a/packages/typo3-docs-theme/assets/sass/components/_code.scss
+++ b/packages/typo3-docs-theme/assets/sass/components/_code.scss
@@ -14,13 +14,7 @@
  * The class "code-block" is used for ".. code-block::" directives
  */
 .code-block {
-    background: var(--code-block-background-color);
-    border: 1px solid var(--code-block-background-border-color);
-    border-radius: .2rem;
-    font-size: 92%;
-    line-height: 125%;
-    margin-bottom: 1rem;
-    overflow-x: auto;
+    margin-bottom: 0;
     padding: .75rem;
 
     & [data-line-number]::before {
@@ -38,15 +32,21 @@
 }
 
 .code-block-wrapper {
+    background: var(--code-block-background-color);
+    border: 1px solid var(--code-block-background-border-color);
+    border-radius: .2rem;
+    display: flex;
+    font-size: 92%;
+    justify-content: space-between;
+    line-height: 125%;
+    margin-bottom: 1rem;
     position: relative;
 }
 
 .code-block-copy {
     background: none;
     border: none;
-    position: absolute;
-    right: 8px;
-    top: 8px;
+    padding: .75rem;
 
     .fa-copy {
         opacity: .5;

--- a/packages/typo3-docs-theme/resources/public/css/theme.css
+++ b/packages/typo3-docs-theme/resources/public/css/theme.css
@@ -23018,13 +23018,7 @@ article h3, article .h3 {
  * The class "code-block" is used for ".. code-block::" directives
  */
 .code-block {
-  background: var(--code-block-background-color);
-  border: 1px solid var(--code-block-background-border-color);
-  border-radius: 0.2rem;
-  font-size: 92%;
-  line-height: 125%;
-  margin-bottom: 1rem;
-  overflow-x: auto;
+  margin-bottom: 0;
   padding: 0.75rem;
 }
 .code-block [data-line-number]::before {
@@ -23040,15 +23034,21 @@ article h3, article .h3 {
 }
 
 .code-block-wrapper {
+  background: var(--code-block-background-color);
+  border: 1px solid var(--code-block-background-border-color);
+  border-radius: 0.2rem;
+  display: flex;
+  font-size: 92%;
+  justify-content: space-between;
+  line-height: 125%;
+  margin-bottom: 1rem;
   position: relative;
 }
 
 .code-block-copy {
   background: none;
   border: none;
-  position: absolute;
-  right: 8px;
-  top: 8px;
+  padding: 0.75rem;
 }
 .code-block-copy .fa-copy {
   opacity: 0.5;

--- a/packages/typo3-docs-theme/resources/template/body/code.html.twig
+++ b/packages/typo3-docs-theme/resources/template/body/code.html.twig
@@ -16,10 +16,12 @@
         {% endif %}
 
         {{ node.value | codehighlight(language=node.language, showLineNumbers=showLineNumbers, startWithLineNumber=startWithLineNumber, emphasizeLines=node.emphasizeLines, classes=node.classesString)}}
-        <button class="code-block-copy" title="Copy to clipboard">
-            <i class="fa-regular fa-copy code-block-copy-icon"></i>
-            <i class="fa-solid fa-check code-block-check-icon code-block-hide"></i>
-        </button>
-        <span class="code-block-check-tooltip code-block-hide" aria-live="polite">Copied!</span>
+        <div>
+            <button class="code-block-copy" title="Copy to clipboard">
+                <i class="fa-regular fa-copy code-block-copy-icon"></i>
+                <i class="fa-solid fa-check code-block-check-icon code-block-hide"></i>
+            </button>
+            <span class="code-block-check-tooltip code-block-hide" aria-live="polite">Copied!</span>
+        </div>
     </div>
 {%- endif -%}

--- a/tests/Integration/tests/code-block/directive-only/expected/index.html
+++ b/tests/Integration/tests/code-block/directive-only/expected/index.html
@@ -5,11 +5,13 @@
             <div class="code-block-wrapper" translate="no">
 
         <pre class="code-block"><code>echo &#039;Hello, TYPO3&#039;;</code></pre>
-        <button class="code-block-copy" title="Copy to clipboard">
-            <i class="fa-regular fa-copy code-block-copy-icon"></i>
-            <i class="fa-solid fa-check code-block-check-icon code-block-hide"></i>
-        </button>
-        <span class="code-block-check-tooltip code-block-hide" aria-live="polite">Copied!</span>
+        <div>
+            <button class="code-block-copy" title="Copy to clipboard">
+                <i class="fa-regular fa-copy code-block-copy-icon"></i>
+                <i class="fa-solid fa-check code-block-check-icon code-block-hide"></i>
+            </button>
+            <span class="code-block-check-tooltip code-block-hide" aria-live="polite">Copied!</span>
+        </div>
     </div>
     </section>
 

--- a/tests/Integration/tests/code-block/with-caption/expected/index.html
+++ b/tests/Integration/tests/code-block/with-caption/expected/index.html
@@ -7,11 +7,13 @@
         </div><div class="code-block-wrapper" translate="no">
 
         <pre class="code-block"><code class="hljs php"><span class="hljs-keyword">echo</span> <span class="hljs-string">'Hello, TYPO3'</span>;</code></pre>
-        <button class="code-block-copy" title="Copy to clipboard">
-            <i class="fa-regular fa-copy code-block-copy-icon"></i>
-            <i class="fa-solid fa-check code-block-check-icon code-block-hide"></i>
-        </button>
-        <span class="code-block-check-tooltip code-block-hide" aria-live="polite">Copied!</span>
+        <div>
+            <button class="code-block-copy" title="Copy to clipboard">
+                <i class="fa-regular fa-copy code-block-copy-icon"></i>
+                <i class="fa-solid fa-check code-block-check-icon code-block-hide"></i>
+            </button>
+            <span class="code-block-check-tooltip code-block-hide" aria-live="polite">Copied!</span>
+        </div>
     </div>
     </section>
 

--- a/tests/Integration/tests/code-block/with-classes/expected/index.html
+++ b/tests/Integration/tests/code-block/with-classes/expected/index.html
@@ -6,11 +6,13 @@
 
         <pre class="code-block some-class another-class"><code class="hljs python"><span class="hljs-function"><span class="hljs-keyword">def</span> <span class="hljs-title">some_function</span><span class="hljs-params">()</span>:</span>
     interesting = <span class="hljs-literal">False</span></code></pre>
-        <button class="code-block-copy" title="Copy to clipboard">
-            <i class="fa-regular fa-copy code-block-copy-icon"></i>
-            <i class="fa-solid fa-check code-block-check-icon code-block-hide"></i>
-        </button>
-        <span class="code-block-check-tooltip code-block-hide" aria-live="polite">Copied!</span>
+        <div>
+            <button class="code-block-copy" title="Copy to clipboard">
+                <i class="fa-regular fa-copy code-block-copy-icon"></i>
+                <i class="fa-solid fa-check code-block-check-icon code-block-hide"></i>
+            </button>
+            <span class="code-block-check-tooltip code-block-hide" aria-live="polite">Copied!</span>
+        </div>
     </div>
     </section>
 

--- a/tests/Integration/tests/code-block/with-emphasize-lines/expected/index.html
+++ b/tests/Integration/tests/code-block/with-emphasize-lines/expected/index.html
@@ -9,11 +9,13 @@
 <span data-emphasize-line>    print(<span class="hljs-string">'This line is highlighted.'</span>)</span>
     print(<span class="hljs-string">'This one is not...'</span>)
 <span data-emphasize-line>    print(<span class="hljs-string">'...but this one is.'</span>)</span></code></pre>
-        <button class="code-block-copy" title="Copy to clipboard">
-            <i class="fa-regular fa-copy code-block-copy-icon"></i>
-            <i class="fa-solid fa-check code-block-check-icon code-block-hide"></i>
-        </button>
-        <span class="code-block-check-tooltip code-block-hide" aria-live="polite">Copied!</span>
+        <div>
+            <button class="code-block-copy" title="Copy to clipboard">
+                <i class="fa-regular fa-copy code-block-copy-icon"></i>
+                <i class="fa-solid fa-check code-block-check-icon code-block-hide"></i>
+            </button>
+            <span class="code-block-check-tooltip code-block-hide" aria-live="polite">Copied!</span>
+        </div>
     </div>
     </section>
 

--- a/tests/Integration/tests/code-block/with-language-aliases/expected/index.html
+++ b/tests/Integration/tests/code-block/with-language-aliases/expected/index.html
@@ -5,29 +5,35 @@
             <div class="code-block-wrapper" translate="no">
 
         <pre class="code-block"><code class="hljs plaintext">something we don't know of</code></pre>
-        <button class="code-block-copy" title="Copy to clipboard">
-            <i class="fa-regular fa-copy code-block-copy-icon"></i>
-            <i class="fa-solid fa-check code-block-check-icon code-block-hide"></i>
-        </button>
-        <span class="code-block-check-tooltip code-block-hide" aria-live="polite">Copied!</span>
+        <div>
+            <button class="code-block-copy" title="Copy to clipboard">
+                <i class="fa-regular fa-copy code-block-copy-icon"></i>
+                <i class="fa-solid fa-check code-block-check-icon code-block-hide"></i>
+            </button>
+            <span class="code-block-check-tooltip code-block-hide" aria-live="polite">Copied!</span>
+        </div>
     </div>
             <div class="code-block-wrapper" translate="no">
 
         <pre class="code-block"><code class="hljs plaintext">some text</code></pre>
-        <button class="code-block-copy" title="Copy to clipboard">
-            <i class="fa-regular fa-copy code-block-copy-icon"></i>
-            <i class="fa-solid fa-check code-block-check-icon code-block-hide"></i>
-        </button>
-        <span class="code-block-check-tooltip code-block-hide" aria-live="polite">Copied!</span>
+        <div>
+            <button class="code-block-copy" title="Copy to clipboard">
+                <i class="fa-regular fa-copy code-block-copy-icon"></i>
+                <i class="fa-solid fa-check code-block-check-icon code-block-hide"></i>
+            </button>
+            <span class="code-block-check-tooltip code-block-hide" aria-live="polite">Copied!</span>
+        </div>
     </div>
             <div class="code-block-wrapper" translate="no">
 
         <pre class="code-block"><code class="hljs typoscript">some TypoScript</code></pre>
-        <button class="code-block-copy" title="Copy to clipboard">
-            <i class="fa-regular fa-copy code-block-copy-icon"></i>
-            <i class="fa-solid fa-check code-block-check-icon code-block-hide"></i>
-        </button>
-        <span class="code-block-check-tooltip code-block-hide" aria-live="polite">Copied!</span>
+        <div>
+            <button class="code-block-copy" title="Copy to clipboard">
+                <i class="fa-regular fa-copy code-block-copy-icon"></i>
+                <i class="fa-solid fa-check code-block-check-icon code-block-hide"></i>
+            </button>
+            <span class="code-block-check-tooltip code-block-hide" aria-live="polite">Copied!</span>
+        </div>
     </div>
     </section>
 

--- a/tests/Integration/tests/code-block/with-language-rst/expected/index.html
+++ b/tests/Integration/tests/code-block/with-language-rst/expected/index.html
@@ -10,11 +10,13 @@
     Lorem <span class="hljs-emphasis">*Ipsum dolor*</span>
 
 <span class="hljs-name">:ref:`see also &lt;this&gt;`</span></code></pre>
-        <button class="code-block-copy" title="Copy to clipboard">
-            <i class="fa-regular fa-copy code-block-copy-icon"></i>
-            <i class="fa-solid fa-check code-block-check-icon code-block-hide"></i>
-        </button>
-        <span class="code-block-check-tooltip code-block-hide" aria-live="polite">Copied!</span>
+        <div>
+            <button class="code-block-copy" title="Copy to clipboard">
+                <i class="fa-regular fa-copy code-block-copy-icon"></i>
+                <i class="fa-solid fa-check code-block-check-icon code-block-hide"></i>
+            </button>
+            <span class="code-block-check-tooltip code-block-hide" aria-live="polite">Copied!</span>
+        </div>
     </div>
             <div class="code-block-wrapper" translate="no">
 
@@ -25,11 +27,13 @@
 <span class="hljs-symbol">
     *</span>   <span class="hljs-emphasis">*Line 21*</span>
 <span class="hljs-symbol">    *</span>   Line 22</code></pre>
-        <button class="code-block-copy" title="Copy to clipboard">
-            <i class="fa-regular fa-copy code-block-copy-icon"></i>
-            <i class="fa-solid fa-check code-block-check-icon code-block-hide"></i>
-        </button>
-        <span class="code-block-check-tooltip code-block-hide" aria-live="polite">Copied!</span>
+        <div>
+            <button class="code-block-copy" title="Copy to clipboard">
+                <i class="fa-regular fa-copy code-block-copy-icon"></i>
+                <i class="fa-solid fa-check code-block-check-icon code-block-hide"></i>
+            </button>
+            <span class="code-block-check-tooltip code-block-hide" aria-live="polite">Copied!</span>
+        </div>
     </div>
             <div class="code-block-wrapper" translate="no">
 
@@ -42,11 +46,13 @@ Check out more information on <span class="hljs-name">t3o_</span>
 _t3o:</span> https://typo3.org
 <span class="hljs-name">
 _`t3o something`:</span> https://typo3.org"</code></pre>
-        <button class="code-block-copy" title="Copy to clipboard">
-            <i class="fa-regular fa-copy code-block-copy-icon"></i>
-            <i class="fa-solid fa-check code-block-check-icon code-block-hide"></i>
-        </button>
-        <span class="code-block-check-tooltip code-block-hide" aria-live="polite">Copied!</span>
+        <div>
+            <button class="code-block-copy" title="Copy to clipboard">
+                <i class="fa-regular fa-copy code-block-copy-icon"></i>
+                <i class="fa-solid fa-check code-block-check-icon code-block-hide"></i>
+            </button>
+            <span class="code-block-check-tooltip code-block-hide" aria-live="polite">Copied!</span>
+        </div>
     </div>
     </section>
 

--- a/tests/Integration/tests/code-block/with-language-typoscript/expected/index.html
+++ b/tests/Integration/tests/code-block/with-language-typoscript/expected/index.html
@@ -14,11 +14,13 @@
 <span class="hljs-name">&lt;INCLUDE_TYPOSCRIPT: source="<span class="hljs-bullet">FILE:EXT:my_extension/Configuration/TypoScript/myMenu.typoscript</span>"&gt;</span>
 <span class="hljs-name">&lt;INCLUDE_TYPOSCRIPT: source="<span class="hljs-bullet">DIR:fileadmin/templates/</span>" extensions="typoscript"&gt;</span>
 <span class="hljs-name">&lt;INCLUDE_TYPOSCRIPT: source="<span class="hljs-bullet">FILE:EXT:my_extension/Configuration/TypoScript/user.typoscript</span>" condition="<span class="hljs-meta">[frontend.user.isLoggedIn]</span>"&gt;</span></code></pre>
-        <button class="code-block-copy" title="Copy to clipboard">
-            <i class="fa-regular fa-copy code-block-copy-icon"></i>
-            <i class="fa-solid fa-check code-block-check-icon code-block-hide"></i>
-        </button>
-        <span class="code-block-check-tooltip code-block-hide" aria-live="polite">Copied!</span>
+        <div>
+            <button class="code-block-copy" title="Copy to clipboard">
+                <i class="fa-regular fa-copy code-block-copy-icon"></i>
+                <i class="fa-solid fa-check code-block-check-icon code-block-hide"></i>
+            </button>
+            <span class="code-block-check-tooltip code-block-hide" aria-live="polite">Copied!</span>
+        </div>
     </div>
     </section>
 
@@ -36,11 +38,13 @@
 <span class="hljs-meta">[ELSE]</span>
     <span class="hljs-comment"># ...</span>
 <span class="hljs-meta">[GLOBAL]</span></code></pre>
-        <button class="code-block-copy" title="Copy to clipboard">
-            <i class="fa-regular fa-copy code-block-copy-icon"></i>
-            <i class="fa-solid fa-check code-block-check-icon code-block-hide"></i>
-        </button>
-        <span class="code-block-check-tooltip code-block-hide" aria-live="polite">Copied!</span>
+        <div>
+            <button class="code-block-copy" title="Copy to clipboard">
+                <i class="fa-regular fa-copy code-block-copy-icon"></i>
+                <i class="fa-solid fa-check code-block-check-icon code-block-hide"></i>
+            </button>
+            <span class="code-block-check-tooltip code-block-hide" aria-live="polite">Copied!</span>
+        </div>
     </div>
     </section>
 
@@ -50,11 +54,13 @@
             <div class="code-block-wrapper" translate="no">
 
         <pre class="code-block"><code class="hljs typoscript">select.where = (<span class="hljs-name">{#title}</span> LIKE <span class="hljs-name">{#%SOMETHING%}</span> AND NOT <span class="hljs-name">{#doktype}</span>)</code></pre>
-        <button class="code-block-copy" title="Copy to clipboard">
-            <i class="fa-regular fa-copy code-block-copy-icon"></i>
-            <i class="fa-solid fa-check code-block-check-icon code-block-hide"></i>
-        </button>
-        <span class="code-block-check-tooltip code-block-hide" aria-live="polite">Copied!</span>
+        <div>
+            <button class="code-block-copy" title="Copy to clipboard">
+                <i class="fa-regular fa-copy code-block-copy-icon"></i>
+                <i class="fa-solid fa-check code-block-check-icon code-block-hide"></i>
+            </button>
+            <span class="code-block-check-tooltip code-block-hide" aria-live="polite">Copied!</span>
+        </div>
     </div>
     </section>
 
@@ -64,11 +70,13 @@
             <div class="code-block-wrapper" translate="no">
 
         <pre class="code-block"><code class="hljs typoscript">something = <span class="hljs-name">{$foo.bar}</span></code></pre>
-        <button class="code-block-copy" title="Copy to clipboard">
-            <i class="fa-regular fa-copy code-block-copy-icon"></i>
-            <i class="fa-solid fa-check code-block-check-icon code-block-hide"></i>
-        </button>
-        <span class="code-block-check-tooltip code-block-hide" aria-live="polite">Copied!</span>
+        <div>
+            <button class="code-block-copy" title="Copy to clipboard">
+                <i class="fa-regular fa-copy code-block-copy-icon"></i>
+                <i class="fa-solid fa-check code-block-check-icon code-block-hide"></i>
+            </button>
+            <span class="code-block-check-tooltip code-block-hide" aria-live="polite">Copied!</span>
+        </div>
     </div>
     </section>
 
@@ -92,11 +100,13 @@ comment */</span>
 something = 42 <span class="hljs-comment">/* some
 multiline
 comment */</span> and more</code></pre>
-        <button class="code-block-copy" title="Copy to clipboard">
-            <i class="fa-regular fa-copy code-block-copy-icon"></i>
-            <i class="fa-solid fa-check code-block-check-icon code-block-hide"></i>
-        </button>
-        <span class="code-block-check-tooltip code-block-hide" aria-live="polite">Copied!</span>
+        <div>
+            <button class="code-block-copy" title="Copy to clipboard">
+                <i class="fa-regular fa-copy code-block-copy-icon"></i>
+                <i class="fa-solid fa-check code-block-check-icon code-block-hide"></i>
+            </button>
+            <span class="code-block-check-tooltip code-block-hide" aria-live="polite">Copied!</span>
+        </div>
     </div>
     </section>
 
@@ -106,11 +116,13 @@ comment */</span> and more</code></pre>
             <div class="code-block-wrapper" translate="no">
 
         <pre class="code-block"><code class="hljs typoscript">dataWrap = &lt;ul class="<span class="hljs-name">{register:ulClass}</span>"&gt;|&lt;/ul&gt;</code></pre>
-        <button class="code-block-copy" title="Copy to clipboard">
-            <i class="fa-regular fa-copy code-block-copy-icon"></i>
-            <i class="fa-solid fa-check code-block-check-icon code-block-hide"></i>
-        </button>
-        <span class="code-block-check-tooltip code-block-hide" aria-live="polite">Copied!</span>
+        <div>
+            <button class="code-block-copy" title="Copy to clipboard">
+                <i class="fa-regular fa-copy code-block-copy-icon"></i>
+                <i class="fa-solid fa-check code-block-check-icon code-block-hide"></i>
+            </button>
+            <span class="code-block-check-tooltip code-block-hide" aria-live="polite">Copied!</span>
+        </div>
     </div>
     </section>
 
@@ -124,11 +136,13 @@ comment */</span> and more</code></pre>
 something = <span class="hljs-number">#abcdef</span>
 
 something = 1234 <span class="hljs-comment"># not recognized as color</span></code></pre>
-        <button class="code-block-copy" title="Copy to clipboard">
-            <i class="fa-regular fa-copy code-block-copy-icon"></i>
-            <i class="fa-solid fa-check code-block-check-icon code-block-hide"></i>
-        </button>
-        <span class="code-block-check-tooltip code-block-hide" aria-live="polite">Copied!</span>
+        <div>
+            <button class="code-block-copy" title="Copy to clipboard">
+                <i class="fa-regular fa-copy code-block-copy-icon"></i>
+                <i class="fa-solid fa-check code-block-check-icon code-block-hide"></i>
+            </button>
+            <span class="code-block-check-tooltip code-block-hide" aria-live="polite">Copied!</span>
+        </div>
     </div>
     </section>
 
@@ -144,11 +158,13 @@ something = 1234 <span class="hljs-comment"># not recognized as color</span></co
 <span class="hljs-title">10</span> {
     value = something
 }</code></pre>
-        <button class="code-block-copy" title="Copy to clipboard">
-            <i class="fa-regular fa-copy code-block-copy-icon"></i>
-            <i class="fa-solid fa-check code-block-check-icon code-block-hide"></i>
-        </button>
-        <span class="code-block-check-tooltip code-block-hide" aria-live="polite">Copied!</span>
+        <div>
+            <button class="code-block-copy" title="Copy to clipboard">
+                <i class="fa-regular fa-copy code-block-copy-icon"></i>
+                <i class="fa-solid fa-check code-block-check-icon code-block-hide"></i>
+            </button>
+            <span class="code-block-check-tooltip code-block-hide" aria-live="polite">Copied!</span>
+        </div>
     </div>
     </section>
 
@@ -164,11 +180,13 @@ something = 1234 <span class="hljs-comment"># not recognized as color</span></co
 <span class="hljs-title">10</span> = <span class="hljs-keyword">TMENU</span>
 
 <span class="hljs-title">10</span> = <span class="hljs-keyword">NO</span></code></pre>
-        <button class="code-block-copy" title="Copy to clipboard">
-            <i class="fa-regular fa-copy code-block-copy-icon"></i>
-            <i class="fa-solid fa-check code-block-check-icon code-block-hide"></i>
-        </button>
-        <span class="code-block-check-tooltip code-block-hide" aria-live="polite">Copied!</span>
+        <div>
+            <button class="code-block-copy" title="Copy to clipboard">
+                <i class="fa-regular fa-copy code-block-copy-icon"></i>
+                <i class="fa-solid fa-check code-block-check-icon code-block-hide"></i>
+            </button>
+            <span class="code-block-check-tooltip code-block-hide" aria-live="polite">Copied!</span>
+        </div>
     </div>
     </section>
 

--- a/tests/Integration/tests/code-block/with-language/expected/index.html
+++ b/tests/Integration/tests/code-block/with-language/expected/index.html
@@ -5,11 +5,13 @@
             <div class="code-block-wrapper" translate="no">
 
         <pre class="code-block"><code class="hljs php"><span class="hljs-keyword">echo</span> <span class="hljs-string">'Hello, TYPO3'</span>;</code></pre>
-        <button class="code-block-copy" title="Copy to clipboard">
-            <i class="fa-regular fa-copy code-block-copy-icon"></i>
-            <i class="fa-solid fa-check code-block-check-icon code-block-hide"></i>
-        </button>
-        <span class="code-block-check-tooltip code-block-hide" aria-live="polite">Copied!</span>
+        <div>
+            <button class="code-block-copy" title="Copy to clipboard">
+                <i class="fa-regular fa-copy code-block-copy-icon"></i>
+                <i class="fa-solid fa-check code-block-check-icon code-block-hide"></i>
+            </button>
+            <span class="code-block-check-tooltip code-block-hide" aria-live="polite">Copied!</span>
+        </div>
     </div>
     </section>
 

--- a/tests/Integration/tests/code-block/with-line-number-start/expected/index.html
+++ b/tests/Integration/tests/code-block/with-line-number-start/expected/index.html
@@ -5,11 +5,13 @@
             <div class="code-block-wrapper" translate="no">
 
         <pre class="code-block"><code class="hljs ruby"><span data-line-number="10">Some more Ruby code.</span></code></pre>
-        <button class="code-block-copy" title="Copy to clipboard">
-            <i class="fa-regular fa-copy code-block-copy-icon"></i>
-            <i class="fa-solid fa-check code-block-check-icon code-block-hide"></i>
-        </button>
-        <span class="code-block-check-tooltip code-block-hide" aria-live="polite">Copied!</span>
+        <div>
+            <button class="code-block-copy" title="Copy to clipboard">
+                <i class="fa-regular fa-copy code-block-copy-icon"></i>
+                <i class="fa-solid fa-check code-block-check-icon code-block-hide"></i>
+            </button>
+            <span class="code-block-check-tooltip code-block-hide" aria-live="polite">Copied!</span>
+        </div>
     </div>
     </section>
 

--- a/tests/Integration/tests/code-block/with-line-numbers/expected/index.html
+++ b/tests/Integration/tests/code-block/with-line-numbers/expected/index.html
@@ -5,11 +5,13 @@
             <div class="code-block-wrapper" translate="no">
 
         <pre class="code-block"><code class="hljs ruby"><span data-line-number="1">Some more Ruby code, with line numbering starting at <span class="hljs-number">10</span>.</span></code></pre>
-        <button class="code-block-copy" title="Copy to clipboard">
-            <i class="fa-regular fa-copy code-block-copy-icon"></i>
-            <i class="fa-solid fa-check code-block-check-icon code-block-hide"></i>
-        </button>
-        <span class="code-block-check-tooltip code-block-hide" aria-live="polite">Copied!</span>
+        <div>
+            <button class="code-block-copy" title="Copy to clipboard">
+                <i class="fa-regular fa-copy code-block-copy-icon"></i>
+                <i class="fa-solid fa-check code-block-check-icon code-block-hide"></i>
+            </button>
+            <span class="code-block-check-tooltip code-block-hide" aria-live="polite">Copied!</span>
+        </div>
     </div>
     </section>
 

--- a/tests/Integration/tests/configuration/expected/index.html
+++ b/tests/Integration/tests/configuration/expected/index.html
@@ -8,11 +8,13 @@ a look at <a href="https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/I
             <div class="code-block-wrapper" translate="no">
 
         <pre class="code-block"><code class="hljs php">$lorem = <span class="hljs-string">"ipsum dolor\n"</span>;</code></pre>
-        <button class="code-block-copy" title="Copy to clipboard">
-            <i class="fa-regular fa-copy code-block-copy-icon"></i>
-            <i class="fa-solid fa-check code-block-check-icon code-block-hide"></i>
-        </button>
-        <span class="code-block-check-tooltip code-block-hide" aria-live="polite">Copied!</span>
+        <div>
+            <button class="code-block-copy" title="Copy to clipboard">
+                <i class="fa-regular fa-copy code-block-copy-icon"></i>
+                <i class="fa-solid fa-check code-block-check-icon code-block-hide"></i>
+            </button>
+            <span class="code-block-check-tooltip code-block-hide" aria-live="polite">Copied!</span>
+        </div>
     </div>
     </section>
 

--- a/tests/Integration/tests/markdown/expected/README.html
+++ b/tests/Integration/tests/markdown/expected/README.html
@@ -62,11 +62,13 @@
 end procedure
 
 </code></pre>
-        <button class="code-block-copy" title="Copy to clipboard">
-            <i class="fa-regular fa-copy code-block-copy-icon"></i>
-            <i class="fa-solid fa-check code-block-check-icon code-block-hide"></i>
-        </button>
-        <span class="code-block-check-tooltip code-block-hide" aria-live="polite">Copied!</span>
+        <div>
+            <button class="code-block-copy" title="Copy to clipboard">
+                <i class="fa-regular fa-copy code-block-copy-icon"></i>
+                <i class="fa-solid fa-check code-block-check-icon code-block-hide"></i>
+            </button>
+            <span class="code-block-check-tooltip code-block-hide" aria-live="polite">Copied!</span>
+        </div>
     </div></li>
 
     <li><p><strong>Supervise Always:</strong> Always supervise your child while they are using theswing. Ensure they are using it safely and within the recommended age and weightlimits.</p></li>

--- a/tests/Integration/tests/tabs/expected/index.html
+++ b/tests/Integration/tests/tabs/expected/index.html
@@ -26,22 +26,26 @@
     <div class="code-block-wrapper" translate="no">
 
         <pre class="code-block"><code class="hljs bash">composer create-project typo3/cms-base-distribution:^11 example-project-directory</code></pre>
-        <button class="code-block-copy" title="Copy to clipboard">
-            <i class="fa-regular fa-copy code-block-copy-icon"></i>
-            <i class="fa-solid fa-check code-block-check-icon code-block-hide"></i>
-        </button>
-        <span class="code-block-check-tooltip code-block-hide" aria-live="polite">Copied!</span>
+        <div>
+            <button class="code-block-copy" title="Copy to clipboard">
+                <i class="fa-regular fa-copy code-block-copy-icon"></i>
+                <i class="fa-solid fa-check code-block-check-icon code-block-hide"></i>
+            </button>
+            <span class="code-block-check-tooltip code-block-hide" aria-live="polite">Copied!</span>
+        </div>
     </div>
 </div>
 <div class="tab-pane fade" id="powershell-tabs-1" role="tabpanel" aria-labelledby="powershell-tab-tabs-1">
     <div class="code-block-wrapper" translate="no">
 
         <pre class="code-block"><code class="hljs powershell">composer create<span class="hljs-literal">-project</span> <span class="hljs-string">"typo3/cms-base-distribution:^11"</span> example<span class="hljs-literal">-project</span><span class="hljs-literal">-directory</span></code></pre>
-        <button class="code-block-copy" title="Copy to clipboard">
-            <i class="fa-regular fa-copy code-block-copy-icon"></i>
-            <i class="fa-solid fa-check code-block-check-icon code-block-hide"></i>
-        </button>
-        <span class="code-block-check-tooltip code-block-hide" aria-live="polite">Copied!</span>
+        <div>
+            <button class="code-block-copy" title="Copy to clipboard">
+                <i class="fa-regular fa-copy code-block-copy-icon"></i>
+                <i class="fa-solid fa-check code-block-check-icon code-block-hide"></i>
+            </button>
+            <span class="code-block-check-tooltip code-block-hide" aria-live="polite">Copied!</span>
+        </div>
     </div>
 </div>
     </div>
@@ -71,22 +75,26 @@
     <div class="code-block-wrapper" translate="no">
 
         <pre class="code-block"><code class="hljs bash">touch example-project-directory/public/FIRST_INSTALL</code></pre>
-        <button class="code-block-copy" title="Copy to clipboard">
-            <i class="fa-regular fa-copy code-block-copy-icon"></i>
-            <i class="fa-solid fa-check code-block-check-icon code-block-hide"></i>
-        </button>
-        <span class="code-block-check-tooltip code-block-hide" aria-live="polite">Copied!</span>
+        <div>
+            <button class="code-block-copy" title="Copy to clipboard">
+                <i class="fa-regular fa-copy code-block-copy-icon"></i>
+                <i class="fa-solid fa-check code-block-check-icon code-block-hide"></i>
+            </button>
+            <span class="code-block-check-tooltip code-block-hide" aria-live="polite">Copied!</span>
+        </div>
     </div>
 </div>
 <div class="tab-pane fade" id="powershell-tabs-2" role="tabpanel" aria-labelledby="powershell-tab-tabs-2">
     <div class="code-block-wrapper" translate="no">
 
         <pre class="code-block"><code class="hljs powershell">echo <span class="hljs-variable">$null</span> &gt;&gt; public/FIRST_INSTALL</code></pre>
-        <button class="code-block-copy" title="Copy to clipboard">
-            <i class="fa-regular fa-copy code-block-copy-icon"></i>
-            <i class="fa-solid fa-check code-block-check-icon code-block-hide"></i>
-        </button>
-        <span class="code-block-check-tooltip code-block-hide" aria-live="polite">Copied!</span>
+        <div>
+            <button class="code-block-copy" title="Copy to clipboard">
+                <i class="fa-regular fa-copy code-block-copy-icon"></i>
+                <i class="fa-solid fa-check code-block-check-icon code-block-hide"></i>
+            </button>
+            <span class="code-block-check-tooltip code-block-hide" aria-live="polite">Copied!</span>
+        </div>
     </div>
 </div>
     </div>


### PR DESCRIPTION
Previously, the copy button was just absolutely positioned at the end of the code block wrapper: Long code lines "run" into the button. Now, there are two distinct columns (brought by a newly introduced flexbox) which separate those two contents.

Resolves: #370