### PR TITLE
[TASK] Streamline documentation for subtree-split repositories

### DIFF
--- a/packages/typo3-docs-theme/README.rst
+++ b/packages/typo3-docs-theme/README.rst
@@ -3,18 +3,19 @@
 Theme for PHP based rendering of docs.typo3.org
 ===============================================
 
-This theme is still in experimantal stage and not used for rendering
-https://docs.typo3.org .
-
-You can find an example on how to use this theme in the
-`TYPO3 Docs RST-Rendering Demo <https://github.com/TYPO3-Documentation/rst-rendering-demo>`
-
-You can also require this theme in your composer.json::
+You can also require this package in your composer.json::
 
     composer req t3docs/typo3-docs-theme
 
 This theme uses the `phpDocumentor Guides <https://github.com/phpDocumentor/guides>`__
 for parsing and rendering restructuredText.
 
-The theme needs to receive a GIT tag to be pushed to the split
-repositories, and also published on the CDN.
+This repository is a subtree-split of the monorepo located at
+https://github.com/TYPO3-Documentation/render-guides/tree/main/packages/typo3-docs-theme
+
+More documentation about this rendering, which uses this theme package:
+
+https://docs.typo3.org/other/t3docs/render-guides/main/en-us/Introduction/Index.html
+
+When this repository receives a GIT tagged push (through the subtree-split
+automation), the theme files on the CDN is updated.

--- a/packages/typo3-guides-cli/README.rst
+++ b/packages/typo3-guides-cli/README.rst
@@ -1,7 +1,7 @@
 
-===========================================
+========================================
 Toolbox for render-guides CLI operations
-===========================================
+========================================
 
 You can also require this package in your composer.json::
 
@@ -9,3 +9,13 @@ You can also require this package in your composer.json::
 
 This package uses the `phpDocumentor Guides <https://github.com/phpDocumentor/guides>`__
 for parsing and rendering restructuredText.
+
+This repository is a subtree-split of the monorepo located at
+https://github.com/TYPO3-Documentation/render-guides/tree/main/packages/typo3-guides-cli
+
+The toolbox allows to perform :bash:`guides.xml` migration and linting and
+programmatic configuration of the file.
+
+More documentation about the documentation rendering:
+
+https://docs.typo3.org/other/t3docs/render-guides/main/en-us/Introduction/Index.html

--- a/packages/typo3-guides-extension/README.rst
+++ b/packages/typo3-guides-extension/README.rst
@@ -1,0 +1,20 @@
+
+======================================
+TYPO3 specific phpDocumentor extension
+======================================
+
+You can also require this package in your composer.json::
+
+    composer req t3docs/typo3-guides-extension
+
+This package uses the `phpDocumentor Guides <https://github.com/phpDocumentor/guides>`__
+for parsing and rendering restructuredText.
+
+This repository is a subtree-split of the monorepo located at
+https://github.com/TYPO3-Documentation/render-guides/tree/main/packages/typo3-guides-extension
+
+The package allows to define and utilize TYPO3 specific ReST formattings.
+
+More documentation about this rendering:
+
+https://docs.typo3.org/other/t3docs/render-guides/main/en-us/Introduction/Index.html

--- a/packages/typo3-version-handling/README.rst
+++ b/packages/typo3-version-handling/README.rst
@@ -3,6 +3,16 @@
 Version handling for PHP based rendering of docs.typo3.org
 ==========================================================
 
+You can also require this package in your composer.json::
+
+    composer req t3docs/typo3-version-handling
+
+This packages uses the `phpDocumentor Guides <https://github.com/phpDocumentor/guides>`__
+for parsing and rendering restructuredText.
+
+This repository is a subtree-split of the monorepo located at
+https://github.com/TYPO3-Documentation/render-guides/tree/main/packages/typo3-version-handling
+
 This package contains a PHP enum that can be used to determine allowed TYPO3
 versions for documentation interlinking. It also allows a matching between
 descriptive versions like  `stable` and absolute minor versions, for
@@ -11,7 +21,7 @@ example `12.4`.
 Additionally, it contains an enum with a list of supported standard inventories
 of official references, tutorials and guides. These are used for interlink mapping.
 
-You can also require this package in your composer.json::
+More documentation about this rendering:
 
-    composer req t3docs/typo3-version-handling
+https://docs.typo3.org/other/t3docs/render-guides/main/en-us/Introduction/Index.html
 


### PR DESCRIPTION
I noticed that the README.rst files for our subtree repositories are shown in the GitHub repositories, and do not properly indicate that those are subtree repos.

I tried to unify all four package READMEs, rather quick and dirty. Please check if this is suitable. Feel free to add commits to this branch to change wordings.