### PR TITLE
[TASK] Add "t3upgrade" key to the default inventories

### DIFF
--- a/packages/typo3-version-handling/src/DefaultInventories.php
+++ b/packages/typo3-version-handling/src/DefaultInventories.php
@@ -11,7 +11,8 @@ enum DefaultInventories: string
     case t3tsref = 't3tsref';
     case t3viewhelper = 't3viewhelper';
     case t3editors = 't3editors';
-    case t3install = 't3install';
+    case t3install = 't3install'; // for legacy reasons
+    case t3upgrade = 't3upgrade';
     case t3sitepackage = 't3sitepackage';
     case t3start = 't3start';
     case t3translate = 't3translate';
@@ -37,6 +38,7 @@ enum DefaultInventories: string
             // Official Core Tutorials and Guides
             DefaultInventories::t3editors => 'https://docs.typo3.org/m/typo3/tutorial-editors/{typo3_version}/en-us/',
             DefaultInventories::t3install => 'https://docs.typo3.org/m/typo3/guide-installation/{typo3_version}/en-us/',
+            DefaultInventories::t3upgrade => 'https://docs.typo3.org/m/typo3/guide-installation/{typo3_version}/en-us/',
             DefaultInventories::t3sitepackage => 'https://docs.typo3.org/m/typo3/tutorial-sitepackage/{typo3_version}/en-us/',
             DefaultInventories::t3start => 'https://docs.typo3.org/m/typo3/tutorial-getting-started/{typo3_version}/en-us/',
             DefaultInventories::t3translate => 'https://docs.typo3.org/m/typo3/guide-frontendlocalization/{typo3_version}/en-us/',

--- a/tests/Integration/tests/guides-inventories/expected/index.html
+++ b/tests/Integration/tests/guides-inventories/expected/index.html
@@ -18,6 +18,7 @@
             <li>t3ts45</li>
             <li>t3tsconfig</li>
             <li>t3tsref</li>
+            <li>t3upgrade</li>
             <li>t3viewhelper</li>
     </ul>
 


### PR DESCRIPTION
The `t3install` references the "Upgrade Guide" which is semantically wrong. Therefore, the `t3upgrade` key has been introduced.

As both are available in the wild, both are valid, but `t3install` should be considered legacy.