### PR TITLE
[Task] Styles focus

### DIFF
--- a/packages/typo3-docs-theme/assets/sass/_text.scss
+++ b/packages/typo3-docs-theme/assets/sass/_text.scss
@@ -18,3 +18,6 @@ article {
         border-bottom: 1px solid rgba(0, 0, 0, .1);
     }
 }
+*:focus-visible {
+    @include focus();
+}

--- a/packages/typo3-docs-theme/assets/sass/mixins/_focus.scss
+++ b/packages/typo3-docs-theme/assets/sass/mixins/_focus.scss
@@ -1,0 +1,3 @@
+@mixin focus() {
+    box-shadow: inset 0px 0px 2px 2px;
+}

--- a/packages/typo3-docs-theme/assets/sass/theme.scss
+++ b/packages/typo3-docs-theme/assets/sass/theme.scss
@@ -16,6 +16,7 @@
 
 // Mixings
 @import 'mixins/container';
+@import 'mixins/focus';
 @import 'mixins/inline_styles';
 
 // tweak bootstrap styles

--- a/packages/typo3-docs-theme/resources/public/css/theme.css
+++ b/packages/typo3-docs-theme/resources/public/css/theme.css
@@ -22869,6 +22869,10 @@ article h3, article .h3 {
   border-bottom: 1px solid rgba(0, 0, 0, 0.1);
 }
 
+*:focus-visible {
+    box-shadow: inset 0px 0px 2px 2px;
+}
+
 .btn, .toc-toggle {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
Hello,

this pull request add a **global behaviour for focus-visible** based on inner box-shadow. In that way, focus that are not yet handled in a specific way are always highlighted. The color is not set in purpose, in that way it will take the text color by default and then should always have a good contrast with the background.

Rachel