### PR TITLE
[Task] Styles article text

### DIFF
--- a/packages/typo3-docs-theme/assets/sass/_text.scss
+++ b/packages/typo3-docs-theme/assets/sass/_text.scss
@@ -8,8 +8,16 @@ a {
 article {
     a:not([class*="btn"]) {
         text-decoration: underline;
+        color: $gray-900;
     }
-
+    p, li {
+        color: $gray-800;
+        font-size: 1.1rem;
+        margin-bottom: 1rem;
+    }
+    li::marker {
+        color: $orange;
+    }
     /**
      * Headlines todo: why only h3 has an underline?
      */

--- a/packages/typo3-docs-theme/assets/sass/_variables.scss
+++ b/packages/typo3-docs-theme/assets/sass/_variables.scss
@@ -9,7 +9,7 @@ $gray-400:          shade-color($white, 20%);
 $gray-500:          shade-color($white, 30%);
 $gray-600:          shade-color($white, 40%);
 $gray-700:          shade-color($white, 50%);
-$gray-800:          shade-color($white, 70%);
+$gray-800:          shade-color($white, 60%);
 $gray-900:          shade-color($white, 80%);
 $black:             #000000;
 

--- a/packages/typo3-docs-theme/resources/public/css/theme.css
+++ b/packages/typo3-docs-theme/resources/public/css/theme.css
@@ -22863,6 +22863,18 @@ article {
 }
 article a:not([class*=btn]) {
   text-decoration: underline;
+  color: #333333;
+}
+article a:not([class*=btn]):hover {
+  text-decoration: none;
+}
+article p, article li {
+  color: #666666;
+  font-size: 1.1rem;
+  margin-bottom: 1rem;
+}
+article li::marker {
+  color: #ff8700;
 }
 article h3, article .h3 {
   padding-bottom: 0.5rem;


### PR DESCRIPTION
Hello,

following this week discussions about styling changes, I'm splitting it in small pull requests easier to review and merge.
This one is focused on the **article text font size and styling**. 

Since the difference between the main menu and the article font sizes was considered too big, I have reduced the article font size from 1.2rem to 1.1rem. It is still confortable. 

Rachel
