### PR TITLE
[BUGFIX] Fix Fluid interlink

### DIFF
--- a/packages/typo3-version-handling/src/DefaultInventories.php
+++ b/packages/typo3-version-handling/src/DefaultInventories.php
@@ -52,7 +52,7 @@ enum DefaultInventories: string
             DefaultInventories::t3writing => 'https://docs.typo3.org/m/typo3/writing-guide/main/en-us/',
 
             // Other
-            DefaultInventories::fluid => 'https://docs.typo3.org/other/typo3fluid/fluid/{typo3_version}/en-us/',
+            DefaultInventories::fluid => 'https://docs.typo3.org/other/typo3fluid/fluid/main/en-us/',
         };
     }
 


### PR DESCRIPTION
Fluid (the standalone API) does not belong to the core and does not support TYPO3 Versions.

Therefore currently interlinks to it fail when prefered version is not main.