### PR TITLE
[FEATURE] Display source and GitHub link on mobile

### DIFF
--- a/packages/typo3-docs-theme/resources/template/structure/document.html.twig
+++ b/packages/typo3-docs-theme/resources/template/structure/document.html.twig
@@ -11,6 +11,7 @@
     <div aria-label="Main navigation" class="main_menu" role="navigation">
         {{ renderMenu('mainmenu') }}
     </div>
+    {% include "structure/navigation/meta-menu.html.twig" %}
 {% endblock %}
 
 {% block body %}

--- a/packages/typo3-docs-theme/resources/template/structure/navigation/meta-menu.html.twig
+++ b/packages/typo3-docs-theme/resources/template/structure/navigation/meta-menu.html.twig
@@ -1,0 +1,28 @@
+
+{%- set copySources = getSettings('copy_sources') -%}
+{%- set howtoEditButton = getSettings('how_to_edit') -%}
+{%- set gitHubLink = getEditOnGitHubLink() -%}
+
+{%- if (copySources or howtoEditButton or gitHubLink)  %}
+<div aria-label="Meta navigation" class="main_menu  d-block d-lg-none" role="navigation">
+    <hr/>
+    <p class="caption">Contributors Corner</p>
+    <ul class="menu-level-1">
+        {%- if (copySources)  %}
+            <li><a href="{{ copyDownload(env.currentFileName ~ '.rst', '_sources/' ~ env.currentFileName ~ '.rst.txt') }}" rel="nofollow noopener" target="_blank">
+                    View source of current document
+            </a></li>
+        {% endif -%}
+        {%- if (howtoEditButton)  %}
+            <li><a href="{{ howtoEditButton }}" rel="nofollow noopener" target="_blank">
+                    How to edit
+            </a></li>
+        {% endif -%}
+        {%- if (gitHubLink)  %}
+            <li><a href="{{ gitHubLink }}" rel="nofollow noopener" target="_blank">
+                    Edit current document on GitHub
+            </a></li>
+        {% endif -%}
+    </ul>
+</div>
+{% endif -%}

--- a/tests/Integration/tests-full/edit-on-github-directory/expected/Index.html
+++ b/tests/Integration/tests-full/edit-on-github-directory/expected/Index.html
@@ -79,6 +79,20 @@
         
 
     </div>
+    <div aria-label="Meta navigation" class="main_menu  d-block d-lg-none" role="navigation">
+    <hr/>
+    <p class="caption">Contributors Corner</p>
+    <ul class="menu-level-1">            <li><a href="_sources/Index.rst.txt" rel="nofollow noopener" target="_blank">
+                    View source of current document
+            </a></li>
+                    <li><a href="https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/WritingDocsOfficial/GithubMethod.html" rel="nofollow noopener" target="_blank">
+                    How to edit
+            </a></li>
+                    <li><a href="https://github.com/typo3/typo3/edit/main/typo3/sysext/adminpanel/Documentation/Index.rst" rel="nofollow noopener" target="_blank">
+                    Edit current document on GitHub
+            </a></li>
+        </ul>
+</div>
                         </div>
                     </div>
                 </nav>

--- a/tests/Integration/tests-full/edit-on-github/expected/index.html
+++ b/tests/Integration/tests-full/edit-on-github/expected/index.html
@@ -99,6 +99,20 @@
 
 
     </div>
+    <div aria-label="Meta navigation" class="main_menu  d-block d-lg-none" role="navigation">
+    <hr/>
+    <p class="caption">Contributors Corner</p>
+    <ul class="menu-level-1">            <li><a href="_sources/index.rst.txt" rel="nofollow noopener" target="_blank">
+                    View source of current document
+            </a></li>
+                    <li><a href="https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/WritingDocsOfficial/GithubMethod.html" rel="nofollow noopener" target="_blank">
+                    How to edit
+            </a></li>
+                    <li><a href="https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-CoreApi/edit/documentation-draft/Documentation/index.rst" rel="nofollow noopener" target="_blank">
+                    Edit current document on GitHub
+            </a></li>
+        </ul>
+</div>
                         </div>
                     </div>
                 </nav>

--- a/tests/Integration/tests-full/edit-on-github/expected/page1.html
+++ b/tests/Integration/tests-full/edit-on-github/expected/page1.html
@@ -100,6 +100,20 @@
 
 
     </div>
+    <div aria-label="Meta navigation" class="main_menu  d-block d-lg-none" role="navigation">
+    <hr/>
+    <p class="caption">Contributors Corner</p>
+    <ul class="menu-level-1">            <li><a href="_sources/page1.rst.txt" rel="nofollow noopener" target="_blank">
+                    View source of current document
+            </a></li>
+                    <li><a href="https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/WritingDocsOfficial/GithubMethod.html" rel="nofollow noopener" target="_blank">
+                    How to edit
+            </a></li>
+                    <li><a href="https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-CoreApi/edit/documentation-draft/Documentation/page1.rst" rel="nofollow noopener" target="_blank">
+                    Edit current document on GitHub
+            </a></li>
+        </ul>
+</div>
                         </div>
                     </div>
                 </nav>

--- a/tests/Integration/tests-full/edit-on-github/expected/subpages/index.html
+++ b/tests/Integration/tests-full/edit-on-github/expected/subpages/index.html
@@ -100,6 +100,20 @@
 
 
     </div>
+    <div aria-label="Meta navigation" class="main_menu  d-block d-lg-none" role="navigation">
+    <hr/>
+    <p class="caption">Contributors Corner</p>
+    <ul class="menu-level-1">            <li><a href="../_sources/subpages/index.rst.txt" rel="nofollow noopener" target="_blank">
+                    View source of current document
+            </a></li>
+                    <li><a href="https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/WritingDocsOfficial/GithubMethod.html" rel="nofollow noopener" target="_blank">
+                    How to edit
+            </a></li>
+                    <li><a href="https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-CoreApi/edit/documentation-draft/Documentation/subpages/index.rst" rel="nofollow noopener" target="_blank">
+                    Edit current document on GitHub
+            </a></li>
+        </ul>
+</div>
                         </div>
                     </div>
                 </nav>

--- a/tests/Integration/tests-full/index/expected/index.html
+++ b/tests/Integration/tests-full/index/expected/index.html
@@ -87,6 +87,20 @@
         
 
     </div>
+    <div aria-label="Meta navigation" class="main_menu  d-block d-lg-none" role="navigation">
+    <hr/>
+    <p class="caption">Contributors Corner</p>
+    <ul class="menu-level-1">            <li><a href="_sources/index.rst.txt" rel="nofollow noopener" target="_blank">
+                    View source of current document
+            </a></li>
+                    <li><a href="https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/WritingDocsOfficial/GithubMethod.html" rel="nofollow noopener" target="_blank">
+                    How to edit
+            </a></li>
+                    <li><a href="https://github.com/TYPO3-Documentation/render-guides/edit/main/Documentation/index.rst" rel="nofollow noopener" target="_blank">
+                    Edit current document on GitHub
+            </a></li>
+        </ul>
+</div>
                         </div>
                     </div>
                 </nav>

--- a/tests/Integration/tests-full/link-wizard/expected/index.html
+++ b/tests/Integration/tests-full/link-wizard/expected/index.html
@@ -79,6 +79,17 @@
         
 
     </div>
+    <div aria-label="Meta navigation" class="main_menu  d-block d-lg-none" role="navigation">
+    <hr/>
+    <p class="caption">Contributors Corner</p>
+    <ul class="menu-level-1">            <li><a href="_sources/index.rst.txt" rel="nofollow noopener" target="_blank">
+                    View source of current document
+            </a></li>
+                    <li><a href="https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/WritingDocsOfficial/GithubMethod.html" rel="nofollow noopener" target="_blank">
+                    How to edit
+            </a></li>
+        </ul>
+</div>
                         </div>
                     </div>
                 </nav>

--- a/tests/Integration/tests-full/menu-subpages-max-1/expected/index.html
+++ b/tests/Integration/tests-full/menu-subpages-max-1/expected/index.html
@@ -95,6 +95,17 @@
 
 
     </div>
+    <div aria-label="Meta navigation" class="main_menu  d-block d-lg-none" role="navigation">
+    <hr/>
+    <p class="caption">Contributors Corner</p>
+    <ul class="menu-level-1">            <li><a href="_sources/index.rst.txt" rel="nofollow noopener" target="_blank">
+                    View source of current document
+            </a></li>
+                    <li><a href="https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/WritingDocsOfficial/GithubMethod.html" rel="nofollow noopener" target="_blank">
+                    How to edit
+            </a></li>
+        </ul>
+</div>
                         </div>
                     </div>
                 </nav>

--- a/tests/Integration/tests-full/menu-subpages-no-titlesonly-maxdepth-1/expected/index.html
+++ b/tests/Integration/tests-full/menu-subpages-no-titlesonly-maxdepth-1/expected/index.html
@@ -107,6 +107,17 @@
 
 
     </div>
+    <div aria-label="Meta navigation" class="main_menu  d-block d-lg-none" role="navigation">
+    <hr/>
+    <p class="caption">Contributors Corner</p>
+    <ul class="menu-level-1">            <li><a href="_sources/index.rst.txt" rel="nofollow noopener" target="_blank">
+                    View source of current document
+            </a></li>
+                    <li><a href="https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/WritingDocsOfficial/GithubMethod.html" rel="nofollow noopener" target="_blank">
+                    How to edit
+            </a></li>
+        </ul>
+</div>
                         </div>
                     </div>
                 </nav>

--- a/tests/Integration/tests-full/menu-subpages-no-titlesonly-maxdepth-2/expected/index.html
+++ b/tests/Integration/tests-full/menu-subpages-no-titlesonly-maxdepth-2/expected/index.html
@@ -107,6 +107,17 @@
 
 
     </div>
+    <div aria-label="Meta navigation" class="main_menu  d-block d-lg-none" role="navigation">
+    <hr/>
+    <p class="caption">Contributors Corner</p>
+    <ul class="menu-level-1">            <li><a href="_sources/index.rst.txt" rel="nofollow noopener" target="_blank">
+                    View source of current document
+            </a></li>
+                    <li><a href="https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/WritingDocsOfficial/GithubMethod.html" rel="nofollow noopener" target="_blank">
+                    How to edit
+            </a></li>
+        </ul>
+</div>
                         </div>
                     </div>
                 </nav>

--- a/tests/Integration/tests-full/menu-subpages/expected/index.html
+++ b/tests/Integration/tests-full/menu-subpages/expected/index.html
@@ -107,6 +107,17 @@
 
 
     </div>
+    <div aria-label="Meta navigation" class="main_menu  d-block d-lg-none" role="navigation">
+    <hr/>
+    <p class="caption">Contributors Corner</p>
+    <ul class="menu-level-1">            <li><a href="_sources/index.rst.txt" rel="nofollow noopener" target="_blank">
+                    View source of current document
+            </a></li>
+                    <li><a href="https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/WritingDocsOfficial/GithubMethod.html" rel="nofollow noopener" target="_blank">
+                    How to edit
+            </a></li>
+        </ul>
+</div>
                         </div>
                     </div>
                 </nav>

--- a/tests/Integration/tests-full/meta-data/expected/index.html
+++ b/tests/Integration/tests-full/meta-data/expected/index.html
@@ -87,6 +87,20 @@
         
 
     </div>
+    <div aria-label="Meta navigation" class="main_menu  d-block d-lg-none" role="navigation">
+    <hr/>
+    <p class="caption">Contributors Corner</p>
+    <ul class="menu-level-1">            <li><a href="_sources/index.rst.txt" rel="nofollow noopener" target="_blank">
+                    View source of current document
+            </a></li>
+                    <li><a href="https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/WritingDocsOfficial/GithubMethod.html" rel="nofollow noopener" target="_blank">
+                    How to edit
+            </a></li>
+                    <li><a href="https://github.com/TYPO3-Documentation/render-guides/edit/main/Documentation/index.rst" rel="nofollow noopener" target="_blank">
+                    Edit current document on GitHub
+            </a></li>
+        </ul>
+</div>
                         </div>
                     </div>
                 </nav>

--- a/tests/Integration/tests-full/next-prev-by-toctree/expected/four.html
+++ b/tests/Integration/tests-full/next-prev-by-toctree/expected/four.html
@@ -108,6 +108,17 @@
 
 
     </div>
+    <div aria-label="Meta navigation" class="main_menu  d-block d-lg-none" role="navigation">
+    <hr/>
+    <p class="caption">Contributors Corner</p>
+    <ul class="menu-level-1">            <li><a href="_sources/four.rst.txt" rel="nofollow noopener" target="_blank">
+                    View source of current document
+            </a></li>
+                    <li><a href="https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/WritingDocsOfficial/GithubMethod.html" rel="nofollow noopener" target="_blank">
+                    How to edit
+            </a></li>
+        </ul>
+</div>
                         </div>
                     </div>
                 </nav>

--- a/tests/Integration/tests-full/next-prev-by-toctree/expected/i.html
+++ b/tests/Integration/tests-full/next-prev-by-toctree/expected/i.html
@@ -108,6 +108,17 @@
 
 
     </div>
+    <div aria-label="Meta navigation" class="main_menu  d-block d-lg-none" role="navigation">
+    <hr/>
+    <p class="caption">Contributors Corner</p>
+    <ul class="menu-level-1">            <li><a href="_sources/i.rst.txt" rel="nofollow noopener" target="_blank">
+                    View source of current document
+            </a></li>
+                    <li><a href="https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/WritingDocsOfficial/GithubMethod.html" rel="nofollow noopener" target="_blank">
+                    How to edit
+            </a></li>
+        </ul>
+</div>
                         </div>
                     </div>
                 </nav>

--- a/tests/Integration/tests-full/next-prev-by-toctree/expected/index.html
+++ b/tests/Integration/tests-full/next-prev-by-toctree/expected/index.html
@@ -107,6 +107,17 @@
 
 
     </div>
+    <div aria-label="Meta navigation" class="main_menu  d-block d-lg-none" role="navigation">
+    <hr/>
+    <p class="caption">Contributors Corner</p>
+    <ul class="menu-level-1">            <li><a href="_sources/index.rst.txt" rel="nofollow noopener" target="_blank">
+                    View source of current document
+            </a></li>
+                    <li><a href="https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/WritingDocsOfficial/GithubMethod.html" rel="nofollow noopener" target="_blank">
+                    How to edit
+            </a></li>
+        </ul>
+</div>
                         </div>
                     </div>
                 </nav>

--- a/tests/Integration/tests-full/next-prev-by-toctree/expected/one.html
+++ b/tests/Integration/tests-full/next-prev-by-toctree/expected/one.html
@@ -108,6 +108,17 @@
 
 
     </div>
+    <div aria-label="Meta navigation" class="main_menu  d-block d-lg-none" role="navigation">
+    <hr/>
+    <p class="caption">Contributors Corner</p>
+    <ul class="menu-level-1">            <li><a href="_sources/one.rst.txt" rel="nofollow noopener" target="_blank">
+                    View source of current document
+            </a></li>
+                    <li><a href="https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/WritingDocsOfficial/GithubMethod.html" rel="nofollow noopener" target="_blank">
+                    How to edit
+            </a></li>
+        </ul>
+</div>
                         </div>
                     </div>
                 </nav>

--- a/tests/Integration/tests-full/next-prev-by-toctree/expected/three/index.html
+++ b/tests/Integration/tests-full/next-prev-by-toctree/expected/three/index.html
@@ -108,6 +108,17 @@
 
 
     </div>
+    <div aria-label="Meta navigation" class="main_menu  d-block d-lg-none" role="navigation">
+    <hr/>
+    <p class="caption">Contributors Corner</p>
+    <ul class="menu-level-1">            <li><a href="../_sources/three/index.rst.txt" rel="nofollow noopener" target="_blank">
+                    View source of current document
+            </a></li>
+                    <li><a href="https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/WritingDocsOfficial/GithubMethod.html" rel="nofollow noopener" target="_blank">
+                    How to edit
+            </a></li>
+        </ul>
+</div>
                         </div>
                     </div>
                 </nav>

--- a/tests/Integration/tests-full/next-prev-by-toctree/expected/three/pi.html
+++ b/tests/Integration/tests-full/next-prev-by-toctree/expected/three/pi.html
@@ -107,6 +107,17 @@
 
 
     </div>
+    <div aria-label="Meta navigation" class="main_menu  d-block d-lg-none" role="navigation">
+    <hr/>
+    <p class="caption">Contributors Corner</p>
+    <ul class="menu-level-1">            <li><a href="../_sources/three/pi.rst.txt" rel="nofollow noopener" target="_blank">
+                    View source of current document
+            </a></li>
+                    <li><a href="https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/WritingDocsOfficial/GithubMethod.html" rel="nofollow noopener" target="_blank">
+                    How to edit
+            </a></li>
+        </ul>
+</div>
                         </div>
                     </div>
                 </nav>

--- a/tests/Integration/tests-full/next-prev-by-toctree/expected/three/three.html
+++ b/tests/Integration/tests-full/next-prev-by-toctree/expected/three/three.html
@@ -108,6 +108,17 @@
 
 
     </div>
+    <div aria-label="Meta navigation" class="main_menu  d-block d-lg-none" role="navigation">
+    <hr/>
+    <p class="caption">Contributors Corner</p>
+    <ul class="menu-level-1">            <li><a href="../_sources/three/three.rst.txt" rel="nofollow noopener" target="_blank">
+                    View source of current document
+            </a></li>
+                    <li><a href="https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/WritingDocsOfficial/GithubMethod.html" rel="nofollow noopener" target="_blank">
+                    How to edit
+            </a></li>
+        </ul>
+</div>
                         </div>
                     </div>
                 </nav>

--- a/tests/Integration/tests-full/next-prev-by-toctree/expected/three/threepointfive.html
+++ b/tests/Integration/tests-full/next-prev-by-toctree/expected/three/threepointfive.html
@@ -108,6 +108,17 @@
 
 
     </div>
+    <div aria-label="Meta navigation" class="main_menu  d-block d-lg-none" role="navigation">
+    <hr/>
+    <p class="caption">Contributors Corner</p>
+    <ul class="menu-level-1">            <li><a href="../_sources/three/threepointfive.rst.txt" rel="nofollow noopener" target="_blank">
+                    View source of current document
+            </a></li>
+                    <li><a href="https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/WritingDocsOfficial/GithubMethod.html" rel="nofollow noopener" target="_blank">
+                    How to edit
+            </a></li>
+        </ul>
+</div>
                         </div>
                     </div>
                 </nav>

--- a/tests/Integration/tests-full/next-prev-by-toctree/expected/two.html
+++ b/tests/Integration/tests-full/next-prev-by-toctree/expected/two.html
@@ -108,6 +108,17 @@
 
 
     </div>
+    <div aria-label="Meta navigation" class="main_menu  d-block d-lg-none" role="navigation">
+    <hr/>
+    <p class="caption">Contributors Corner</p>
+    <ul class="menu-level-1">            <li><a href="_sources/two.rst.txt" rel="nofollow noopener" target="_blank">
+                    View source of current document
+            </a></li>
+                    <li><a href="https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/WritingDocsOfficial/GithubMethod.html" rel="nofollow noopener" target="_blank">
+                    How to edit
+            </a></li>
+        </ul>
+</div>
                         </div>
                     </div>
                 </nav>

--- a/tests/Integration/tests-full/next-prev/expected/index.html
+++ b/tests/Integration/tests-full/next-prev/expected/index.html
@@ -91,6 +91,17 @@
 
 
     </div>
+    <div aria-label="Meta navigation" class="main_menu  d-block d-lg-none" role="navigation">
+    <hr/>
+    <p class="caption">Contributors Corner</p>
+    <ul class="menu-level-1">            <li><a href="_sources/index.rst.txt" rel="nofollow noopener" target="_blank">
+                    View source of current document
+            </a></li>
+                    <li><a href="https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/WritingDocsOfficial/GithubMethod.html" rel="nofollow noopener" target="_blank">
+                    How to edit
+            </a></li>
+        </ul>
+</div>
                         </div>
                     </div>
                 </nav>

--- a/tests/Integration/tests-full/next-prev/expected/page.html
+++ b/tests/Integration/tests-full/next-prev/expected/page.html
@@ -92,6 +92,17 @@
 
 
     </div>
+    <div aria-label="Meta navigation" class="main_menu  d-block d-lg-none" role="navigation">
+    <hr/>
+    <p class="caption">Contributors Corner</p>
+    <ul class="menu-level-1">            <li><a href="_sources/page.rst.txt" rel="nofollow noopener" target="_blank">
+                    View source of current document
+            </a></li>
+                    <li><a href="https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/WritingDocsOfficial/GithubMethod.html" rel="nofollow noopener" target="_blank">
+                    How to edit
+            </a></li>
+        </ul>
+</div>
                         </div>
                     </div>
                 </nav>

--- a/tests/Integration/tests-full/next-prev/expected/yetAnotherPage.html
+++ b/tests/Integration/tests-full/next-prev/expected/yetAnotherPage.html
@@ -91,6 +91,17 @@
 
 
     </div>
+    <div aria-label="Meta navigation" class="main_menu  d-block d-lg-none" role="navigation">
+    <hr/>
+    <p class="caption">Contributors Corner</p>
+    <ul class="menu-level-1">            <li><a href="_sources/yetAnotherPage.rst.txt" rel="nofollow noopener" target="_blank">
+                    View source of current document
+            </a></li>
+                    <li><a href="https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/WritingDocsOfficial/GithubMethod.html" rel="nofollow noopener" target="_blank">
+                    How to edit
+            </a></li>
+        </ul>
+</div>
                         </div>
                     </div>
                 </nav>

--- a/tests/Integration/tests-full/page-with-subpages/expected/index.html
+++ b/tests/Integration/tests-full/page-with-subpages/expected/index.html
@@ -87,6 +87,17 @@
 
 
     </div>
+    <div aria-label="Meta navigation" class="main_menu  d-block d-lg-none" role="navigation">
+    <hr/>
+    <p class="caption">Contributors Corner</p>
+    <ul class="menu-level-1">            <li><a href="_sources/index.rst.txt" rel="nofollow noopener" target="_blank">
+                    View source of current document
+            </a></li>
+                    <li><a href="https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/WritingDocsOfficial/GithubMethod.html" rel="nofollow noopener" target="_blank">
+                    How to edit
+            </a></li>
+        </ul>
+</div>
                         </div>
                     </div>
                 </nav>

--- a/tests/Integration/tests-full/page-with-subpages/expected/sub/index.html
+++ b/tests/Integration/tests-full/page-with-subpages/expected/sub/index.html
@@ -87,6 +87,17 @@
 
 
     </div>
+    <div aria-label="Meta navigation" class="main_menu  d-block d-lg-none" role="navigation">
+    <hr/>
+    <p class="caption">Contributors Corner</p>
+    <ul class="menu-level-1">            <li><a href="../_sources/sub/index.rst.txt" rel="nofollow noopener" target="_blank">
+                    View source of current document
+            </a></li>
+                    <li><a href="https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/WritingDocsOfficial/GithubMethod.html" rel="nofollow noopener" target="_blank">
+                    How to edit
+            </a></li>
+        </ul>
+</div>
                         </div>
                     </div>
                 </nav>

--- a/tests/Integration/tests-full/two-toctrees/expected/index.html
+++ b/tests/Integration/tests-full/two-toctrees/expected/index.html
@@ -106,6 +106,20 @@
 
 
     </div>
+    <div aria-label="Meta navigation" class="main_menu  d-block d-lg-none" role="navigation">
+    <hr/>
+    <p class="caption">Contributors Corner</p>
+    <ul class="menu-level-1">            <li><a href="_sources/index.rst.txt" rel="nofollow noopener" target="_blank">
+                    View source of current document
+            </a></li>
+                    <li><a href="https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/WritingDocsOfficial/GithubMethod.html" rel="nofollow noopener" target="_blank">
+                    How to edit
+            </a></li>
+                    <li><a href="https://github.com/TYPO3-Documentation/render-guides/edit/main/Documentation/index.rst" rel="nofollow noopener" target="_blank">
+                    Edit current document on GitHub
+            </a></li>
+        </ul>
+</div>
                         </div>
                     </div>
                 </nav>


### PR DESCRIPTION
Adds a "Contributors Corner" to the mobile menu:

![image](https://github.com/TYPO3-Documentation/render-guides/assets/48202465/83b9d7f3-a25d-40f5-8672-e104f7259c8e)

resolves https://github.com/TYPO3-Documentation/render-guides/issues/377