### PR TITLE
[BUGFIX] Raise docker memory limit to 4G

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ COPY . /opt/guides
 WORKDIR /opt/guides
 
 COPY --from=Builder /opt/guides/vendor /opt/guides/vendor
-RUN echo "memory_limit=1G" >> /usr/local/etc/php/conf.d/typo3.ini
+RUN echo "memory_limit=4G" >> /usr/local/etc/php/conf.d/typo3.ini
 
 ARG TYPO3AZUREEDGEURIVERSION
 ENV TYPO3AZUREEDGEURIVERSION=$TYPO3AZUREEDGEURIVERSION


### PR DESCRIPTION
The Changelog rendering takes up a lot of memory, and thus cannot be done with the current 1G limit.

A change in guides:1.1.0 introduced caching, and that cache takes up a lot of space.

Native/local rendering often has no PHP memory limit set, so this may not apply to CI/development.