### PR TITLE
[TASK] Overhaul the confval examples

### DIFF
--- a/Documentation-rendertest/Confval/Index.rst
+++ b/Documentation-rendertest/Confval/Index.rst
@@ -1,35 +1,24 @@
-.. include:: /Includes.rst.txt
-.. index:: ! confval
-.. _confval:
+..  include:: /Includes.rst.txt
+..  index:: ! confval
+..  _confval:
 
-=========================
+=======
 confval
-=========================
+=======
 
-.. contents:: This page
-   :backlinks: top
-   :class: compact-list
-   :depth: 99
-   :local:
+..  contents:: This page
+    :local:
 
 
 Summary
 =======
 
-`.. confval::` is the directive.
+`..  confval::` is the directive.
 
 `:confval:` is a text role to create a reference to the description.
 
 
-Examples:
-
-*  A page where sphinx-doc.org uses the `:confval` directive:
-   https://www.sphinx-doc.org/en/master/usage/configuration.html
-   \• `rst-source
-   <http://www.sphinx-doc.org/en/master/_sources/usage/configuration.rst.txt>`__
-
-*  See long list of automatic entries for "configuration value" in the index:
-   https://www.sphinx-doc.org/en/master/genindex.html#C
+See also https://sphinx-toolbox.readthedocs.io/en/stable/extensions/confval.html#directive-option-confval-noindex
 
 
 Demo 1
@@ -37,23 +26,21 @@ Demo 1
 
 Source:
 
-.. code-block:: rst
+..  code-block:: rst
 
-   .. confval:: mr_pommeroy
+    ..  confval:: mr_pommeroy
+        :default: Happy new year, Sophie!
+        :type:     shy
 
-      :default: Happy new year, Sophie!
-      :type:    shy
-
-      Participant of Miss Sophie's birthday party.
+        Participant of Miss Sophie's birthday party.
 
 Result:
 
-.. confval:: mr_pommeroy
+..  confval:: mr_pommeroy
+    :default: Happy new year, Sophie!
+    :type:     shy
 
-   :default: Happy new year, Sophie!
-   :type:    shy
-
-   Participant of Miss Sophie's birthday party.
+    Participant of Miss Sophie's birthday party.
 
 You can easily link to the description of a 'confval' by means of the
 `:confval:` text role. Example: Here is a link to :confval:`mr_pommeroy`.
@@ -63,91 +50,118 @@ You can easily link to the description of a 'confval' by means of the
 Demo 2
 ======
 
-.. highlight:: typoscript
+..  highlight:: typoscript
 
 Adapted from the TypoScript Reference Manual:
 
-.. confval:: align
+..  confval:: align
+    :type:     align
+    :default: left
+    :Possible: \left | \center \| right
 
-   :type:    align
-   :default: left
-   :Possible: \left | \center \| right
+    Decides about alignment.
 
-   Decides about alignment.
+    Example::
 
-   Example::
-
-      10.align = right
-
-
-
-.. confval:: boolean
-
-   :type: boolean
-   :Possible: 1 | 0
-
-   1 means TRUE and 0 means FALSE.
-
-   Everything else is evaluated to one of these values by PHP:
-   Non-empty strings (except `0` [zero]) are treated as TRUE,
-   empty strings are evaluated to FALSE.
-
-   Examples::
-
-      dummy.enable = 0   # false, preferred notation
-      dummy.enable = 1   # true,  preferred notation
-      dummy.enable =     # false, because the value is empty
+        10.align = right
 
 
 
-.. confval:: case
+..  confval:: boolean
+    :type: boolean
+    :Possible: 1 | 0
 
-   :type: case
-   :Possible:
-      ===================== ==========================================================
-      Value                 Effect
-      ===================== ==========================================================
-      :ts:`upper`           Convert all letters of the string to upper case
-      :ts:`lower`           Convert all letters of the string to lower case
-      :ts:`capitalize`      Uppercase the first character of each word in the string
-      :ts:`ucfirst`         Convert the first letter of the string to upper case
-      :ts:`lcfirst`         Convert the first letter of the string to lower case
-      :ts:`uppercamelcase`  Convert underscored `upper_camel_case` to `UpperCamelCase`
-      :ts:`lowercamelcase`  Convert underscored `lower_camel_case` to `lowerCamelCase`
-      ===================== ==========================================================
+    1 means TRUE and 0 means FALSE.
 
-   Do a case conversion.
+    Everything else is evaluated to one of these values by PHP:
+    Non-empty strings (except `0` [zero]) are treated as TRUE,
+    empty strings are evaluated to FALSE.
 
-   Example code::
+    Examples::
 
-      10 = TEXT
-      10.value = Hello world!
-      10.case = upper
-
-   Result::
-
-      HELLO WORLD!
+        dummy.enable = 0    # false, preferred notation
+        dummy.enable = 1    # true,  preferred notation
+        dummy.enable =      # false, because the value is empty
 
 
-.. _Demo 3 - addRecord:
+
+..  confval:: case
+
+    :type: case
+    :Possible:
+        ===================== ==========================================================
+        Value                 Effect
+        ===================== ==========================================================
+        :ts:`upper`           Convert all letters of the string to upper case
+        :ts:`lower`           Convert all letters of the string to lower case
+        :ts:`capitalize`      Uppercase the first character of each word in the string
+        :ts:`ucfirst`         Convert the first letter of the string to upper case
+        :ts:`lcfirst`         Convert the first letter of the string to lower case
+        :ts:`uppercamelcase`  Convert underscored `upper_camel_case` to `UpperCamelCase`
+        :ts:`lowercamelcase`  Convert underscored `lower_camel_case` to `lowerCamelCase`
+        ===================== ==========================================================
+
+    Do a case conversion.
+
+    Example code::
+
+        10 = TEXT
+        10.value = Hello world!
+        10.case = upper
+
+    Result::
+
+        HELLO WORLD!
+
+
+..  _Demo 3 - addRecord:
 
 Demo 3 - addRecord
 ==================
 
-.. confval:: addRecord
+..  confval:: addRecord
+    :type: array
+    :Scope: fieldControl
+    :Types: :ref:`group <Demo 3 - addRecord>`
 
-   :type: array
-   :Scope: fieldControl
-   :Types: :ref:`group <Demo 3 - addRecord>`
+    Control button to directly add a related record. Leaves the current view and opens a new form to add
+    a new record. On 'Save and close', the record is directly selected as referenced element
+    in the `type='group'` field. If multiple tables are :ref:`allowed <Demo 3 - addRecord>`, the
+    first table from the allowed list is selected, if no specific `table` option is given.
 
-   Control button to directly add a related record. Leaves the current view and opens a new form to add
-   a new record. On 'Save and close', the record is directly selected as referenced element
-   in the `type='group'` field. If multiple tables are :ref:`allowed <Demo 3 - addRecord>`, the
-   first table from the allowed list is selected, if no specific `table` option is given.
+    ..  note::
 
-   .. note::
+        The add record control is disabled by default, enable it if needed. It
+        is shown below the `edit popup` control if not changed by `below` or
+        `after` settings.
 
-      The add record control is disabled by default, enable it if needed. It
-      is shown below the `edit popup` control if not changed by `below` or
-      `after` settings.
 
+Confval with name
+=================
+
+..  confval:: addRecord
+    :name: another-context-addRecord
+    :type: array
+    :Scope: fieldControl
+    :Types: :ref:`group <Demo 3 - addRecord>`
+
+    Lorem Ipsum
+
+Link here with :confval:`another-context-addRecord`, link to the one above with
+:confval:`addRecord`.
+
+..  _confval-with-noindex:
+
+Confval with noindex
+====================
+
+..  confval:: addRecord
+    :noindex:
+    :type: array
+    :Scope: fieldControl
+    :Types: :ref:`group <Demo 3 - addRecord>`
+
+    Lorem Ipsum
+
+You cannot link here with the `:confval:` textrole, but only with `:ref:` to the
+reference above it. :ref:`confval-with-noindex`.


### PR DESCRIPTION
Use a directive with options as is done for sphinx: https://sphinx-toolbox.readthedocs.io/en/stable/extensions/confval.html#directive-option-confval-noindex

Demonstrate noindex and name options.

The style when options is used needs some overhaul, see #466

The permalink dialoge also needs to be adjusted for confvals with noindex option set: #467