### PR TITLE
[BUGFIX] Adjust HTML of confval options

### DIFF
--- a/packages/typo3-docs-theme/resources/template/body/directive/confval.html.twig
+++ b/packages/typo3-docs-theme/resources/template/body/directive/confval.html.twig
@@ -4,18 +4,30 @@
         <a class="headerlink" href="#{{ node.id }}" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-rstCode="{{ getRstCodeForLink(node) }}"  title="Reference this configuration value">¶</a>
     </dt>
     <dd>
-        <div class="line-block">
-            {% if node.type != null %} <div class="line"><strong>Type:</strong>  {{ renderNode(node.type) }}</div>
+        {% if node.type or node.required or node.default or node.additionalOptions %}
+        <dl class="field-list simple">
+            {% if node.type != null %}
+                <dt class="field-even">Type</dt>
+                <dd class="field-even">{{ renderNode(node.type) }}
+                </dd>
             {% endif -%}
-            {%- if node.required %} <div class="line"><strong>Required:</strong> true</div>
+            {%- if node.required %}
+            <dt class="field-odd">Required</dt>
+            <dd class="field-odd"><p>true</p>
+            </dd>
             {% endif -%}
-            {% if node.default != null %} <div class="line"><strong>Type:</strong>  {{ renderNode(node.default) }}</div>
+            {% if node.default != null %}
+            <dt class="field-odd">Default</dt>
+            <dd class="field-odd">{{ renderNode(node.default) }}
+            </dd>
             {% endif -%}
             {%- for key, option in node.additionalOptions -%}
-                <div class="line"><strong>{{ key }}:</strong> {{  renderNode(option) }}</div>
-
+                <dt class="field-even">{{ key }}</dt>
+                <dd class="field-even">{{  renderNode(option) }}
+                </dd>
             {% endfor -%}
-        </div>
+        </dl>
+        {% endif %}
         <div class="confval-description">
             {{ renderNode(node.value) }}
         </div>

--- a/tests/Integration/tests/confval/confval-basic/expected/index.html
+++ b/tests/Integration/tests/confval/confval-basic/expected/index.html
@@ -7,11 +7,15 @@
         <a class="headerlink" href="#demo" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-rstCode=":confval:`demo &lt;somemanual:demo&gt;`"  title="Reference this configuration value">¶</a>
     </dt>
     <dd>
-        <div class="line-block">
-             <div class="line"><strong>Type:</strong>  <code>&quot;Hello World&quot;</code></div>
-             <div class="line"><strong>Required:</strong> true</div>
-            </div>
-        <div class="confval-description">
+                <dl class="field-list simple">
+                            <dt class="field-even">Type</dt>
+                <dd class="field-even"><code>&quot;Hello World&quot;</code>
+                </dd>
+                        <dt class="field-odd">Required</dt>
+            <dd class="field-odd"><p>true</p>
+            </dd>
+            </dl>
+                <div class="confval-description">
 
     <p>Some Text</p>
 

--- a/tests/Integration/tests/confval/confval-duplicate-with-name/expected/anotherDomain.html
+++ b/tests/Integration/tests/confval/confval-duplicate-with-name/expected/anotherDomain.html
@@ -7,11 +7,15 @@
         <a class="headerlink" href="#another-demo" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-rstCode=":confval:`demo &lt;somemanual:another-demo&gt;`"  title="Reference this configuration value">¶</a>
     </dt>
     <dd>
-        <div class="line-block">
-             <div class="line"><strong>Type:</strong>  <code>&quot;Hello World&quot;</code></div>
-             <div class="line"><strong>Required:</strong> true</div>
-            </div>
-        <div class="confval-description">
+                <dl class="field-list simple">
+                            <dt class="field-even">Type</dt>
+                <dd class="field-even"><code>&quot;Hello World&quot;</code>
+                </dd>
+                        <dt class="field-odd">Required</dt>
+            <dd class="field-odd"><p>true</p>
+            </dd>
+            </dl>
+                <div class="confval-description">
 
     <p>Some Text</p>
 

--- a/tests/Integration/tests/confval/confval-duplicate-with-name/expected/index.html
+++ b/tests/Integration/tests/confval/confval-duplicate-with-name/expected/index.html
@@ -7,11 +7,15 @@
         <a class="headerlink" href="#demo" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-rstCode=":confval:`demo &lt;somemanual:demo&gt;`"  title="Reference this configuration value">¶</a>
     </dt>
     <dd>
-        <div class="line-block">
-             <div class="line"><strong>Type:</strong>  <code>&quot;Hello World&quot;</code></div>
-             <div class="line"><strong>Required:</strong> true</div>
-            </div>
-        <div class="confval-description">
+                <dl class="field-list simple">
+                            <dt class="field-even">Type</dt>
+                <dd class="field-even"><code>&quot;Hello World&quot;</code>
+                </dd>
+                        <dt class="field-odd">Required</dt>
+            <dd class="field-odd"><p>true</p>
+            </dd>
+            </dl>
+                <div class="confval-description">
 
     <p>Some Text</p>
 

--- a/tests/Integration/tests/confval/confval-duplicate/expected/anotherDomain.html
+++ b/tests/Integration/tests/confval/confval-duplicate/expected/anotherDomain.html
@@ -7,11 +7,15 @@
         <a class="headerlink" href="#demo" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-rstCode=":confval:`demo &lt;somemanual:demo&gt;`"  title="Reference this configuration value">¶</a>
     </dt>
     <dd>
-        <div class="line-block">
-             <div class="line"><strong>Type:</strong>  <code>&quot;Hello World&quot;</code></div>
-             <div class="line"><strong>Required:</strong> true</div>
-            </div>
-        <div class="confval-description">
+                <dl class="field-list simple">
+                            <dt class="field-even">Type</dt>
+                <dd class="field-even"><code>&quot;Hello World&quot;</code>
+                </dd>
+                        <dt class="field-odd">Required</dt>
+            <dd class="field-odd"><p>true</p>
+            </dd>
+            </dl>
+                <div class="confval-description">
 
     <p>Some Text</p>
 

--- a/tests/Integration/tests/confval/confval-duplicate/expected/index.html
+++ b/tests/Integration/tests/confval/confval-duplicate/expected/index.html
@@ -7,11 +7,15 @@
         <a class="headerlink" href="#demo" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-rstCode=":confval:`demo &lt;somemanual:demo&gt;`"  title="Reference this configuration value">¶</a>
     </dt>
     <dd>
-        <div class="line-block">
-             <div class="line"><strong>Type:</strong>  <code>&quot;Hello World&quot;</code></div>
-             <div class="line"><strong>Required:</strong> true</div>
-            </div>
-        <div class="confval-description">
+                <dl class="field-list simple">
+                            <dt class="field-even">Type</dt>
+                <dd class="field-even"><code>&quot;Hello World&quot;</code>
+                </dd>
+                        <dt class="field-odd">Required</dt>
+            <dd class="field-odd"><p>true</p>
+            </dd>
+            </dl>
+                <div class="confval-description">
 
     <p>Some Text</p>
 


### PR DESCRIPTION
Style the options of the confval directive that are displayed as a fieldlist.

Resolves https://github.com/TYPO3-Documentation/render-guides/issues/466

After: 
![image](https://github.com/TYPO3-Documentation/render-guides/assets/48202465/3a0a98b0-7c78-495f-b8b1-70601ba7c416)

Before:
![image](https://github.com/TYPO3-Documentation/render-guides/assets/48202465/93f1bc22-8310-4e30-92a9-c9187358e93d)
