### PR TITLE
[TASK] Disables tracking when locally rendered

### DIFF
--- a/packages/typo3-docs-theme/resources/template/structure/layoutParts/footerAssets.html.twig
+++ b/packages/typo3-docs-theme/resources/template/structure/layoutParts/footerAssets.html.twig
@@ -3,16 +3,22 @@
 <script src="{{ getRelativePath('_resources/js/bootstrap.min.js') }}"></script>
 <script src="{{ getRelativePath('_resources/js/theme.min.js') }}"></script>
 
+{% if isRenderedForDeployment() %}
 <script id="R9wBKTwzv" src="https://app.usercentrics.eu/latest/main.js"></script>
 {# Matomo is an absolute link on the server #}
 <script data-usercentrics="Matomo" src="/js/piwik.js" type="text/plain"></script>
 
 {#
     Google Tag Manager
-    It is responsible for the Adds by TYPO3 GmbH
+    It is responsible for the ads by TYPO3 GmbH
 #}
 <script type="text/plain" data-usercentrics="Google Tag Manager">(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
 j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
 })(window,document,'script','dataLayer','GTM-MKNXD8Q');</script>
+{% else %}
+<!--
+ Locally rendered. No tracking embedded.
+-->
+{% endif %}

--- a/packages/typo3-docs-theme/src/Twig/TwigExtension.php
+++ b/packages/typo3-docs-theme/src/Twig/TwigExtension.php
@@ -60,6 +60,7 @@ final class TwigExtension extends AbstractExtension
             new TwigFunction('copyDownload', $this->copyDownload(...), ['is_safe' => ['html'], 'needs_context' => true]),
             new TwigFunction('getStandardInventories', $this->getStandardInventories(...), ['is_safe' => ['html'], 'needs_context' => true]),
             new TwigFunction('getRstCodeForLink', $this->getRstCodeForLink(...), ['is_safe' => [], 'needs_context' => true]),
+            new TwigFunction('isRenderedForDeployment', $this->isRenderedForDeployment(...)),
         ];
     }
 
@@ -326,5 +327,14 @@ final class TwigExtension extends AbstractExtension
             }
         }
         return $pagerList;
+    }
+
+    public function isRenderedForDeployment(): bool
+    {
+        if ($this->typo3AzureEdgeURI !== '') {
+            return true;
+        }
+
+        return false;
     }
 }

--- a/tests/Integration/tests-full/edit-on-github-directory/expected/Index.html
+++ b/tests/Integration/tests-full/edit-on-github-directory/expected/Index.html
@@ -199,12 +199,8 @@
 <script src="_resources/js/bootstrap.min.js"></script>
 <script src="_resources/js/theme.min.js"></script>
 
-<script id="R9wBKTwzv" src="https://app.usercentrics.eu/latest/main.js"></script>
-<script data-usercentrics="Matomo" src="/js/piwik.js" type="text/plain"></script>
-
-<script type="text/plain" data-usercentrics="Google Tag Manager">(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','GTM-MKNXD8Q');</script></body>
+<!--
+ Locally rendered. No tracking embedded.
+-->
+</body>
 </html>

--- a/tests/Integration/tests-full/edit-on-github/expected/index.html
+++ b/tests/Integration/tests-full/edit-on-github/expected/index.html
@@ -248,12 +248,8 @@
 <script src="_resources/js/bootstrap.min.js"></script>
 <script src="_resources/js/theme.min.js"></script>
 
-<script id="R9wBKTwzv" src="https://app.usercentrics.eu/latest/main.js"></script>
-<script data-usercentrics="Matomo" src="/js/piwik.js" type="text/plain"></script>
-
-<script type="text/plain" data-usercentrics="Google Tag Manager">(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','GTM-MKNXD8Q');</script></body>
+<!--
+ Locally rendered. No tracking embedded.
+-->
+</body>
 </html>

--- a/tests/Integration/tests-full/edit-on-github/expected/page1.html
+++ b/tests/Integration/tests-full/edit-on-github/expected/page1.html
@@ -231,12 +231,8 @@
 <script src="_resources/js/bootstrap.min.js"></script>
 <script src="_resources/js/theme.min.js"></script>
 
-<script id="R9wBKTwzv" src="https://app.usercentrics.eu/latest/main.js"></script>
-<script data-usercentrics="Matomo" src="/js/piwik.js" type="text/plain"></script>
-
-<script type="text/plain" data-usercentrics="Google Tag Manager">(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','GTM-MKNXD8Q');</script></body>
+<!--
+ Locally rendered. No tracking embedded.
+-->
+</body>
 </html>

--- a/tests/Integration/tests-full/edit-on-github/expected/subpages/index.html
+++ b/tests/Integration/tests-full/edit-on-github/expected/subpages/index.html
@@ -232,12 +232,8 @@
 <script src="../_resources/js/bootstrap.min.js"></script>
 <script src="../_resources/js/theme.min.js"></script>
 
-<script id="R9wBKTwzv" src="https://app.usercentrics.eu/latest/main.js"></script>
-<script data-usercentrics="Matomo" src="/js/piwik.js" type="text/plain"></script>
-
-<script type="text/plain" data-usercentrics="Google Tag Manager">(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','GTM-MKNXD8Q');</script></body>
+<!--
+ Locally rendered. No tracking embedded.
+-->
+</body>
 </html>

--- a/tests/Integration/tests-full/index/expected/index.html
+++ b/tests/Integration/tests-full/index/expected/index.html
@@ -207,12 +207,8 @@
 <script src="_resources/js/bootstrap.min.js"></script>
 <script src="_resources/js/theme.min.js"></script>
 
-<script id="R9wBKTwzv" src="https://app.usercentrics.eu/latest/main.js"></script>
-<script data-usercentrics="Matomo" src="/js/piwik.js" type="text/plain"></script>
-
-<script type="text/plain" data-usercentrics="Google Tag Manager">(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','GTM-MKNXD8Q');</script></body>
+<!--
+ Locally rendered. No tracking embedded.
+-->
+</body>
 </html>

--- a/tests/Integration/tests-full/link-wizard/expected/index.html
+++ b/tests/Integration/tests-full/link-wizard/expected/index.html
@@ -199,12 +199,8 @@
 <script src="_resources/js/bootstrap.min.js"></script>
 <script src="_resources/js/theme.min.js"></script>
 
-<script id="R9wBKTwzv" src="https://app.usercentrics.eu/latest/main.js"></script>
-<script data-usercentrics="Matomo" src="/js/piwik.js" type="text/plain"></script>
-
-<script type="text/plain" data-usercentrics="Google Tag Manager">(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','GTM-MKNXD8Q');</script></body>
+<!--
+ Locally rendered. No tracking embedded.
+-->
+</body>
 </html>

--- a/tests/Integration/tests-full/menu-subpages-max-1/expected/index.html
+++ b/tests/Integration/tests-full/menu-subpages-max-1/expected/index.html
@@ -224,12 +224,8 @@
 <script src="_resources/js/bootstrap.min.js"></script>
 <script src="_resources/js/theme.min.js"></script>
 
-<script id="R9wBKTwzv" src="https://app.usercentrics.eu/latest/main.js"></script>
-<script data-usercentrics="Matomo" src="/js/piwik.js" type="text/plain"></script>
-
-<script type="text/plain" data-usercentrics="Google Tag Manager">(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','GTM-MKNXD8Q');</script></body>
+<!--
+ Locally rendered. No tracking embedded.
+-->
+</body>
 </html>

--- a/tests/Integration/tests-full/menu-subpages-no-titlesonly-maxdepth-1/expected/index.html
+++ b/tests/Integration/tests-full/menu-subpages-no-titlesonly-maxdepth-1/expected/index.html
@@ -233,12 +233,8 @@
 <script src="_resources/js/bootstrap.min.js"></script>
 <script src="_resources/js/theme.min.js"></script>
 
-<script id="R9wBKTwzv" src="https://app.usercentrics.eu/latest/main.js"></script>
-<script data-usercentrics="Matomo" src="/js/piwik.js" type="text/plain"></script>
-
-<script type="text/plain" data-usercentrics="Google Tag Manager">(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','GTM-MKNXD8Q');</script></body>
+<!--
+ Locally rendered. No tracking embedded.
+-->
+</body>
 </html>

--- a/tests/Integration/tests-full/menu-subpages-no-titlesonly-maxdepth-2/expected/index.html
+++ b/tests/Integration/tests-full/menu-subpages-no-titlesonly-maxdepth-2/expected/index.html
@@ -250,12 +250,8 @@
 <script src="_resources/js/bootstrap.min.js"></script>
 <script src="_resources/js/theme.min.js"></script>
 
-<script id="R9wBKTwzv" src="https://app.usercentrics.eu/latest/main.js"></script>
-<script data-usercentrics="Matomo" src="/js/piwik.js" type="text/plain"></script>
-
-<script type="text/plain" data-usercentrics="Google Tag Manager">(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','GTM-MKNXD8Q');</script></body>
+<!--
+ Locally rendered. No tracking embedded.
+-->
+</body>
 </html>

--- a/tests/Integration/tests-full/menu-subpages/expected/index.html
+++ b/tests/Integration/tests-full/menu-subpages/expected/index.html
@@ -233,12 +233,8 @@
 <script src="_resources/js/bootstrap.min.js"></script>
 <script src="_resources/js/theme.min.js"></script>
 
-<script id="R9wBKTwzv" src="https://app.usercentrics.eu/latest/main.js"></script>
-<script data-usercentrics="Matomo" src="/js/piwik.js" type="text/plain"></script>
-
-<script type="text/plain" data-usercentrics="Google Tag Manager">(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','GTM-MKNXD8Q');</script></body>
+<!--
+ Locally rendered. No tracking embedded.
+-->
+</body>
 </html>

--- a/tests/Integration/tests-full/meta-data/expected/index.html
+++ b/tests/Integration/tests-full/meta-data/expected/index.html
@@ -210,12 +210,8 @@
 <script src="_resources/js/bootstrap.min.js"></script>
 <script src="_resources/js/theme.min.js"></script>
 
-<script id="R9wBKTwzv" src="https://app.usercentrics.eu/latest/main.js"></script>
-<script data-usercentrics="Matomo" src="/js/piwik.js" type="text/plain"></script>
-
-<script type="text/plain" data-usercentrics="Google Tag Manager">(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','GTM-MKNXD8Q');</script></body>
+<!--
+ Locally rendered. No tracking embedded.
+-->
+</body>
 </html>

--- a/tests/Integration/tests-full/next-prev-by-toctree/expected/four.html
+++ b/tests/Integration/tests-full/next-prev-by-toctree/expected/four.html
@@ -229,12 +229,8 @@
 <script src="_resources/js/bootstrap.min.js"></script>
 <script src="_resources/js/theme.min.js"></script>
 
-<script id="R9wBKTwzv" src="https://app.usercentrics.eu/latest/main.js"></script>
-<script data-usercentrics="Matomo" src="/js/piwik.js" type="text/plain"></script>
-
-<script type="text/plain" data-usercentrics="Google Tag Manager">(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','GTM-MKNXD8Q');</script></body>
+<!--
+ Locally rendered. No tracking embedded.
+-->
+</body>
 </html>

--- a/tests/Integration/tests-full/next-prev-by-toctree/expected/i.html
+++ b/tests/Integration/tests-full/next-prev-by-toctree/expected/i.html
@@ -229,12 +229,8 @@
 <script src="_resources/js/bootstrap.min.js"></script>
 <script src="_resources/js/theme.min.js"></script>
 
-<script id="R9wBKTwzv" src="https://app.usercentrics.eu/latest/main.js"></script>
-<script data-usercentrics="Matomo" src="/js/piwik.js" type="text/plain"></script>
-
-<script type="text/plain" data-usercentrics="Google Tag Manager">(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','GTM-MKNXD8Q');</script></body>
+<!--
+ Locally rendered. No tracking embedded.
+-->
+</body>
 </html>

--- a/tests/Integration/tests-full/next-prev-by-toctree/expected/index.html
+++ b/tests/Integration/tests-full/next-prev-by-toctree/expected/index.html
@@ -256,12 +256,8 @@
 <script src="_resources/js/bootstrap.min.js"></script>
 <script src="_resources/js/theme.min.js"></script>
 
-<script id="R9wBKTwzv" src="https://app.usercentrics.eu/latest/main.js"></script>
-<script data-usercentrics="Matomo" src="/js/piwik.js" type="text/plain"></script>
-
-<script type="text/plain" data-usercentrics="Google Tag Manager">(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','GTM-MKNXD8Q');</script></body>
+<!--
+ Locally rendered. No tracking embedded.
+-->
+</body>
 </html>

--- a/tests/Integration/tests-full/next-prev-by-toctree/expected/one.html
+++ b/tests/Integration/tests-full/next-prev-by-toctree/expected/one.html
@@ -229,12 +229,8 @@
 <script src="_resources/js/bootstrap.min.js"></script>
 <script src="_resources/js/theme.min.js"></script>
 
-<script id="R9wBKTwzv" src="https://app.usercentrics.eu/latest/main.js"></script>
-<script data-usercentrics="Matomo" src="/js/piwik.js" type="text/plain"></script>
-
-<script type="text/plain" data-usercentrics="Google Tag Manager">(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','GTM-MKNXD8Q');</script></body>
+<!--
+ Locally rendered. No tracking embedded.
+-->
+</body>
 </html>

--- a/tests/Integration/tests-full/next-prev-by-toctree/expected/three/index.html
+++ b/tests/Integration/tests-full/next-prev-by-toctree/expected/three/index.html
@@ -243,12 +243,8 @@
 <script src="../_resources/js/bootstrap.min.js"></script>
 <script src="../_resources/js/theme.min.js"></script>
 
-<script id="R9wBKTwzv" src="https://app.usercentrics.eu/latest/main.js"></script>
-<script data-usercentrics="Matomo" src="/js/piwik.js" type="text/plain"></script>
-
-<script type="text/plain" data-usercentrics="Google Tag Manager">(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','GTM-MKNXD8Q');</script></body>
+<!--
+ Locally rendered. No tracking embedded.
+-->
+</body>
 </html>

--- a/tests/Integration/tests-full/next-prev-by-toctree/expected/three/pi.html
+++ b/tests/Integration/tests-full/next-prev-by-toctree/expected/three/pi.html
@@ -222,12 +222,8 @@
 <script src="../_resources/js/bootstrap.min.js"></script>
 <script src="../_resources/js/theme.min.js"></script>
 
-<script id="R9wBKTwzv" src="https://app.usercentrics.eu/latest/main.js"></script>
-<script data-usercentrics="Matomo" src="/js/piwik.js" type="text/plain"></script>
-
-<script type="text/plain" data-usercentrics="Google Tag Manager">(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','GTM-MKNXD8Q');</script></body>
+<!--
+ Locally rendered. No tracking embedded.
+-->
+</body>
 </html>

--- a/tests/Integration/tests-full/next-prev-by-toctree/expected/three/three.html
+++ b/tests/Integration/tests-full/next-prev-by-toctree/expected/three/three.html
@@ -230,12 +230,8 @@
 <script src="../_resources/js/bootstrap.min.js"></script>
 <script src="../_resources/js/theme.min.js"></script>
 
-<script id="R9wBKTwzv" src="https://app.usercentrics.eu/latest/main.js"></script>
-<script data-usercentrics="Matomo" src="/js/piwik.js" type="text/plain"></script>
-
-<script type="text/plain" data-usercentrics="Google Tag Manager">(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','GTM-MKNXD8Q');</script></body>
+<!--
+ Locally rendered. No tracking embedded.
+-->
+</body>
 </html>

--- a/tests/Integration/tests-full/next-prev-by-toctree/expected/three/threepointfive.html
+++ b/tests/Integration/tests-full/next-prev-by-toctree/expected/three/threepointfive.html
@@ -230,12 +230,8 @@
 <script src="../_resources/js/bootstrap.min.js"></script>
 <script src="../_resources/js/theme.min.js"></script>
 
-<script id="R9wBKTwzv" src="https://app.usercentrics.eu/latest/main.js"></script>
-<script data-usercentrics="Matomo" src="/js/piwik.js" type="text/plain"></script>
-
-<script type="text/plain" data-usercentrics="Google Tag Manager">(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','GTM-MKNXD8Q');</script></body>
+<!--
+ Locally rendered. No tracking embedded.
+-->
+</body>
 </html>

--- a/tests/Integration/tests-full/next-prev-by-toctree/expected/two.html
+++ b/tests/Integration/tests-full/next-prev-by-toctree/expected/two.html
@@ -229,12 +229,8 @@
 <script src="_resources/js/bootstrap.min.js"></script>
 <script src="_resources/js/theme.min.js"></script>
 
-<script id="R9wBKTwzv" src="https://app.usercentrics.eu/latest/main.js"></script>
-<script data-usercentrics="Matomo" src="/js/piwik.js" type="text/plain"></script>
-
-<script type="text/plain" data-usercentrics="Google Tag Manager">(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','GTM-MKNXD8Q');</script></body>
+<!--
+ Locally rendered. No tracking embedded.
+-->
+</body>
 </html>

--- a/tests/Integration/tests-full/next-prev/expected/index.html
+++ b/tests/Integration/tests-full/next-prev/expected/index.html
@@ -210,12 +210,8 @@
 <script src="_resources/js/bootstrap.min.js"></script>
 <script src="_resources/js/theme.min.js"></script>
 
-<script id="R9wBKTwzv" src="https://app.usercentrics.eu/latest/main.js"></script>
-<script data-usercentrics="Matomo" src="/js/piwik.js" type="text/plain"></script>
-
-<script type="text/plain" data-usercentrics="Google Tag Manager">(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','GTM-MKNXD8Q');</script></body>
+<!--
+ Locally rendered. No tracking embedded.
+-->
+</body>
 </html>

--- a/tests/Integration/tests-full/next-prev/expected/page.html
+++ b/tests/Integration/tests-full/next-prev/expected/page.html
@@ -217,12 +217,8 @@
 <script src="_resources/js/bootstrap.min.js"></script>
 <script src="_resources/js/theme.min.js"></script>
 
-<script id="R9wBKTwzv" src="https://app.usercentrics.eu/latest/main.js"></script>
-<script data-usercentrics="Matomo" src="/js/piwik.js" type="text/plain"></script>
-
-<script type="text/plain" data-usercentrics="Google Tag Manager">(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','GTM-MKNXD8Q');</script></body>
+<!--
+ Locally rendered. No tracking embedded.
+-->
+</body>
 </html>

--- a/tests/Integration/tests-full/next-prev/expected/yetAnotherPage.html
+++ b/tests/Integration/tests-full/next-prev/expected/yetAnotherPage.html
@@ -210,12 +210,8 @@
 <script src="_resources/js/bootstrap.min.js"></script>
 <script src="_resources/js/theme.min.js"></script>
 
-<script id="R9wBKTwzv" src="https://app.usercentrics.eu/latest/main.js"></script>
-<script data-usercentrics="Matomo" src="/js/piwik.js" type="text/plain"></script>
-
-<script type="text/plain" data-usercentrics="Google Tag Manager">(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','GTM-MKNXD8Q');</script></body>
+<!--
+ Locally rendered. No tracking embedded.
+-->
+</body>
 </html>

--- a/tests/Integration/tests-full/page-with-subpages/expected/index.html
+++ b/tests/Integration/tests-full/page-with-subpages/expected/index.html
@@ -215,12 +215,8 @@
 <script src="_resources/js/bootstrap.min.js"></script>
 <script src="_resources/js/theme.min.js"></script>
 
-<script id="R9wBKTwzv" src="https://app.usercentrics.eu/latest/main.js"></script>
-<script data-usercentrics="Matomo" src="/js/piwik.js" type="text/plain"></script>
-
-<script type="text/plain" data-usercentrics="Google Tag Manager">(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','GTM-MKNXD8Q');</script></body>
+<!--
+ Locally rendered. No tracking embedded.
+-->
+</body>
 </html>

--- a/tests/Integration/tests-full/page-with-subpages/expected/singlehtml/Index.html
+++ b/tests/Integration/tests-full/page-with-subpages/expected/singlehtml/Index.html
@@ -195,12 +195,8 @@
 <script src="../_resources/js/bootstrap.min.js"></script>
 <script src="../_resources/js/theme.min.js"></script>
 
-<script id="R9wBKTwzv" src="https://app.usercentrics.eu/latest/main.js"></script>
-<script data-usercentrics="Matomo" src="/js/piwik.js" type="text/plain"></script>
-
-<script type="text/plain" data-usercentrics="Google Tag Manager">(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','GTM-MKNXD8Q');</script></body>
+<!--
+ Locally rendered. No tracking embedded.
+-->
+</body>
 </html>

--- a/tests/Integration/tests-full/page-with-subpages/expected/sub/index.html
+++ b/tests/Integration/tests-full/page-with-subpages/expected/sub/index.html
@@ -207,12 +207,8 @@
 <script src="../_resources/js/bootstrap.min.js"></script>
 <script src="../_resources/js/theme.min.js"></script>
 
-<script id="R9wBKTwzv" src="https://app.usercentrics.eu/latest/main.js"></script>
-<script data-usercentrics="Matomo" src="/js/piwik.js" type="text/plain"></script>
-
-<script type="text/plain" data-usercentrics="Google Tag Manager">(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','GTM-MKNXD8Q');</script></body>
+<!--
+ Locally rendered. No tracking embedded.
+-->
+</body>
 </html>

--- a/tests/Integration/tests-full/two-toctrees/expected/index.html
+++ b/tests/Integration/tests-full/two-toctrees/expected/index.html
@@ -249,12 +249,8 @@
 <script src="_resources/js/bootstrap.min.js"></script>
 <script src="_resources/js/theme.min.js"></script>
 
-<script id="R9wBKTwzv" src="https://app.usercentrics.eu/latest/main.js"></script>
-<script data-usercentrics="Matomo" src="/js/piwik.js" type="text/plain"></script>
-
-<script type="text/plain" data-usercentrics="Google Tag Manager">(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','GTM-MKNXD8Q');</script></body>
+<!--
+ Locally rendered. No tracking embedded.
+-->
+</body>
 </html>


### PR DESCRIPTION
Introduce a new Twig function "isRenderedForDeployment" that returns "true" when rendering is performed for upload to docs.typo3.org. In this case, URIs are generated with the "typo3.azureedge.net..." scope.

Only then, tracking javascript code will be emitted.

With local URIs in use, no tracking will be performed.

Fixes https://github.com/TYPO3-Documentation/render-guides/issues/378