### PR TITLE
[BUGFIX] Use anchor, not id for confval target

### DIFF
--- a/packages/typo3-docs-theme/resources/template/body/directive/confval.html.twig
+++ b/packages/typo3-docs-theme/resources/template/body/directive/confval.html.twig
@@ -1,7 +1,7 @@
 <dl class="confval">
     <dt id="{{ node.id }}">
         <code class="sig-name descname"><span class="pre">{{ node.plainContent }}</span></code>
-        <a class="headerlink" href="#{{ node.id }}" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  data-id="{{ node.id }}" data-rstCode="{{ getRstCodeForLink(node) }}"  title="Reference this configuration value">¶</a>
+        <a class="headerlink" href="#{{ node.anchor }}" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="{{ node.anchor }}" data-rstCode="{{ getRstCodeForLink(node) }}"  title="Reference this configuration value">¶</a>
     </dt>
     <dd>
         {% if node.type or node.required or node.default or node.additionalOptions %}

--- a/tests/Integration/tests/confval/confval-basic/expected/index.html
+++ b/tests/Integration/tests/confval/confval-basic/expected/index.html
@@ -4,7 +4,7 @@
             <dl class="confval">
     <dt id="demo">
         <code class="sig-name descname"><span class="pre">demo</span></code>
-        <a class="headerlink" href="#demo" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  data-id="demo" data-rstCode=":confval:`demo &lt;somemanual:demo&gt;`"  title="Reference this configuration value">¶</a>
+        <a class="headerlink" href="#confval-demo" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-demo" data-rstCode=":confval:`demo &lt;somemanual:demo&gt;`"  title="Reference this configuration value">¶</a>
     </dt>
     <dd>
                 <dl class="field-list simple">

--- a/tests/Integration/tests/confval/confval-duplicate-with-name/expected/anotherDomain.html
+++ b/tests/Integration/tests/confval/confval-duplicate-with-name/expected/anotherDomain.html
@@ -4,7 +4,7 @@
             <dl class="confval">
     <dt id="another-demo">
         <code class="sig-name descname"><span class="pre">demo</span></code>
-        <a class="headerlink" href="#another-demo" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  data-id="another-demo" data-rstCode=":confval:`demo &lt;somemanual:another-demo&gt;`"  title="Reference this configuration value">¶</a>
+        <a class="headerlink" href="#confval-another-demo" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-another-demo" data-rstCode=":confval:`demo &lt;somemanual:another-demo&gt;`"  title="Reference this configuration value">¶</a>
     </dt>
     <dd>
                 <dl class="field-list simple">

--- a/tests/Integration/tests/confval/confval-duplicate-with-name/expected/index.html
+++ b/tests/Integration/tests/confval/confval-duplicate-with-name/expected/index.html
@@ -4,7 +4,7 @@
             <dl class="confval">
     <dt id="demo">
         <code class="sig-name descname"><span class="pre">demo</span></code>
-        <a class="headerlink" href="#demo" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  data-id="demo" data-rstCode=":confval:`demo &lt;somemanual:demo&gt;`"  title="Reference this configuration value">¶</a>
+        <a class="headerlink" href="#confval-demo" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-demo" data-rstCode=":confval:`demo &lt;somemanual:demo&gt;`"  title="Reference this configuration value">¶</a>
     </dt>
     <dd>
                 <dl class="field-list simple">

--- a/tests/Integration/tests/confval/confval-duplicate/expected/anotherDomain.html
+++ b/tests/Integration/tests/confval/confval-duplicate/expected/anotherDomain.html
@@ -4,7 +4,7 @@
             <dl class="confval">
     <dt id="demo">
         <code class="sig-name descname"><span class="pre">demo</span></code>
-        <a class="headerlink" href="#demo" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  data-id="demo" data-rstCode=":confval:`demo &lt;somemanual:demo&gt;`"  title="Reference this configuration value">¶</a>
+        <a class="headerlink" href="#confval-demo" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-demo" data-rstCode=":confval:`demo &lt;somemanual:demo&gt;`"  title="Reference this configuration value">¶</a>
     </dt>
     <dd>
                 <dl class="field-list simple">

--- a/tests/Integration/tests/confval/confval-duplicate/expected/index.html
+++ b/tests/Integration/tests/confval/confval-duplicate/expected/index.html
@@ -4,7 +4,7 @@
             <dl class="confval">
     <dt id="demo">
         <code class="sig-name descname"><span class="pre">demo</span></code>
-        <a class="headerlink" href="#demo" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  data-id="demo" data-rstCode=":confval:`demo &lt;somemanual:demo&gt;`"  title="Reference this configuration value">¶</a>
+        <a class="headerlink" href="#confval-demo" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-demo" data-rstCode=":confval:`demo &lt;somemanual:demo&gt;`"  title="Reference this configuration value">¶</a>
     </dt>
     <dd>
                 <dl class="field-list simple">


### PR DESCRIPTION
Resolves https://github.com/TYPO3-Documentation/render-guides/issues/479