### PR TITLE
[BUGFIX] Fix code size in headers

### DIFF
--- a/Documentation-rendertest/Typesetting/Index.rst
+++ b/Documentation-rendertest/Typesetting/Index.rst
@@ -2,9 +2,9 @@
 
 ..  _typesetting:
 
-===========
-Typesetting
-===========
+=================
+Typesetting `code`
+==================
 
 ..  contents:: Table of contents
 
@@ -30,24 +30,24 @@ Headers
 
 There are multiple levels of headers available:
 
-Level 2 Header
-==============
+Level 2 Header `code`
+=====================
 
 Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod
 tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.
 
-Level 3 Header
---------------
+Level 3 Header `code`
+---------------------
 
 At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd
 gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
 Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod
 tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.
 
-Level 4 Header
-~~~~~~~~~~~~~~
+Level 4 Header `code`
+~~~~~~~~~~~~~~~~~~~~~
 
-At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd
+At vero eos et `accusam` et justo duo dolores et ea rebum. Stet clita kasd
 gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
 
 Level 5 Header

--- a/packages/typo3-docs-theme/assets/sass/components/_code.scss
+++ b/packages/typo3-docs-theme/assets/sass/components/_code.scss
@@ -2,14 +2,14 @@
 
 code {
     color: $gray-900;
-    font-size: 0.85rem;
+    font-size: 85%;
 }
 /*
  * The class "code-block" is used for ".. code-block::" directives
  */
 .code-block {
     margin-bottom: 0;
-    padding: .75rem;
+    padding: 75%;
 
     & [data-line-number]::before {
         color: $gray-600;

--- a/packages/typo3-docs-theme/resources/public/css/theme.css
+++ b/packages/typo3-docs-theme/resources/public/css/theme.css
@@ -23035,7 +23035,7 @@ article h3, article .h3 {
 
 code {
   color: #333333;
-  font-size: 0.85rem;
+  font-size: 85%;
 }
 
 /*
@@ -23043,7 +23043,7 @@ code {
  */
 .code-block {
   margin-bottom: 0;
-  padding: 0.75rem;
+  padding: 75%;
 }
 .code-block [data-line-number]::before {
   color: #999999;


### PR DESCRIPTION
After:

![After](https://github.com/TYPO3-Documentation/render-guides/assets/48202465/ae0788ab-f12c-4a45-b280-87da9a38ff2e)

Before:

![Before](https://github.com/TYPO3-Documentation/render-guides/assets/48202465/6839ee56-cc21-4eb9-bad5-bb4f902ea16d)


resolves https://github.com/TYPO3-Documentation/render-guides/issues/501