### PR TITLE
[BUGFIX] Remove gab after tabs

### DIFF
--- a/packages/typo3-docs-theme/assets/sass/components/_tabs.scss
+++ b/packages/typo3-docs-theme/assets/sass/components/_tabs.scss
@@ -4,3 +4,7 @@
     padding: $spacer;
     margin-bottom: 1em;
 }
+
+.nav-tabs li.nav-item {
+    margin: 0;
+}

--- a/packages/typo3-docs-theme/resources/public/css/theme.css
+++ b/packages/typo3-docs-theme/resources/public/css/theme.css
@@ -24064,6 +24064,10 @@ article *:hover > a.headerlink:after, article *:hover > a.permalink:after, artic
   margin-bottom: 1em;
 }
 
+.nav-tabs li.nav-item {
+  margin: 0;
+}
+
 /**
  * Keyboard Shortcuts, text role :kbd:
  */


### PR DESCRIPTION
After:
![After](https://github.com/TYPO3-Documentation/render-guides/assets/48202465/f183cab5-a8d1-4e7e-9c8d-5ef16f5f66f6)

Before:

![Before](https://github.com/TYPO3-Documentation/render-guides/assets/48202465/2df35a55-9755-49f4-ac65-24e968abe5d1)

resolves https://github.com/TYPO3-Documentation/render-guides/issues/419