### PR TITLE
[BUGFIX] Fix automatic detection of input directory in localization mode

### DIFF
--- a/packages/typo3-guides-extension/src/Command/RunDecorator.php
+++ b/packages/typo3-guides-extension/src/Command/RunDecorator.php
@@ -63,7 +63,7 @@ final class RunDecorator extends Command
 
         $arguments = $input->getArguments();
         if ($arguments['input'] === null) {
-            $guessedInput = $this->guessInput(self::DEFAULT_INPUT_DIRECTORY, $output);
+            $guessedInput = $this->guessInput(self::DEFAULT_INPUT_DIRECTORY, $output, false);
         } else {
             $guessedInput = [];
         }
@@ -175,7 +175,7 @@ final class RunDecorator extends Command
         }
         $output->writeln(sprintf('<info>Trying to render %s ...</info>', $availableLocalization));
 
-        $guessInput = $this->guessInput($localInputDirectives['input-file'], $output);
+        $guessInput = $this->guessInput($localInputDirectives['input-file'], $output, true);
         if ($guessInput === []) {
             $output->writeln('<info>Skipping, no entrypoint for localization found.</info>');
             return Command::SUCCESS;
@@ -294,7 +294,7 @@ final class RunDecorator extends Command
     }
 
     /** @return array<string, string> */
-    private function guessInput(string $inputBaseDirectory, OutputInterface $output): array
+    private function guessInput(string $inputBaseDirectory, OutputInterface $output, bool $isAbsoluteDirectory = false): array
     {
         $currentDirectory = getcwd();
         if ($currentDirectory === false) {
@@ -305,7 +305,13 @@ final class RunDecorator extends Command
             return [];
         }
 
-        $inputDirectory = $currentDirectory . DIRECTORY_SEPARATOR . $inputBaseDirectory;
+        if ($isAbsoluteDirectory) {
+            // Directory is already fully passed, and not a sub-directory (i.e. for localizations)
+            $inputDirectory = $inputBaseDirectory;
+        } else {
+            // Directory needs to be checked within our working space (i.e. /project in container)
+            $inputDirectory = $currentDirectory . DIRECTORY_SEPARATOR . $inputBaseDirectory;
+        }
 
         if (is_dir($inputDirectory)) {
             if ($output->isDebug()) {


### PR DESCRIPTION
When the rendering gets performed without an input directory, "Documentation" is passed by default.

This means in a docker context, using this:

```
docker run --rm --pull always -v "$(shell pwd)":/project -t ghcr.io/typo3-documentation/render-guides:latest --config=Documentation --no-progress --fail-on-log --output-format=html
```

always needs to fixate the config directory, but does not explicitly specify `Documentation` as an input. This could be done with:

```
docker run --rm --pull always -v "$(shell pwd)":/project -t ghcr.io/typo3-documentation/render-guides:latest --config=Documentation --no-progress --fail-on-log --output-format=html Documentation
```

If that would be the case, all is good. A possible "Localization.ru_RU" directory would then be appended to the input, forming "Documentation/Localization.ru_RU".

HOWEVER, when this `Documentation` is missing, the `guessInput` method auto-detects the proper path.

It then returns `/project/Documentation/` as the actual input. The Localization output will then later use try to auto-detect the prefix as `/project/project/Documentation` (`cwd`+`input` auto guessed result). This will of course fail.

The solution now is to make the dual-use of `guessInput` (once for the base language, and once for the localization base) recognize if it already submits an absolute directory, or a relative one. This will then lead to proper path resolution.
