### PR TITLE
[Feature] Introduce directory tree directive

### DIFF
--- a/Documentation-rendertest/Directives/directoryTree.rst
+++ b/Documentation-rendertest/Directives/directoryTree.rst
@@ -1,0 +1,74 @@
+==============
+Directory tree
+==============
+
+..  directory-tree::
+    :level: 2
+    :show-file-icons: true
+
+    *   EXT:my_sitepackage/Resources/Private/Templates/
+
+        *   Layouts
+
+            *   Default.html
+            *   WithoutHeader.html
+
+        *   Pages
+
+            *   Default.html
+            *   StartPage.html
+            *   TwoColumns.html
+            *   With_sidebar.html
+
+        *   Partials
+
+            *   Footer.html
+            *   Sidebar.html
+            *   Menu.html
+
+
+Directory tree with links
+=========================
+
+Directory structure of a typo3 extension
+========================================
+
+..  directory-tree::
+
+    *   :file:`composer.json`
+    *   :file:`ext_conf_template.txt`
+    *   :file:`ext_emconf.php`
+    *   :file:`ext_localconf.php`
+    *   :file:`ext_tables.php`
+    *   :file:`ext_tables.sql`
+    *   :file:`ext_tables_static+adt.sql`
+    *   :file:`ext_typoscript_constants.typoscript`
+    *   :file:`ext_typoscript_setup.typoscript`
+    *   :path:`Classes`
+    *   :path:`Configuration`
+
+        *   :path:`Backend`
+        *   :path:`Extbase`
+
+            *   :path:`Persistence`
+
+        *   :path:`TCA`
+        *   :path:`TsConfig`
+        *   :path:`TypoScript`
+        *   :file:`ContentSecurityPolicies.php`
+        *   :file:`Icons.php`
+        *   :file:`page.tsconfig`
+        *   :file:`RequestMiddlewares.php`
+        *   :file:`Services.yaml`
+        *   :file:`user.tsconfig`
+
+    *   :path:`Documentation`
+    *   :path:`Resources`
+
+        *   :path:`Private`
+
+            *   :path:`Language`
+
+        *   :path:`Public`
+
+    *   :path:`Tests`

--- a/packages/typo3-docs-theme/assets/sass/components/_directoryTree.scss
+++ b/packages/typo3-docs-theme/assets/sass/components/_directoryTree.scss
@@ -1,0 +1,57 @@
+.directory-tree {
+    ul {
+        margin-bottom: 0;
+        list-style: none;
+        li {
+            margin-bottom: 0;
+            .content {
+                @extend .d-flex,.flex-row;
+                .toggle {
+                    width: 1.5em;
+                    a[data-bs-toggle="collapse"] {
+                        text-decoration: none;
+                        .icon::before {
+                            font-family: 'Font Awesome 6 Free';
+                            content: "\f0fe";
+                        }
+
+                        &.collapsed {
+                            .icon::before {
+                                content: "\f146";
+                            }
+                        }
+                    }
+                }
+                .no-toggle {
+                    width: 1.5em;
+                }
+                .fileItem {
+                    width: 2em;
+                }
+                .label {
+                    code.file, code.path {
+                        background-color: $white;
+                        font-family: var(--bs-body-font-family);
+                        line-height: var(--bs-body-line-height);
+                        font-size: 1.1rem;
+                        &::before {
+                            width: 1.5em;
+                            font-family: 'Font Awesome 6 Free';
+                            display: inline-block;
+                            content:"\f15b";
+                        }
+                    }
+                    code.path {
+                        &::before {
+                            content:"\f07b";
+                        }
+                    }
+                    p:last-child {
+                        /* Prevent margin cause by last p */
+                        margin-bottom: 0;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/packages/typo3-docs-theme/assets/sass/theme.scss
+++ b/packages/typo3-docs-theme/assets/sass/theme.scss
@@ -27,6 +27,7 @@
 @import 'components/button';
 @import 'components/card';
 @import 'components/code';
+@import 'components/directoryTree';
 @import 'components/frame';
 @import 'components/images';
 @import 'components/math';

--- a/packages/typo3-docs-theme/resources/config/typo3-docs-theme.php
+++ b/packages/typo3-docs-theme/resources/config/typo3-docs-theme.php
@@ -15,6 +15,7 @@ use phpDocumentor\Guides\RestructuredText\Parser\Interlink\InterlinkParser;
 use phpDocumentor\Guides\RestructuredText\Parser\Productions\DirectiveContentRule;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
+use T3Docs\Typo3DocsTheme\Directives\DirectoryTreeDirective;
 use T3Docs\Typo3DocsTheme\Directives\RawDirective;
 use T3Docs\Typo3DocsTheme\EventListeners\AddThemeSettingsToProjectNode;
 use T3Docs\Typo3DocsTheme\EventListeners\CopyResources;
@@ -103,6 +104,7 @@ return static function (ContainerConfigurator $container): void {
         ->decorate(PlantumlServerRenderer::class)
         ->public()
 
+        ->set(DirectoryTreeDirective::class)
         ->set(GroupTabDirective::class)
         ->set(RawDirective::class)
         ->set(T3FieldListTableDirective::class)

--- a/packages/typo3-docs-theme/resources/public/css/theme.css
+++ b/packages/typo3-docs-theme/resources/public/css/theme.css
@@ -18092,7 +18092,7 @@ textarea.form-control-lg {
   display: table-cell !important;
 }
 
-.d-flex {
+.d-flex, .directory-tree ul li .content {
   display: flex !important;
 }
 
@@ -18516,7 +18516,7 @@ textarea.form-control-lg {
   flex: 1 1 auto !important;
 }
 
-.flex-row {
+.flex-row, .directory-tree ul li .content {
   flex-direction: row !important;
 }
 
@@ -23183,6 +23183,52 @@ code {
     max-width: 60vw;
   }
 }
+.directory-tree ul {
+  margin-bottom: 0;
+  list-style: none;
+}
+.directory-tree ul li {
+  margin-bottom: 0;
+}
+.directory-tree ul li .content .toggle {
+  width: 1.5em;
+}
+.directory-tree ul li .content .toggle a[data-bs-toggle=collapse] {
+  text-decoration: none;
+}
+.directory-tree ul li .content .toggle a[data-bs-toggle=collapse] .icon::before {
+  font-family: "Font Awesome 6 Free";
+  content: "\f0fe";
+}
+.directory-tree ul li .content .toggle a[data-bs-toggle=collapse].collapsed .icon::before {
+  content: "\f146";
+}
+.directory-tree ul li .content .no-toggle {
+  width: 1.5em;
+}
+.directory-tree ul li .content .fileItem {
+  width: 2em;
+}
+.directory-tree ul li .content .label code.file, .directory-tree ul li .content .label code.path {
+  background-color: #ffffff;
+  font-family: var(--bs-body-font-family);
+  line-height: var(--bs-body-line-height);
+  font-size: 1.1rem;
+}
+.directory-tree ul li .content .label code.file::before, .directory-tree ul li .content .label code.path::before {
+  width: 1.5em;
+  font-family: "Font Awesome 6 Free";
+  display: inline-block;
+  content: "\f15b";
+}
+.directory-tree ul li .content .label code.path::before {
+  content: "\f07b";
+}
+.directory-tree ul li .content .label p:last-child {
+  /* Prevent margin cause by last p */
+  margin-bottom: 0;
+}
+
 :root {
   --frame-color: inherit;
   --frame-link-color: #005E85;

--- a/packages/typo3-docs-theme/resources/template/body/directive/directory-tree.html.twig
+++ b/packages/typo3-docs-theme/resources/template/body/directive/directory-tree.html.twig
@@ -1,0 +1,58 @@
+{% macro renderListItem(item, namePrefix, level, maxLevel, showFileIcons) %}
+    {% set expanded = level < maxLevel %}
+    <li id="{{ item.name }}">
+        <div class="content">
+            {% if item.subLists %}
+                <div class="toggle">
+                    <a data-bs-toggle="collapse"
+                       href="#{{ item.name }}-list"
+                       aria-expanded="{% if expanded %}true{% else %}false{% endif %}"
+                       aria-controls="{{ item.name }}-list"
+                       class="{% if not expanded %}collapsed{% endif %}"
+                    >
+                        <span class="icon"></span>
+                    </a>
+                </div>
+                {% if showFileIcons %}
+                    <div class="fileItem">
+                        <i class="far fa-folder"></i>
+                    </div>
+                {% endif %}
+            {% else %}
+                <div class="no-toggle">
+                </div>
+                {% if showFileIcons %}
+                    <div class="fileItem">
+                        <i class="far fa-file"></i>
+                    </div>
+                {% endif %}
+            {% endif %}
+            <div class="label">
+                {% for part in item.children %}
+                    {% if not part.isList %}
+                        {{ renderNode(part) }}
+                    {% endif %}
+                {% endfor %}
+            </div>
+        </div>
+        {% for part in item.subLists %}
+            <ul class="collapse {%- if expanded %} show{% endif %}" id="{{ item.name }}-list">
+                {% for item2 in part.value %}
+                    {{  _self.renderListItem(item2, item2.name, level+1, maxLevel, showFileIcons) }}
+                {% endfor %}
+            </ul>
+        {% endfor %}
+    </li>
+{% endmacro %}
+
+{% import _self as macros %}
+
+<div class="directory-tree">
+    {% for list in node.children %}
+        <ul id="{{ list.name }}">
+            {% for item in list.children %}
+                {{ macros.renderListItem(item, list.name, 1, node.level, node.showFileIcons) }}
+            {% endfor %}
+        </ul>
+    {% endfor %}
+</div>

--- a/packages/typo3-docs-theme/resources/template/inline/textroles/file.html.twig
+++ b/packages/typo3-docs-theme/resources/template/inline/textroles/file.html.twig
@@ -1,3 +1,3 @@
 {% apply spaceless %}
-    <code class="code-inline" translate="no" title="File path">{{ node.value }}</code>
+    <code class="code-inline file" translate="no" title="File path">{{ node.value }}</code>
 {% endapply %}

--- a/packages/typo3-docs-theme/resources/template/inline/textroles/path.html.twig
+++ b/packages/typo3-docs-theme/resources/template/inline/textroles/path.html.twig
@@ -1,3 +1,3 @@
 {% apply spaceless %}
-    <code class="code-inline" translate="no" title="Path">{{ node.value }}</code>
+    <code class="code-inline path" translate="no" title="Path">{{ node.value }}</code>
 {% endapply %}

--- a/packages/typo3-docs-theme/src/Directives/DirectoryTreeDirective.php
+++ b/packages/typo3-docs-theme/src/Directives/DirectoryTreeDirective.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link https://phpdoc.org
+ */
+
+namespace T3Docs\Typo3DocsTheme\Directives;
+
+use phpDocumentor\Guides\Nodes\CollectionNode;
+use phpDocumentor\Guides\Nodes\InlineCompoundNode;
+use phpDocumentor\Guides\Nodes\ListItemNode;
+use phpDocumentor\Guides\Nodes\ListNode;
+use phpDocumentor\Guides\Nodes\Node;
+use phpDocumentor\Guides\RestructuredText\Directives\SubDirective;
+use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
+use phpDocumentor\Guides\RestructuredText\Parser\Directive;
+use phpDocumentor\Guides\RestructuredText\Parser\Productions\Rule;
+use Psr\Log\LoggerInterface;
+use T3Docs\Typo3DocsTheme\Nodes\DirectoryTree\DirectoryTreeListItemNode;
+use T3Docs\Typo3DocsTheme\Nodes\DirectoryTree\DirectoryTreeListNode;
+use T3Docs\Typo3DocsTheme\Nodes\DirectoryTreeNode;
+
+class DirectoryTreeDirective extends SubDirective
+{
+    private static int $counter = 0;
+    public function __construct(
+        Rule $startingRule,
+        private readonly LoggerInterface $logger,
+    ) {
+        parent::__construct($startingRule);
+    }
+
+    public function getName(): string
+    {
+        return 'directory-tree';
+    }
+
+    protected function processSub(
+        BlockContext   $blockContext,
+        CollectionNode $collectionNode,
+        Directive      $directive,
+    ): Node|null {
+        if($directive->hasOption('name')) {
+            $id = $directive->getOption('name')->toString();
+        } else {
+            self::$counter++;
+            $id = 'directory-tree-' . self::$counter;
+        }
+        if($directive->hasOption('level')) {
+            $level = (int) $directive->getOption('level')->getValue();
+        } else {
+            $level = PHP_INT_MAX;
+        }
+        $showFileIcons = false;
+        if ($directive->hasOption('show-file-icons')) {
+            $showFileIcons = (bool) $directive->getOption('show-file-icons')->getValue();
+        }
+        $originalChildren = $collectionNode->getChildren();
+        $children = [];
+        foreach ($originalChildren as $child) {
+            if ($child instanceof ListNode) {
+                $children[] = $this->setNames($child, $id);
+            } else {
+                $this->logger->warning('A directory-tree may only a list. ', $blockContext->getLoggerInformation());
+            }
+        }
+        if (count($children) === 0) {
+            $this->logger->warning('A directory-tree must contain at least one list. ', $blockContext->getLoggerInformation());
+        }
+        return new DirectoryTreeNode(
+            'directory-tree',
+            $directive->getData(),
+            $directive->getDataNode() ?? new InlineCompoundNode(),
+            $children,
+            $id,
+            $level,
+            $showFileIcons,
+        );
+    }
+
+    private function setNames(ListNode $list, string $id, int $count = 0): DirectoryTreeListNode
+    {
+        $count++;
+        if (!$list->hasOption('name')) {
+            $list = $list->withOptions(['name' => $id]);
+        }
+        $children = [];
+        $subCount = 0;
+        foreach ($list->getChildren() as $child) {
+            if ($child instanceof ListItemNode) {
+                $subCount++;
+                $children[] = $this->setItemNames($child, $id, $subCount);
+            } else {
+                $children[] = $child;
+            }
+        }
+        return new DirectoryTreeListNode($children, $id);
+    }
+    private function setItemNames(ListItemNode $item, string $id, int $count): DirectoryTreeListItemNode
+    {
+        $id .= '-' . $count;
+        $children = [];
+        $lists = [];
+        $subCount = 0;
+        foreach ($item->getChildren() as $child) {
+            if ($child instanceof ListNode) {
+                $subCount++;
+                $lists[] = $this->setNames($child, $id, $subCount);
+            } else {
+                $children[] = $child;
+            }
+        }
+        return new DirectoryTreeListItemNode($children, $id, $lists);
+    }
+}

--- a/packages/typo3-docs-theme/src/Nodes/DirectoryTree/DirectoryTreeListItemNode.php
+++ b/packages/typo3-docs-theme/src/Nodes/DirectoryTree/DirectoryTreeListItemNode.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace T3Docs\Typo3DocsTheme\Nodes\DirectoryTree;
+
+use phpDocumentor\Guides\Nodes\CompoundNode;
+use phpDocumentor\Guides\Nodes\Node;
+
+/** @extends CompoundNode<Node> */
+final class DirectoryTreeListItemNode extends CompoundNode
+{
+    /**
+     * @param Node[] $items
+     * @param string $name
+     * @param DirectoryTreeListNode[] $subLists
+     */
+    public function __construct(
+        array $items,
+        private readonly string $name,
+        private readonly array $subLists,
+    ) {
+        parent::__construct($items);
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return DirectoryTreeListNode[]
+     */
+    public function getSubLists(): array
+    {
+        return $this->subLists;
+    }
+}

--- a/packages/typo3-docs-theme/src/Nodes/DirectoryTree/DirectoryTreeListNode.php
+++ b/packages/typo3-docs-theme/src/Nodes/DirectoryTree/DirectoryTreeListNode.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace T3Docs\Typo3DocsTheme\Nodes\DirectoryTree;
+
+use phpDocumentor\Guides\Nodes\CompoundNode;
+
+/** @extends CompoundNode<DirectoryTreeListItemNode> */
+final class DirectoryTreeListNode extends CompoundNode
+{
+    /**
+     * @param DirectoryTreeListItemNode[] $items
+     */
+    public function __construct(array $items, private readonly string $name)
+    {
+        parent::__construct($items);
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return DirectoryTreeListItemNode[]
+     */
+    public function getChildren(): array
+    {
+        return $this->value;
+    }
+}

--- a/packages/typo3-docs-theme/src/Nodes/DirectoryTreeNode.php
+++ b/packages/typo3-docs-theme/src/Nodes/DirectoryTreeNode.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace T3Docs\Typo3DocsTheme\Nodes;
+
+use phpDocumentor\Guides\Nodes\InlineCompoundNode;
+use phpDocumentor\Guides\Nodes\Node;
+use phpDocumentor\Guides\RestructuredText\Nodes\GeneralDirectiveNode;
+
+final class DirectoryTreeNode extends GeneralDirectiveNode
+{
+    /** @param list<Node> $value */
+    public function __construct(
+        protected readonly string $name,
+        protected readonly string $plainContent,
+        protected readonly InlineCompoundNode $content,
+        array $value = [],
+        private readonly string $id = '',
+        private readonly int $level = PHP_INT_MAX,
+        private readonly bool $showFileIcons = false,
+    ) {
+        parent::__construct($name, $plainContent, $content, $value);
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getLevel(): int
+    {
+        return $this->level;
+    }
+
+    public function isShowFileIcons(): bool
+    {
+        return $this->showFileIcons;
+    }
+
+}

--- a/tests/Integration/tests/directory-tree/expected/index.html
+++ b/tests/Integration/tests/directory-tree/expected/index.html
@@ -1,0 +1,575 @@
+<!-- content start -->
+                <section class="section" id="directory-tree">
+            <h1>Directory tree<a class="headerlink" href="#directory-tree" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+
+
+<div class="directory-tree">
+            <ul id="directory-tree-1">
+                                    <li id="directory-tree-1-1">
+        <div class="content">
+                            <div class="toggle">
+                    <a data-bs-toggle="collapse"
+                       href="#directory-tree-1-1-list"
+                       aria-expanded="true"
+                       aria-controls="directory-tree-1-1-list"
+                       class=""
+                    >
+                        <span class="icon"></span>
+                    </a>
+                </div>
+                                    <div class="fileItem">
+                        <i class="far fa-folder"></i>
+                    </div>
+                                        <div class="label">
+
+    <p>EXT:my_sitepackage/Resources/Private/Templates/</p>
+
+                                                </div>
+        </div>
+                    <ul class="collapse show" id="directory-tree-1-1-list">
+                                            <li id="directory-tree-1-1-1">
+        <div class="content">
+                            <div class="toggle">
+                    <a data-bs-toggle="collapse"
+                       href="#directory-tree-1-1-1-list"
+                       aria-expanded="false"
+                       aria-controls="directory-tree-1-1-1-list"
+                       class="collapsed"
+                    >
+                        <span class="icon"></span>
+                    </a>
+                </div>
+                                    <div class="fileItem">
+                        <i class="far fa-folder"></i>
+                    </div>
+                                        <div class="label">
+
+    <p>Layouts</p>
+
+                                                </div>
+        </div>
+                    <ul class="collapse" id="directory-tree-1-1-1-list">
+                                            <li id="directory-tree-1-1-1-1">
+        <div class="content">
+                            <div class="no-toggle">
+                </div>
+                                    <div class="fileItem">
+                        <i class="far fa-file"></i>
+                    </div>
+                                        <div class="label">
+                                                            Default.html
+                                                </div>
+        </div>
+            </li>
+
+                                            <li id="directory-tree-1-1-1-2">
+        <div class="content">
+                            <div class="no-toggle">
+                </div>
+                                    <div class="fileItem">
+                        <i class="far fa-file"></i>
+                    </div>
+                                        <div class="label">
+                                                            WithoutHeader.html
+                                                </div>
+        </div>
+            </li>
+
+                            </ul>
+            </li>
+
+                                            <li id="directory-tree-1-1-2">
+        <div class="content">
+                            <div class="toggle">
+                    <a data-bs-toggle="collapse"
+                       href="#directory-tree-1-1-2-list"
+                       aria-expanded="false"
+                       aria-controls="directory-tree-1-1-2-list"
+                       class="collapsed"
+                    >
+                        <span class="icon"></span>
+                    </a>
+                </div>
+                                    <div class="fileItem">
+                        <i class="far fa-folder"></i>
+                    </div>
+                                        <div class="label">
+
+    <p>Pages</p>
+
+                                                </div>
+        </div>
+                    <ul class="collapse" id="directory-tree-1-1-2-list">
+                                            <li id="directory-tree-1-1-2-1">
+        <div class="content">
+                            <div class="no-toggle">
+                </div>
+                                    <div class="fileItem">
+                        <i class="far fa-file"></i>
+                    </div>
+                                        <div class="label">
+                                                            Default.html
+                                                </div>
+        </div>
+            </li>
+
+                                            <li id="directory-tree-1-1-2-2">
+        <div class="content">
+                            <div class="no-toggle">
+                </div>
+                                    <div class="fileItem">
+                        <i class="far fa-file"></i>
+                    </div>
+                                        <div class="label">
+                                                            StartPage.html
+                                                </div>
+        </div>
+            </li>
+
+                                            <li id="directory-tree-1-1-2-3">
+        <div class="content">
+                            <div class="no-toggle">
+                </div>
+                                    <div class="fileItem">
+                        <i class="far fa-file"></i>
+                    </div>
+                                        <div class="label">
+                                                            TwoColumns.html
+                                                </div>
+        </div>
+            </li>
+
+                                            <li id="directory-tree-1-1-2-4">
+        <div class="content">
+                            <div class="no-toggle">
+                </div>
+                                    <div class="fileItem">
+                        <i class="far fa-file"></i>
+                    </div>
+                                        <div class="label">
+                                                            With_sidebar.html
+                                                </div>
+        </div>
+            </li>
+
+                            </ul>
+            </li>
+
+                                            <li id="directory-tree-1-1-3">
+        <div class="content">
+                            <div class="toggle">
+                    <a data-bs-toggle="collapse"
+                       href="#directory-tree-1-1-3-list"
+                       aria-expanded="false"
+                       aria-controls="directory-tree-1-1-3-list"
+                       class="collapsed"
+                    >
+                        <span class="icon"></span>
+                    </a>
+                </div>
+                                    <div class="fileItem">
+                        <i class="far fa-folder"></i>
+                    </div>
+                                        <div class="label">
+
+    <p>Partials</p>
+
+                                                </div>
+        </div>
+                    <ul class="collapse" id="directory-tree-1-1-3-list">
+                                            <li id="directory-tree-1-1-3-1">
+        <div class="content">
+                            <div class="no-toggle">
+                </div>
+                                    <div class="fileItem">
+                        <i class="far fa-file"></i>
+                    </div>
+                                        <div class="label">
+                                                            Footer.html
+                                                </div>
+        </div>
+            </li>
+
+                                            <li id="directory-tree-1-1-3-2">
+        <div class="content">
+                            <div class="no-toggle">
+                </div>
+                                    <div class="fileItem">
+                        <i class="far fa-file"></i>
+                    </div>
+                                        <div class="label">
+                                                            Sidebar.html
+                                                </div>
+        </div>
+            </li>
+
+                                            <li id="directory-tree-1-1-3-3">
+        <div class="content">
+                            <div class="no-toggle">
+                </div>
+                                    <div class="fileItem">
+                        <i class="far fa-file"></i>
+                    </div>
+                                        <div class="label">
+                                                            Menu.html
+                                                </div>
+        </div>
+            </li>
+
+                            </ul>
+            </li>
+
+                            </ul>
+            </li>
+
+                    </ul>
+    </div>
+            <section class="section" id="directory-structure-of-a-typo3-extension">
+            <h2>Directory structure of a typo3 extension<a class="headerlink" href="#directory-structure-of-a-typo3-extension" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h2>
+
+
+<div class="directory-tree">
+            <ul id="directory-tree-2">
+                                    <li id="directory-tree-2-1">
+        <div class="content">
+                            <div class="no-toggle">
+                </div>
+                                        <div class="label">
+                                                            <code class="code-inline file" translate="no" title="File path">composer.json</code>
+                                                </div>
+        </div>
+            </li>
+
+                                    <li id="directory-tree-2-2">
+        <div class="content">
+                            <div class="no-toggle">
+                </div>
+                                        <div class="label">
+                                                            <code class="code-inline file" translate="no" title="File path">ext_conf_template.txt</code>
+                                                </div>
+        </div>
+            </li>
+
+                                    <li id="directory-tree-2-3">
+        <div class="content">
+                            <div class="no-toggle">
+                </div>
+                                        <div class="label">
+                                                            <code class="code-inline file" translate="no" title="File path">ext_emconf.php</code>
+                                                </div>
+        </div>
+            </li>
+
+                                    <li id="directory-tree-2-4">
+        <div class="content">
+                            <div class="no-toggle">
+                </div>
+                                        <div class="label">
+                                                            <code class="code-inline file" translate="no" title="File path">ext_localconf.php</code>
+                                                </div>
+        </div>
+            </li>
+
+                                    <li id="directory-tree-2-5">
+        <div class="content">
+                            <div class="no-toggle">
+                </div>
+                                        <div class="label">
+                                                            <code class="code-inline file" translate="no" title="File path">ext_tables.php</code>
+                                                </div>
+        </div>
+            </li>
+
+                                    <li id="directory-tree-2-6">
+        <div class="content">
+                            <div class="no-toggle">
+                </div>
+                                        <div class="label">
+                                                            <code class="code-inline file" translate="no" title="File path">ext_tables.sql</code>
+                                                </div>
+        </div>
+            </li>
+
+                                    <li id="directory-tree-2-7">
+        <div class="content">
+                            <div class="no-toggle">
+                </div>
+                                        <div class="label">
+                                                            <code class="code-inline file" translate="no" title="File path">ext_tables_static+adt.sql</code>
+                                                </div>
+        </div>
+            </li>
+
+                                    <li id="directory-tree-2-8">
+        <div class="content">
+                            <div class="no-toggle">
+                </div>
+                                        <div class="label">
+                                                            <code class="code-inline file" translate="no" title="File path">ext_typoscript_constants.typoscript</code>
+                                                </div>
+        </div>
+            </li>
+
+                                    <li id="directory-tree-2-9">
+        <div class="content">
+                            <div class="no-toggle">
+                </div>
+                                        <div class="label">
+                                                            <code class="code-inline file" translate="no" title="File path">ext_typoscript_setup.typoscript</code>
+                                                </div>
+        </div>
+            </li>
+
+                                    <li id="directory-tree-2-10">
+        <div class="content">
+                            <div class="no-toggle">
+                </div>
+                                        <div class="label">
+                                                            <code class="code-inline path" translate="no" title="Path">Classes</code>
+                                                </div>
+        </div>
+            </li>
+
+                                    <li id="directory-tree-2-11">
+        <div class="content">
+                            <div class="toggle">
+                    <a data-bs-toggle="collapse"
+                       href="#directory-tree-2-11-list"
+                       aria-expanded="true"
+                       aria-controls="directory-tree-2-11-list"
+                       class=""
+                    >
+                        <span class="icon"></span>
+                    </a>
+                </div>
+                                        <div class="label">
+
+    <p><code class="code-inline path" translate="no" title="Path">Configuration</code></p>
+
+                                                </div>
+        </div>
+                    <ul class="collapse show" id="directory-tree-2-11-list">
+                                            <li id="directory-tree-2-11-1">
+        <div class="content">
+                            <div class="no-toggle">
+                </div>
+                                        <div class="label">
+                                                            <code class="code-inline path" translate="no" title="Path">Backend</code>
+                                                </div>
+        </div>
+            </li>
+
+                                            <li id="directory-tree-2-11-2">
+        <div class="content">
+                            <div class="toggle">
+                    <a data-bs-toggle="collapse"
+                       href="#directory-tree-2-11-2-list"
+                       aria-expanded="true"
+                       aria-controls="directory-tree-2-11-2-list"
+                       class=""
+                    >
+                        <span class="icon"></span>
+                    </a>
+                </div>
+                                        <div class="label">
+
+    <p><code class="code-inline path" translate="no" title="Path">Extbase</code></p>
+
+                                                </div>
+        </div>
+                    <ul class="collapse show" id="directory-tree-2-11-2-list">
+                                            <li id="directory-tree-2-11-2-1">
+        <div class="content">
+                            <div class="no-toggle">
+                </div>
+                                        <div class="label">
+                                                            <code class="code-inline path" translate="no" title="Path">Persistence</code>
+                                                </div>
+        </div>
+            </li>
+
+                            </ul>
+            </li>
+
+                                            <li id="directory-tree-2-11-3">
+        <div class="content">
+                            <div class="no-toggle">
+                </div>
+                                        <div class="label">
+                                                            <code class="code-inline path" translate="no" title="Path">TCA</code>
+                                                </div>
+        </div>
+            </li>
+
+                                            <li id="directory-tree-2-11-4">
+        <div class="content">
+                            <div class="no-toggle">
+                </div>
+                                        <div class="label">
+                                                            <code class="code-inline path" translate="no" title="Path">TsConfig</code>
+                                                </div>
+        </div>
+            </li>
+
+                                            <li id="directory-tree-2-11-5">
+        <div class="content">
+                            <div class="no-toggle">
+                </div>
+                                        <div class="label">
+                                                            <code class="code-inline path" translate="no" title="Path">TypoScript</code>
+                                                </div>
+        </div>
+            </li>
+
+                                            <li id="directory-tree-2-11-6">
+        <div class="content">
+                            <div class="no-toggle">
+                </div>
+                                        <div class="label">
+                                                            <code class="code-inline file" translate="no" title="File path">ContentSecurityPolicies.php</code>
+                                                </div>
+        </div>
+            </li>
+
+                                            <li id="directory-tree-2-11-7">
+        <div class="content">
+                            <div class="no-toggle">
+                </div>
+                                        <div class="label">
+                                                            <code class="code-inline file" translate="no" title="File path">Icons.php</code>
+                                                </div>
+        </div>
+            </li>
+
+                                            <li id="directory-tree-2-11-8">
+        <div class="content">
+                            <div class="no-toggle">
+                </div>
+                                        <div class="label">
+                                                            <code class="code-inline file" translate="no" title="File path">page.tsconfig</code>
+                                                </div>
+        </div>
+            </li>
+
+                                            <li id="directory-tree-2-11-9">
+        <div class="content">
+                            <div class="no-toggle">
+                </div>
+                                        <div class="label">
+                                                            <code class="code-inline file" translate="no" title="File path">RequestMiddlewares.php</code>
+                                                </div>
+        </div>
+            </li>
+
+                                            <li id="directory-tree-2-11-10">
+        <div class="content">
+                            <div class="no-toggle">
+                </div>
+                                        <div class="label">
+                                                            <code class="code-inline file" translate="no" title="File path">Services.yaml</code>
+                                                </div>
+        </div>
+            </li>
+
+                                            <li id="directory-tree-2-11-11">
+        <div class="content">
+                            <div class="no-toggle">
+                </div>
+                                        <div class="label">
+                                                            <code class="code-inline file" translate="no" title="File path">user.tsconfig</code>
+                                                </div>
+        </div>
+            </li>
+
+                            </ul>
+            </li>
+
+                                    <li id="directory-tree-2-12">
+        <div class="content">
+                            <div class="no-toggle">
+                </div>
+                                        <div class="label">
+                                                            <code class="code-inline path" translate="no" title="Path">Documentation</code>
+                                                </div>
+        </div>
+            </li>
+
+                                    <li id="directory-tree-2-13">
+        <div class="content">
+                            <div class="toggle">
+                    <a data-bs-toggle="collapse"
+                       href="#directory-tree-2-13-list"
+                       aria-expanded="true"
+                       aria-controls="directory-tree-2-13-list"
+                       class=""
+                    >
+                        <span class="icon"></span>
+                    </a>
+                </div>
+                                        <div class="label">
+
+    <p><code class="code-inline path" translate="no" title="Path">Resources</code></p>
+
+                                                </div>
+        </div>
+                    <ul class="collapse show" id="directory-tree-2-13-list">
+                                            <li id="directory-tree-2-13-1">
+        <div class="content">
+                            <div class="toggle">
+                    <a data-bs-toggle="collapse"
+                       href="#directory-tree-2-13-1-list"
+                       aria-expanded="true"
+                       aria-controls="directory-tree-2-13-1-list"
+                       class=""
+                    >
+                        <span class="icon"></span>
+                    </a>
+                </div>
+                                        <div class="label">
+
+    <p><code class="code-inline path" translate="no" title="Path">Private</code></p>
+
+                                                </div>
+        </div>
+                    <ul class="collapse show" id="directory-tree-2-13-1-list">
+                                            <li id="directory-tree-2-13-1-1">
+        <div class="content">
+                            <div class="no-toggle">
+                </div>
+                                        <div class="label">
+                                                            <code class="code-inline path" translate="no" title="Path">Language</code>
+                                                </div>
+        </div>
+            </li>
+
+                            </ul>
+            </li>
+
+                                            <li id="directory-tree-2-13-2">
+        <div class="content">
+                            <div class="no-toggle">
+                </div>
+                                        <div class="label">
+                                                            <code class="code-inline path" translate="no" title="Path">Public</code>
+                                                </div>
+        </div>
+            </li>
+
+                            </ul>
+            </li>
+
+                                    <li id="directory-tree-2-14">
+        <div class="content">
+                            <div class="no-toggle">
+                </div>
+                                        <div class="label">
+                                                            <code class="code-inline path" translate="no" title="Path">Tests</code>
+                                                </div>
+        </div>
+            </li>
+
+                    </ul>
+    </div>
+    </section>
+    </section>
+        <!-- content end -->

--- a/tests/Integration/tests/directory-tree/input/index.rst
+++ b/tests/Integration/tests/directory-tree/input/index.rst
@@ -1,0 +1,70 @@
+==============
+Directory tree
+==============
+
+..  directory-tree::
+    :level: 2
+    :show-file-icons: true
+
+    *   EXT:my_sitepackage/Resources/Private/Templates/
+
+        *   Layouts
+
+            *   Default.html
+            *   WithoutHeader.html
+
+        *   Pages
+
+            *   Default.html
+            *   StartPage.html
+            *   TwoColumns.html
+            *   With_sidebar.html
+
+        *   Partials
+
+            *   Footer.html
+            *   Sidebar.html
+            *   Menu.html
+
+Directory structure of a typo3 extension
+========================================
+
+..  directory-tree::
+
+    *   :file:`composer.json`
+    *   :file:`ext_conf_template.txt`
+    *   :file:`ext_emconf.php`
+    *   :file:`ext_localconf.php`
+    *   :file:`ext_tables.php`
+    *   :file:`ext_tables.sql`
+    *   :file:`ext_tables_static+adt.sql`
+    *   :file:`ext_typoscript_constants.typoscript`
+    *   :file:`ext_typoscript_setup.typoscript`
+    *   :path:`Classes`
+    *   :path:`Configuration`
+
+        *   :path:`Backend`
+        *   :path:`Extbase`
+
+            *   :path:`Persistence`
+
+        *   :path:`TCA`
+        *   :path:`TsConfig`
+        *   :path:`TypoScript`
+        *   :file:`ContentSecurityPolicies.php`
+        *   :file:`Icons.php`
+        *   :file:`page.tsconfig`
+        *   :file:`RequestMiddlewares.php`
+        *   :file:`Services.yaml`
+        *   :file:`user.tsconfig`
+
+    *   :path:`Documentation`
+    *   :path:`Resources`
+
+        *   :path:`Private`
+
+            *   :path:`Language`
+
+        *   :path:`Public`
+
+    *   :path:`Tests`

--- a/tests/Integration/tests/file/expected/index.html
+++ b/tests/Integration/tests/file/expected/index.html
@@ -2,7 +2,7 @@
                 <section class="section" id="file">
             <h1>File<a class="headerlink" href="#file" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
 
-    <p><code class="code-inline" translate="no" title="File path">/tmp/some.file</code></p>
+    <p><code class="code-inline file" translate="no" title="File path">/tmp/some.file</code></p>
 
     </section>
         <!-- content end -->

--- a/tests/Integration/tests/roles/role-file/expected/index.html
+++ b/tests/Integration/tests/roles/role-file/expected/index.html
@@ -2,7 +2,7 @@
                 <section class="section" id="document-title">
             <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
 
-    <p>Configure your manual in <code class="code-inline" translate="no" title="File path">Documentation/guides.xml</code>.</p>
+    <p>Configure your manual in <code class="code-inline file" translate="no" title="File path">Documentation/guides.xml</code>.</p>
 
     </section>
         <!-- content end -->


### PR DESCRIPTION
Introduce a collapsible directory tree:

![image](https://github.com/TYPO3-Documentation/render-guides/assets/48202465/1ca42fea-4e45-4de4-bc0f-fb6f3f9d76c4)

There are advantages over using a plaintext codeblock like 
https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/WritingReST/Reference/Code/Codeblocks.html#show-a-directory-tree
In that the resulting tree is collapsible, takes up less space and is a native nested list which improves a11y.
Also it is much easier to use