### PR TITLE
[FEATURE] Introduce confval-menu directive

### DIFF
--- a/Documentation-rendertest/Confval/Index.rst
+++ b/Documentation-rendertest/Confval/Index.rst
@@ -6,9 +6,13 @@
 confval
 =======
 
-..  contents:: This page
-    :local:
-
+..  confval-menu::
+    :display: table
+    :exclude-noindex: true
+    :exclude: addRecord
+    :type:
+    :Default:
+    :Possible:
 
 Summary
 =======
@@ -29,7 +33,7 @@ Source:
 ..  code-block:: rst
 
     ..  confval:: mr_pommeroy
-        :default: Happy new year, Sophie!
+        :Default: Happy new year, Sophie!
         :type:     shy
 
         Participant of Miss Sophie's birthday party.
@@ -37,8 +41,8 @@ Source:
 Result:
 
 ..  confval:: mr_pommeroy
-    :default: Happy new year, Sophie!
-    :type:     shy
+    :type: shy
+    :Default: Happy new year, Sophie!
 
     Participant of Miss Sophie's birthday party.
 
@@ -56,7 +60,7 @@ Adapted from the TypoScript Reference Manual:
 
 ..  confval:: align
     :type:     align
-    :default: left
+    :Default: left
     :Possible: \left | \center \| right
 
     Decides about alignment.
@@ -67,51 +71,67 @@ Adapted from the TypoScript Reference Manual:
 
 
 
-..  confval:: boolean
-    :type: boolean
-    :Possible: 1 | 0
+    ..  confval:: boolean
+        :type: boolean
+        :Possible: 1 | 0
 
-    1 means TRUE and 0 means FALSE.
+        1 means TRUE and 0 means FALSE.
 
-    Everything else is evaluated to one of these values by PHP:
-    Non-empty strings (except `0` [zero]) are treated as TRUE,
-    empty strings are evaluated to FALSE.
+        Everything else is evaluated to one of these values by PHP:
+        Non-empty strings (except `0` [zero]) are treated as TRUE,
+        empty strings are evaluated to FALSE.
 
-    Examples::
+        Examples::
 
-        dummy.enable = 0    # false, preferred notation
-        dummy.enable = 1    # true,  preferred notation
-        dummy.enable =      # false, because the value is empty
+            dummy.enable = 0    # false, preferred notation
+            dummy.enable = 1    # true,  preferred notation
+            dummy.enable =      # false, because the value is empty
+
+        ..  confval:: boolean2
+            :type: boolean
+            :Possible: 1 | 0
+
+            1 means TRUE and 0 means FALSE.
+
+            Everything else is evaluated to one of these values by PHP:
+            Non-empty strings (except `0` [zero]) are treated as TRUE,
+            empty strings are evaluated to FALSE.
+
+            Examples::
+
+                dummy.enable = 0    # false, preferred notation
+                dummy.enable = 1    # true,  preferred notation
+                dummy.enable =      #
 
 
 
-..  confval:: case
+    ..  confval:: case
+        :type: case
 
-    :type: case
-    :Possible:
-        ===================== ==========================================================
-        Value                 Effect
-        ===================== ==========================================================
-        :ts:`upper`           Convert all letters of the string to upper case
-        :ts:`lower`           Convert all letters of the string to lower case
-        :ts:`capitalize`      Uppercase the first character of each word in the string
-        :ts:`ucfirst`         Convert the first letter of the string to upper case
-        :ts:`lcfirst`         Convert the first letter of the string to lower case
-        :ts:`uppercamelcase`  Convert underscored `upper_camel_case` to `UpperCamelCase`
-        :ts:`lowercamelcase`  Convert underscored `lower_camel_case` to `lowerCamelCase`
-        ===================== ==========================================================
+        :Possible:
+            ===================== ==========================================================
+            Value                 Effect
+            ===================== ==========================================================
+            :ts:`upper`           Convert all letters of the string to upper case
+            :ts:`lower`           Convert all letters of the string to lower case
+            :ts:`capitalize`      Uppercase the first character of each word in the string
+            :ts:`ucfirst`         Convert the first letter of the string to upper case
+            :ts:`lcfirst`         Convert the first letter of the string to lower case
+            :ts:`uppercamelcase`  Convert underscored `upper_camel_case` to `UpperCamelCase`
+            :ts:`lowercamelcase`  Convert underscored `lower_camel_case` to `lowerCamelCase`
+            ===================== ==========================================================
 
-    Do a case conversion.
+        Do a case conversion.
 
-    Example code::
+        Example code::
 
-        10 = TEXT
-        10.value = Hello world!
-        10.case = upper
+            10 = TEXT
+            10.value = Hello world!
+            10.case = upper
 
-    Result::
+        Result::
 
-        HELLO WORLD!
+            HELLO WORLD!
 
 
 ..  _Demo 3 - addRecord:

--- a/composer.lock
+++ b/composer.lock
@@ -1455,16 +1455,16 @@
         },
         {
             "name": "phpdocumentor/guides-restructured-text",
-            "version": "1.3.4",
+            "version": "1.3.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/guides-restructured-text.git",
-                "reference": "08f3e17cb999d841fe5478a9c35a9ff0ccbda7a2"
+                "reference": "8527348a36b4e228c453041f4d8cb52a2a45092c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/guides-restructured-text/zipball/08f3e17cb999d841fe5478a9c35a9ff0ccbda7a2",
-                "reference": "08f3e17cb999d841fe5478a9c35a9ff0ccbda7a2",
+                "url": "https://api.github.com/repos/phpDocumentor/guides-restructured-text/zipball/8527348a36b4e228c453041f4d8cb52a2a45092c",
+                "reference": "8527348a36b4e228c453041f4d8cb52a2a45092c",
                 "shasum": ""
             },
             "require": {
@@ -1487,9 +1487,9 @@
             "description": "Adds reStructuredText Markup support to the phpDocumentor's Guides library.",
             "homepage": "https://www.phpdoc.org",
             "support": {
-                "source": "https://github.com/phpDocumentor/guides-restructured-text/tree/1.3.4"
+                "source": "https://github.com/phpDocumentor/guides-restructured-text/tree/1.3.6"
             },
-            "time": "2024-05-07T05:15:52+00:00"
+            "time": "2024-05-10T16:42:35+00:00"
         },
         {
             "name": "phpdocumentor/guides-theme-bootstrap",
@@ -1680,20 +1680,20 @@
         },
         {
             "name": "psr/http-factory",
-            "version": "1.0.2",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/http-factory.git",
-                "reference": "e616d01114759c4c489f93b099585439f795fe35"
+                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/e616d01114759c4c489f93b099585439f795fe35",
-                "reference": "e616d01114759c4c489f93b099585439f795fe35",
+                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
+                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.0.0",
+                "php": ">=7.1",
                 "psr/http-message": "^1.0 || ^2.0"
             },
             "type": "library",
@@ -1717,7 +1717,7 @@
                     "homepage": "https://www.php-fig.org/"
                 }
             ],
-            "description": "Common interfaces for PSR-7 HTTP message factories",
+            "description": "PSR-17: Common interfaces for PSR-7 HTTP message factories",
             "keywords": [
                 "factory",
                 "http",
@@ -1729,9 +1729,9 @@
                 "response"
             ],
             "support": {
-                "source": "https://github.com/php-fig/http-factory/tree/1.0.2"
+                "source": "https://github.com/php-fig/http-factory"
             },
-            "time": "2023-04-10T20:10:41+00:00"
+            "time": "2024-04-15T12:06:14+00:00"
         },
         {
             "name": "psr/http-message",
@@ -4355,16 +4355,16 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v3.56.0",
+            "version": "v3.56.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer.git",
-                "reference": "4429303e62a4ce583ddfe64ff5c34c76bcf74931"
+                "reference": "69c6168ae8bc96dc656c7f6c7271120a68ae5903"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/4429303e62a4ce583ddfe64ff5c34c76bcf74931",
-                "reference": "4429303e62a4ce583ddfe64ff5c34c76bcf74931",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/69c6168ae8bc96dc656c7f6c7271120a68ae5903",
+                "reference": "69c6168ae8bc96dc656c7f6c7271120a68ae5903",
                 "shasum": ""
             },
             "require": {
@@ -4436,7 +4436,7 @@
             ],
             "support": {
                 "issues": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues",
-                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.56.0"
+                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.56.1"
             },
             "funding": [
                 {
@@ -4444,7 +4444,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-05-07T15:50:05+00:00"
+            "time": "2024-05-10T11:31:15+00:00"
         },
         {
             "name": "justinrainbow/json-schema",

--- a/packages/typo3-docs-theme/assets/sass/components/_table.scss
+++ b/packages/typo3-docs-theme/assets/sass/components/_table.scss
@@ -1,5 +1,4 @@
 .table {
-    @extend .table-striped;
     th :last-child,
     td :last-child {
         margin-bottom: 0;

--- a/packages/typo3-docs-theme/resources/config/typo3-docs-theme.php
+++ b/packages/typo3-docs-theme/resources/config/typo3-docs-theme.php
@@ -15,6 +15,7 @@ use phpDocumentor\Guides\RestructuredText\Parser\Interlink\InterlinkParser;
 use phpDocumentor\Guides\RestructuredText\Parser\Productions\DirectiveContentRule;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
+use T3Docs\Typo3DocsTheme\Compiler\NodeTransformers\ConfvalMenuNodeTransformer;
 use T3Docs\Typo3DocsTheme\Directives\DirectoryTreeDirective;
 use T3Docs\Typo3DocsTheme\Directives\RawDirective;
 use T3Docs\Typo3DocsTheme\EventListeners\AddThemeSettingsToProjectNode;
@@ -58,6 +59,9 @@ return static function (ContainerConfigurator $container): void {
         ->bind('$startingRule', service(DirectiveContentRule::class))
         ->instanceof(BaseDirective::class)
         ->tag('phpdoc.guides.directive')
+        ->set(ConfvalMenuNodeTransformer::class)
+        ->tag('phpdoc.guides.compiler.nodeTransformers')
+        ->set(TwigExtension::class)
         ->set(TwigExtension::class)
         ->tag('twig.extension')
         ->autowire()
@@ -104,6 +108,7 @@ return static function (ContainerConfigurator $container): void {
         ->decorate(PlantumlServerRenderer::class)
         ->public()
 
+        ->set(\T3Docs\Typo3DocsTheme\Directives\ConfvalMenuDirective::class)
         ->set(DirectoryTreeDirective::class)
         ->set(GroupTabDirective::class)
         ->set(RawDirective::class)

--- a/packages/typo3-docs-theme/resources/public/css/theme.css
+++ b/packages/typo3-docs-theme/resources/public/css/theme.css
@@ -12343,7 +12343,7 @@ progress {
   border-top-width: 0;
 }
 
-.table-striped > tbody > tr:nth-of-type(odd) > *, .table > tbody > tr:nth-of-type(odd) > * {
+.table-striped > tbody > tr:nth-of-type(odd) > * {
   --bs-table-color-type: var(--bs-table-striped-color);
   --bs-table-bg-type: var(--bs-table-striped-bg);
 }

--- a/packages/typo3-docs-theme/resources/template/body/directive/confval-menu.html.twig
+++ b/packages/typo3-docs-theme/resources/template/body/directive/confval-menu.html.twig
@@ -1,0 +1,154 @@
+{% macro renderConfvalListItem(entry, node) %}
+    <li id="{{ entry.id }}-tree">
+
+        {% set relevant_children = [] %}
+        {% for child in entry.value %}
+            {% if child.linkType == 'std:confval' %}
+                {% set relevant_children = relevant_children|merge([child]) %}
+            {% endif %}
+        {% endfor %}
+        <div class="label">
+            <a href="#{{ entry.id }}">{{ entry.plainContent }}</a>
+            {% for field in node.fields %}
+                {% if field=='type' %}
+                    , Type: {{ renderNode(entry.type) }}
+                {% elseif field=='default' %}
+                    , Default: {{ renderNode(entry.default) }}
+                {% else %}
+                    {%- for key, option in entry.additionalOptions -%}
+                        {%- if field==key %}
+                            , {{ key }}: {{  renderNode(option) }}
+                        {% endif -%}
+                    {% endfor -%}
+                {% endif %}
+            {% endfor %}
+        </div>
+
+        {% if relevant_children %}
+            <ul>
+                {% for child in relevant_children %}
+                    {{ _self.renderConfvalItem(child, node) }}
+                {% endfor %}
+            </ul>
+        {% endif %}
+    </li>
+{% endmacro %}
+
+{% macro renderConfvalItem(entry, node) %}
+    <li id="{{ entry.id }}-tree">
+        <div class="content">
+            {% set expanded = true %}
+            {% set relevant_children = [] %}
+            {% for child in entry.value %}
+                {% if child.linkType == 'std:confval' %}
+                    {% set relevant_children = relevant_children|merge([child]) %}
+                {% endif %}
+            {% endfor %}
+            {% if relevant_children %}
+                <div class="toggle">
+                    <a data-bs-toggle="collapse"
+                       href="#{{ entry.id }}-list"
+                       aria-expanded="{% if expanded %}true{% else %}false{% endif %}"
+                       aria-controls="{{ entry.id }}-list"
+                       class="{% if not expanded %}collapsed{% endif %}"
+                    >
+                        <span class="icon"></span>
+                    </a>
+                </div>
+            {% else %}
+                <div class="no-toggle">
+                </div>
+            {% endif %}
+            <div class="label">
+                <a href="#{{ entry.id }}">{{ entry.plainContent }}</a>
+                {% for field in node.fields %}
+                    {% if field=='type' %}
+                        , Type: {{ renderNode(entry.type) }}
+                    {% elseif field=='default' %}
+                        , Default: {{ renderNode(entry.default) }}
+                    {% else %}
+                        {%- for key, option in entry.additionalOptions -%}
+                            {%- if field==key %}
+                                , {{ key }}: {{  renderNode(option) }}
+                            {% endif -%}
+                        {% endfor -%}
+                    {% endif %}
+                {% endfor %}
+            </div>
+        </div>
+
+        {% if relevant_children %}
+            <ul class="collapse {%- if expanded %} show{% endif %}" id="{{ entry.id }}-list">
+                {% for child in relevant_children %}
+                    {{ _self.renderConfvalItem(child, node) }}
+                {% endfor %}
+            </ul>
+        {% endif %}
+    </li>
+{% endmacro %}
+
+{% macro renderConfvalRow(entry, node, level) %}
+    <tr>
+        <td><div class="confval-label ps-{{ level * 2 }}"><a href="#{{ entry.id }}">{{ entry.plainContent }}</a></div></td>
+        {% for field in node.fields %}
+            {% if field=='type' %}
+                <td>{{ renderNode(entry.type) }}</td>
+            {% elseif field=='default' %}
+                <td>{{ renderNode(entry.default) }}</td>
+            {% else %}
+                <td>
+                    {%- for key, option in entry.additionalOptions -%}
+                        {%- if field==key %}
+                            {{  renderNode(option) }}
+                        {% endif -%}
+                    {% endfor -%}
+                </td>
+            {% endif %}
+        {% endfor %}
+    </tr>
+    {% for child in entry.value %}
+        {% if child.linkType == 'std:confval' %}
+            {{ _self.renderConfvalRow(child, node, level+1) }}
+        {% endif %}
+    {% endfor %}
+{% endmacro %}
+
+{% import _self as macros %}
+{% if node.display=='list' %}
+<div class="mb-4">
+    <ul>
+        {% for entry in node.confvals %}
+            {{ macros.renderConfvalListItem(entry, node) }}
+        {% endfor %}
+    </ul>
+</div>
+{% elseif node.display=='tree' %}
+    <div class="directory-tree mb-4">
+        <ul>
+        {% for entry in node.confvals %}
+            {{ macros.renderConfvalItem(entry, node) }}
+        {% endfor %}
+        </ul>
+    </div>
+{% else %}
+<table class="table table-hover">
+    <thead>
+    <tr>
+        <th scope="col">Name</th>
+        {% for field in node.fields %}
+
+            {% if field=='type' %}
+                <th scope="col">Type</th>
+            {% elseif field=='default' %}
+                <th scope="col">Default</th>
+            {% else %}
+                <th scope="col">{{ field }}</th>
+            {% endif %}
+        {% endfor %}
+    </tr>
+    </thead>
+    {% for entry in node.confvals %}
+        {{ macros.renderConfvalRow(entry, node, 0) }}
+    {% endfor %}
+</table>
+{% endif %}

--- a/packages/typo3-docs-theme/src/Compiler/NodeTransformers/ConfvalMenuNodeTransformer.php
+++ b/packages/typo3-docs-theme/src/Compiler/NodeTransformers/ConfvalMenuNodeTransformer.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link https://phpdoc.org
+ */
+
+namespace T3Docs\Typo3DocsTheme\Compiler\NodeTransformers;
+
+use phpDocumentor\Guides\Compiler\CompilerContextInterface;
+use phpDocumentor\Guides\Compiler\NodeTransformer;
+use phpDocumentor\Guides\Nodes\CompoundNode;
+use phpDocumentor\Guides\Nodes\Node;
+use phpDocumentor\Guides\RestructuredText\Nodes\ConfvalNode;
+use Psr\Log\LoggerInterface;
+
+use T3Docs\Typo3DocsTheme\Nodes\ConfvalMenuNode;
+
+use function assert;
+
+/** @implements NodeTransformer<ConfvalMenuNode> */
+final class ConfvalMenuNodeTransformer implements NodeTransformer
+{
+    public function __construct(
+        private readonly LoggerInterface $logger,
+    ) {}
+
+    public function enterNode(Node $node, CompilerContextInterface $compilerContext): Node
+    {
+        return $node;
+    }
+
+    public function leaveNode(Node $node, CompilerContextInterface $compilerContext): Node|null
+    {
+        assert($node instanceof ConfvalMenuNode);
+        $confvals = $this->findConfvals($compilerContext->getDocumentNode(), $node);
+        if (count($confvals) < 1) {
+            $this->logger->warning('No confvals found for the confval-menu', $compilerContext->getLoggerInformation());
+        }
+        $node->setConfvals($confvals);
+
+        return $node;
+    }
+
+    /**
+     * @return ConfvalNode[]
+     */
+    private function findConfvals(Node $node, ConfvalMenuNode $confvalMenuNode): array
+    {
+        if ($node instanceof ConfvalNode) {
+            if ($confvalMenuNode->isExcludeNoindex() && $node->isNoindex()) {
+                return [];
+            }
+            if (in_array($node->getId(), $confvalMenuNode->getExclude(), true)) {
+                return [];
+            }
+            return [$node];
+        }
+        if ($node instanceof CompoundNode) {
+            $confvalNodes = [];
+            foreach ($node->getChildren() as $child) {
+                $confvalNodes = array_merge($confvalNodes, $this->findConfvals($child, $confvalMenuNode));
+            }
+            return $confvalNodes;
+        }
+        return [];
+    }
+
+    public function supports(Node $node): bool
+    {
+        return $node instanceof ConfvalMenuNode;
+    }
+
+    public function getPriority(): int
+    {
+        return 1000;
+    }
+}

--- a/packages/typo3-docs-theme/src/Directives/ConfvalMenuDirective.php
+++ b/packages/typo3-docs-theme/src/Directives/ConfvalMenuDirective.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link https://phpdoc.org
+ */
+
+namespace T3Docs\Typo3DocsTheme\Directives;
+
+use phpDocumentor\Guides\Nodes\CollectionNode;
+use phpDocumentor\Guides\Nodes\InlineCompoundNode;
+use phpDocumentor\Guides\Nodes\Node;
+use phpDocumentor\Guides\ReferenceResolvers\AnchorNormalizer;
+use phpDocumentor\Guides\RestructuredText\Directives\SubDirective;
+use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
+use phpDocumentor\Guides\RestructuredText\Parser\Directive;
+use phpDocumentor\Guides\RestructuredText\Parser\Productions\Rule;
+use T3Docs\Typo3DocsTheme\Nodes\ConfvalMenuNode;
+
+class ConfvalMenuDirective extends SubDirective
+{
+    public function __construct(
+        Rule $startingRule,
+        private readonly AnchorNormalizer $anchorReducer,
+    ) {
+        parent::__construct($startingRule);
+    }
+    protected function processSub(
+        BlockContext   $blockContext,
+        CollectionNode $collectionNode,
+        Directive      $directive,
+    ): Node|null {
+        $children = $collectionNode->getChildren();
+        $fields = [];
+        $display = 'list';
+        $excludeNoindex = false;
+        $excludeString = '';
+        foreach ($directive->getOptions() as $option) {
+            if ($option->getName() == 'name' || $option->getName() == 'class') {
+                continue;
+            }
+            if ($option->getName() == 'display') {
+                $display = (string) $option->getValue();
+                continue;
+            }
+            if ($option->getName() == 'exclude-noindex') {
+                $excludeNoindex = (bool) $option->getValue();
+                continue;
+            }
+            if ($option->getName() == 'exclude') {
+                $excludeString = (string) $option->getValue();
+                continue;
+            }
+            $fields[] = $option->getName();
+        }
+        $exclude = explode(',', $excludeString);
+        $anchorReducer = $this->anchorReducer;
+        $exclude = array_map(function ($element) use ($anchorReducer) {
+            return $anchorReducer->reduceAnchor($element);
+        }, $exclude);
+        return new ConfvalMenuNode(
+            $directive->getData(),
+            $directive->getDataNode() ?? new InlineCompoundNode(),
+            $children,
+            [],
+            $fields,
+            $display,
+            $excludeNoindex,
+            $exclude,
+        );
+    }
+    public function getName(): string
+    {
+        return 'confval-menu';
+    }
+}

--- a/packages/typo3-docs-theme/src/Nodes/ConfvalMenuNode.php
+++ b/packages/typo3-docs-theme/src/Nodes/ConfvalMenuNode.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace T3Docs\Typo3DocsTheme\Nodes;
+
+use phpDocumentor\Guides\Nodes\InlineCompoundNode;
+use phpDocumentor\Guides\Nodes\Node;
+use phpDocumentor\Guides\RestructuredText\Nodes\ConfvalNode;
+use phpDocumentor\Guides\RestructuredText\Nodes\GeneralDirectiveNode;
+
+final class ConfvalMenuNode extends GeneralDirectiveNode
+{
+    /**
+     * @param list<Node> $value
+     * @param Node[] $value
+     * @param ConfvalNode[] $confvals
+     * @param string[] $fields
+     * @param string[] $exclude
+     */
+    public function __construct(
+        protected readonly string $plainContent,
+        protected readonly InlineCompoundNode $content,
+        array $value = [],
+        private array $confvals = [],
+        private readonly array $fields = [],
+        private readonly string $display = 'tree',
+        private readonly bool $excludeNoindex = false,
+        private readonly array $exclude = []
+    ) {
+        parent::__construct('confval-menu', $plainContent, $content, $value);
+    }
+
+    /**
+     * @return ConfvalNode[]
+     */
+    public function getConfvals(): array
+    {
+        return $this->confvals;
+    }
+
+    /**
+     * @param ConfvalNode[] $confvals
+     */
+    public function setConfvals(array $confvals): void
+    {
+        $this->confvals = $confvals;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getFields(): array
+    {
+        return $this->fields;
+    }
+
+    public function getDisplay(): string
+    {
+        return $this->display;
+    }
+
+    public function isExcludeNoindex(): bool
+    {
+        return $this->excludeNoindex;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getExclude(): array
+    {
+        return $this->exclude;
+    }
+}

--- a/tests/Integration/tests-full/navigation-title/expected/anotherPage.html
+++ b/tests/Integration/tests-full/navigation-title/expected/anotherPage.html
@@ -3,7 +3,7 @@
 <head>
     <title>Another Page — Example Project 12.4 documentation</title>
 
-
+    
 <meta charset="utf-8">
 <meta content="width=device-width, initial-scale=1.0" name="viewport">
 <meta content="phpdocumentor/guides" name="generator">
@@ -25,7 +25,7 @@
     </head>
 <body>
 <div class="page">
-
+    
 <header>
     <div class="page-topbar">
         <div class="page-topbar-inner">
@@ -65,7 +65,7 @@
                 <nav>
                     <input class="toc-checkbox" id="toggleToc" type="checkbox">
 
-
+                    
 <div class="toc-header">
     <div class="toc-title">
         <a class="toc-title-project" href="index.html">Example Project</a>
@@ -86,7 +86,7 @@
 </div>                    <div class="toc-collapse">
                                                 <div aria-label="main navigation" class="toc" role="navigation">
                                 <div aria-label="Main navigation" class="main_menu" role="navigation">
-
+        
     <ul class="menu-level-1">
     <li class=" current active">
     <a href="#" aria-current="page">
@@ -119,7 +119,7 @@
             </div>
             <div class="page-main-content">
                 <div class="rst-content">                        <nav aria-label="breadcrumbs navigation" class="breadcrumb-bar" role="navigation">
-
+        
 <ol class="breadcrumb">
     <li class="breadcrumb-item"><a href="index.html">Document Title</a></li>
                     <li aria-current="page"  class="breadcrumb-item  active">Another Page</li>
@@ -137,21 +137,21 @@
         <span class="btn-text">Edit on GitHub</span>
     </a>
     </div>    </nav>
-
+                    
 <article class="document" itemscope="itemscope" itemtype="http://schema.org/Article" role="main">
     <div itemprop="articleBody">
         <!-- content start -->
-
+                
 <section class="section" id="another-page">
             <h1>Another Page<a class="headerlink" href="#another-page" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
-
+            
     <p>Lorem Ipsum Dolor.</p>
 
     </section>
         <!-- content end -->
     </div>
 </article>
-
+                        
             <nav aria-label="Page navigation">
             <ul class="pagination justify-content-center"><li class="page-item">
                             <a class="page-link" href="index.html"

--- a/tests/Integration/tests-full/navigation-title/expected/index.html
+++ b/tests/Integration/tests-full/navigation-title/expected/index.html
@@ -3,7 +3,7 @@
 <head>
     <title>Document Title — Example Project 12.4 documentation</title>
 
-
+    
 <meta charset="utf-8">
 <meta content="width=device-width, initial-scale=1.0" name="viewport">
 <meta content="phpdocumentor/guides" name="generator">
@@ -24,7 +24,7 @@
     </head>
 <body>
 <div class="page">
-
+    
 <header>
     <div class="page-topbar">
         <div class="page-topbar-inner">
@@ -64,7 +64,7 @@
                 <nav>
                     <input class="toc-checkbox" id="toggleToc" type="checkbox">
 
-
+                    
 <div class="toc-header">
     <div class="toc-title">
         <a class="toc-title-project" href="#">Example Project</a>
@@ -85,7 +85,7 @@
 </div>                    <div class="toc-collapse">
                                                 <div aria-label="main navigation" class="toc" role="navigation">
                                 <div aria-label="Main navigation" class="main_menu" role="navigation">
-
+        
     <ul class="menu-level-1">
     <li class="">
     <a href="anotherPage.html">
@@ -118,7 +118,7 @@
             </div>
             <div class="page-main-content">
                 <div class="rst-content">                        <nav aria-label="breadcrumbs navigation" class="breadcrumb-bar" role="navigation">
-
+        
 <ol class="breadcrumb">
                 <li aria-current="page"  class="breadcrumb-item  active">Document Title</li>
         </ol>
@@ -135,14 +135,14 @@
         <span class="btn-text">Edit on GitHub</span>
     </a>
     </div>    </nav>
-
+                    
 <article class="document" itemscope="itemscope" itemtype="http://schema.org/Article" role="main">
     <div itemprop="articleBody">
         <!-- content start -->
-
+                
 <section class="section" id="document-title">
             <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
-
+            
     <p>Lorem Ipsum Dolor.</p>
 
             <div class="toctree-wrapper compound">
@@ -164,14 +164,14 @@
 </li>
     </ul>
 </div>
-
+            
     <p>See also</p>
 
     </section>
         <!-- content end -->
     </div>
 </article>
-
+                        
             <nav aria-label="Page navigation">
             <ul class="pagination justify-content-center"><li class="page-item">
                             <a class="page-link" href="anotherPage.html"

--- a/tests/Integration/tests-full/navigation-title/expected/yetAnotherPage.html
+++ b/tests/Integration/tests-full/navigation-title/expected/yetAnotherPage.html
@@ -3,7 +3,7 @@
 <head>
     <title>Yet Another Page — Example Project 12.4 documentation</title>
 
-
+    
 <meta charset="utf-8">
 <meta content="width=device-width, initial-scale=1.0" name="viewport">
 <meta content="phpdocumentor/guides" name="generator">
@@ -24,7 +24,7 @@
     </head>
 <body>
 <div class="page">
-
+    
 <header>
     <div class="page-topbar">
         <div class="page-topbar-inner">
@@ -64,7 +64,7 @@
                 <nav>
                     <input class="toc-checkbox" id="toggleToc" type="checkbox">
 
-
+                    
 <div class="toc-header">
     <div class="toc-title">
         <a class="toc-title-project" href="index.html">Example Project</a>
@@ -85,7 +85,7 @@
 </div>                    <div class="toc-collapse">
                                                 <div aria-label="main navigation" class="toc" role="navigation">
                                 <div aria-label="Main navigation" class="main_menu" role="navigation">
-
+        
     <ul class="menu-level-1">
     <li class="">
     <a href="anotherPage.html">
@@ -118,7 +118,7 @@
             </div>
             <div class="page-main-content">
                 <div class="rst-content">                        <nav aria-label="breadcrumbs navigation" class="breadcrumb-bar" role="navigation">
-
+        
 <ol class="breadcrumb">
     <li class="breadcrumb-item"><a href="index.html">Document Title</a></li>
                     <li aria-current="page"  class="breadcrumb-item  active">Title in Menu</li>
@@ -136,22 +136,22 @@
         <span class="btn-text">Edit on GitHub</span>
     </a>
     </div>    </nav>
-
+                    
 <article class="document" itemscope="itemscope" itemtype="http://schema.org/Article" role="main">
     <div itemprop="articleBody">
         <!-- content start -->
-
+                
 <section class="section" id="yet-another-page-1" data-rst-anchor="yet-another-page">
             <a id="yet-another-page"></a>
             <h1>Yet Another Page<a class="headerlink" href="#yet-another-page-1" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
-
+            
     <p>Lorem Ipsum Dolor.</p>
 
     </section>
         <!-- content end -->
     </div>
 </article>
-
+                        
             <nav aria-label="Page navigation">
             <ul class="pagination justify-content-center"><li class="page-item">
                             <a class="page-link" href="somePage.html"

--- a/tests/Integration/tests/confval/confval-basic/expected/index.html
+++ b/tests/Integration/tests/confval/confval-basic/expected/index.html
@@ -9,10 +9,13 @@
     <dd>
                 <dl class="field-list simple">
                             <dt class="field-even">Type</dt>
-                <dd class="field-even"><code class="code-inline" translate="no">&quot;Hello World&quot;</code>
+                <dd class="field-even">string
                 </dd>
                         <dt class="field-odd">Required</dt>
             <dd class="field-odd"><p>true</p>
+            </dd>
+                        <dt class="field-odd">Default</dt>
+            <dd class="field-odd"><code class="code-inline" translate="no">&quot;Hello World&quot;</code>
             </dd>
             </dl>
                 <div class="confval-description">

--- a/tests/Integration/tests/confval/confval-duplicate-with-name/expected/anotherDomain.html
+++ b/tests/Integration/tests/confval/confval-duplicate-with-name/expected/anotherDomain.html
@@ -9,10 +9,13 @@
     <dd>
                 <dl class="field-list simple">
                             <dt class="field-even">Type</dt>
-                <dd class="field-even"><code class="code-inline" translate="no">&quot;Hello World&quot;</code>
+                <dd class="field-even">string
                 </dd>
                         <dt class="field-odd">Required</dt>
             <dd class="field-odd"><p>true</p>
+            </dd>
+                        <dt class="field-odd">Default</dt>
+            <dd class="field-odd"><code class="code-inline" translate="no">&quot;Hello World&quot;</code>
             </dd>
             </dl>
                 <div class="confval-description">

--- a/tests/Integration/tests/confval/confval-duplicate-with-name/expected/index.html
+++ b/tests/Integration/tests/confval/confval-duplicate-with-name/expected/index.html
@@ -9,10 +9,13 @@
     <dd>
                 <dl class="field-list simple">
                             <dt class="field-even">Type</dt>
-                <dd class="field-even"><code class="code-inline" translate="no">&quot;Hello World&quot;</code>
+                <dd class="field-even">string
                 </dd>
                         <dt class="field-odd">Required</dt>
             <dd class="field-odd"><p>true</p>
+            </dd>
+                        <dt class="field-odd">Default</dt>
+            <dd class="field-odd"><code class="code-inline" translate="no">&quot;Hello World&quot;</code>
             </dd>
             </dl>
                 <div class="confval-description">

--- a/tests/Integration/tests/confval/confval-duplicate/expected/anotherDomain.html
+++ b/tests/Integration/tests/confval/confval-duplicate/expected/anotherDomain.html
@@ -9,10 +9,13 @@
     <dd>
                 <dl class="field-list simple">
                             <dt class="field-even">Type</dt>
-                <dd class="field-even"><code class="code-inline" translate="no">&quot;Hello World&quot;</code>
+                <dd class="field-even">string
                 </dd>
                         <dt class="field-odd">Required</dt>
             <dd class="field-odd"><p>true</p>
+            </dd>
+                        <dt class="field-odd">Default</dt>
+            <dd class="field-odd"><code class="code-inline" translate="no">&quot;Hello World&quot;</code>
             </dd>
             </dl>
                 <div class="confval-description">

--- a/tests/Integration/tests/confval/confval-duplicate/expected/index.html
+++ b/tests/Integration/tests/confval/confval-duplicate/expected/index.html
@@ -9,10 +9,13 @@
     <dd>
                 <dl class="field-list simple">
                             <dt class="field-even">Type</dt>
-                <dd class="field-even"><code class="code-inline" translate="no">&quot;Hello World&quot;</code>
+                <dd class="field-even">string
                 </dd>
                         <dt class="field-odd">Required</dt>
             <dd class="field-odd"><p>true</p>
+            </dd>
+                        <dt class="field-odd">Default</dt>
+            <dd class="field-odd"><code class="code-inline" translate="no">&quot;Hello World&quot;</code>
             </dd>
             </dl>
                 <div class="confval-description">

--- a/tests/Integration/tests/confval/confval-menu-tree/expected/index.html
+++ b/tests/Integration/tests/confval/confval-menu-tree/expected/index.html
@@ -1,0 +1,841 @@
+<!-- content start -->
+                <section class="section" id="confval">
+            <h1>Confval<a class="headerlink" href="#confval" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <section class="section" id="confval-menu-as-list">
+            <h2>Confval menu as list<a class="headerlink" href="#confval-menu-as-list" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h2>
+
+
+
+<div class="mb-4">
+    <ul>
+                        <li id="demo-1-tree">
+
+                                            <div class="label">
+            <a href="#demo-1">demo 1</a>
+                    </div>
+
+            </li>
+
+                        <li id="demo-2-tree">
+
+                                                                                                                                            <div class="label">
+            <a href="#demo-2">demo 2</a>
+                    </div>
+
+                    <ul>
+                                        <li id="demo-2-1-tree">
+        <div class="content">
+                                                                                                                                                                                                                            <div class="toggle">
+                    <a data-bs-toggle="collapse"
+                       href="#demo-2-1-list"
+                       aria-expanded="true"
+                       aria-controls="demo-2-1-list"
+                       class=""
+                    >
+                        <span class="icon"></span>
+                    </a>
+                </div>
+                        <div class="label">
+                <a href="#demo-2-1">demo 2.1</a>
+                            </div>
+        </div>
+
+                    <ul class="collapse show" id="demo-2-1-list">
+                                        <li id="demo-2-1-1-tree">
+        <div class="content">
+                                                                                            <div class="no-toggle">
+                </div>
+                        <div class="label">
+                <a href="#demo-2-1-1">demo 2.1.1</a>
+                            </div>
+        </div>
+
+            </li>
+
+                                        <li id="demo-2-1-2-tree">
+        <div class="content">
+                                                                                            <div class="no-toggle">
+                </div>
+                        <div class="label">
+                <a href="#demo-2-1-2">demo 2.1.2</a>
+                            </div>
+        </div>
+
+            </li>
+
+                            </ul>
+            </li>
+
+                                        <li id="demo-2-2-tree">
+        <div class="content">
+                                                                                            <div class="no-toggle">
+                </div>
+                        <div class="label">
+                <a href="#demo-2-2">demo 2.2</a>
+                            </div>
+        </div>
+
+            </li>
+
+                            </ul>
+            </li>
+
+                        <li id="demo-3-tree">
+
+                                            <div class="label">
+            <a href="#demo-3">demo 3</a>
+                    </div>
+
+            </li>
+
+                        <li id="demo-4-tree">
+
+                                            <div class="label">
+            <a href="#demo-4">demo 4</a>
+                    </div>
+
+            </li>
+
+                        <li id="exclude-in-table-tree">
+
+                                            <div class="label">
+            <a href="#exclude-in-table">exclude in table</a>
+                    </div>
+
+            </li>
+
+            </ul>
+</div>
+
+    </section>
+            <section class="section" id="confval-menu-as-list-with-more-info">
+            <h2>Confval menu as list with more info<a class="headerlink" href="#confval-menu-as-list-with-more-info" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h2>
+
+
+
+<div class="mb-4">
+    <ul>
+                        <li id="demo-1-tree">
+
+                                            <div class="label">
+            <a href="#demo-1">demo 1</a>
+                                                , Type: string
+                                                                , Default: <code class="code-inline" translate="no">&quot;Hello World&quot;</code>
+                                    </div>
+
+            </li>
+
+                        <li id="demo-2-tree">
+
+                                                                                                                                            <div class="label">
+            <a href="#demo-2">demo 2</a>
+                                                , Type: string
+                                                                , Default: <code class="code-inline" translate="no">&quot;Hello World&quot;</code>
+                                    </div>
+
+                    <ul>
+                                        <li id="demo-2-1-tree">
+        <div class="content">
+                                                                                                                                                                                                                            <div class="toggle">
+                    <a data-bs-toggle="collapse"
+                       href="#demo-2-1-list"
+                       aria-expanded="true"
+                       aria-controls="demo-2-1-list"
+                       class=""
+                    >
+                        <span class="icon"></span>
+                    </a>
+                </div>
+                        <div class="label">
+                <a href="#demo-2-1">demo 2.1</a>
+                                                            , Type: string
+                                                                                , Default: <code class="code-inline" translate="no">&quot;Hello World&quot;</code>
+                                                </div>
+        </div>
+
+                    <ul class="collapse show" id="demo-2-1-list">
+                                        <li id="demo-2-1-1-tree">
+        <div class="content">
+                                                                                            <div class="no-toggle">
+                </div>
+                        <div class="label">
+                <a href="#demo-2-1-1">demo 2.1.1</a>
+                                                            , Type: string
+                                                                                , Default: <code class="code-inline" translate="no">&quot;Hello World&quot;</code>
+                                                </div>
+        </div>
+
+            </li>
+
+                                        <li id="demo-2-1-2-tree">
+        <div class="content">
+                                                                                            <div class="no-toggle">
+                </div>
+                        <div class="label">
+                <a href="#demo-2-1-2">demo 2.1.2</a>
+                                                            , Type: string
+                                                                                , Default: <code class="code-inline" translate="no">&quot;Hello World&quot;</code>
+                                                </div>
+        </div>
+
+            </li>
+
+                            </ul>
+            </li>
+
+                                        <li id="demo-2-2-tree">
+        <div class="content">
+                                                                                            <div class="no-toggle">
+                </div>
+                        <div class="label">
+                <a href="#demo-2-2">demo 2.2</a>
+                                                            , Type: string
+                                                                                , Default: <code class="code-inline" translate="no">&quot;Hello World&quot;</code>
+                                                </div>
+        </div>
+
+            </li>
+
+                            </ul>
+            </li>
+
+                        <li id="demo-3-tree">
+
+                                            <div class="label">
+            <a href="#demo-3">demo 3</a>
+                                                , Type: string
+                                                                , Default: <code class="code-inline" translate="no">&quot;Hello World&quot;</code>
+                                    </div>
+
+            </li>
+
+                        <li id="demo-4-tree">
+
+                                            <div class="label">
+            <a href="#demo-4">demo 4</a>
+                                                , Type: string
+                                                                , Default: <code class="code-inline" translate="no">&quot;Hello World&quot;</code>
+                                    </div>
+
+            </li>
+
+                        <li id="exclude-in-table-tree">
+
+                                            <div class="label">
+            <a href="#exclude-in-table">exclude in table</a>
+                                                , Type: string
+                                                                , Default: <code class="code-inline" translate="no">&quot;Hello World&quot;</code>
+                                    </div>
+
+            </li>
+
+            </ul>
+</div>
+
+    </section>
+            <section class="section" id="confval-menu-as-tree">
+            <h2>Confval menu as tree<a class="headerlink" href="#confval-menu-as-tree" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h2>
+
+
+
+    <div class="directory-tree mb-4">
+        <ul>
+                        <li id="demo-1-tree">
+        <div class="content">
+                                                                                            <div class="no-toggle">
+                </div>
+                        <div class="label">
+                <a href="#demo-1">demo 1</a>
+                            </div>
+        </div>
+
+            </li>
+
+                        <li id="demo-2-tree">
+        <div class="content">
+                                                                                                                                                                                                                            <div class="toggle">
+                    <a data-bs-toggle="collapse"
+                       href="#demo-2-list"
+                       aria-expanded="true"
+                       aria-controls="demo-2-list"
+                       class=""
+                    >
+                        <span class="icon"></span>
+                    </a>
+                </div>
+                        <div class="label">
+                <a href="#demo-2">demo 2</a>
+                            </div>
+        </div>
+
+                    <ul class="collapse show" id="demo-2-list">
+                                        <li id="demo-2-1-tree">
+        <div class="content">
+                                                                                                                                                                                                                            <div class="toggle">
+                    <a data-bs-toggle="collapse"
+                       href="#demo-2-1-list"
+                       aria-expanded="true"
+                       aria-controls="demo-2-1-list"
+                       class=""
+                    >
+                        <span class="icon"></span>
+                    </a>
+                </div>
+                        <div class="label">
+                <a href="#demo-2-1">demo 2.1</a>
+                            </div>
+        </div>
+
+                    <ul class="collapse show" id="demo-2-1-list">
+                                        <li id="demo-2-1-1-tree">
+        <div class="content">
+                                                                                            <div class="no-toggle">
+                </div>
+                        <div class="label">
+                <a href="#demo-2-1-1">demo 2.1.1</a>
+                            </div>
+        </div>
+
+            </li>
+
+                                        <li id="demo-2-1-2-tree">
+        <div class="content">
+                                                                                            <div class="no-toggle">
+                </div>
+                        <div class="label">
+                <a href="#demo-2-1-2">demo 2.1.2</a>
+                            </div>
+        </div>
+
+            </li>
+
+                            </ul>
+            </li>
+
+                                        <li id="demo-2-2-tree">
+        <div class="content">
+                                                                                            <div class="no-toggle">
+                </div>
+                        <div class="label">
+                <a href="#demo-2-2">demo 2.2</a>
+                            </div>
+        </div>
+
+            </li>
+
+                            </ul>
+            </li>
+
+                        <li id="demo-3-tree">
+        <div class="content">
+                                                                                            <div class="no-toggle">
+                </div>
+                        <div class="label">
+                <a href="#demo-3">demo 3</a>
+                            </div>
+        </div>
+
+            </li>
+
+                        <li id="demo-4-tree">
+        <div class="content">
+                                                                                            <div class="no-toggle">
+                </div>
+                        <div class="label">
+                <a href="#demo-4">demo 4</a>
+                            </div>
+        </div>
+
+            </li>
+
+                        <li id="exclude-in-table-tree">
+        <div class="content">
+                                                                                            <div class="no-toggle">
+                </div>
+                        <div class="label">
+                <a href="#exclude-in-table">exclude in table</a>
+                            </div>
+        </div>
+
+            </li>
+
+                </ul>
+    </div>
+
+    </section>
+            <section class="section" id="confval-menu-as-tree-with-more-info">
+            <h2>Confval menu as tree with more info<a class="headerlink" href="#confval-menu-as-tree-with-more-info" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h2>
+
+
+
+    <div class="directory-tree mb-4">
+        <ul>
+                        <li id="demo-1-tree">
+        <div class="content">
+                                                                                            <div class="no-toggle">
+                </div>
+                        <div class="label">
+                <a href="#demo-1">demo 1</a>
+                                                            , Type: string
+                                                                                , Default: <code class="code-inline" translate="no">&quot;Hello World&quot;</code>
+                                                </div>
+        </div>
+
+            </li>
+
+                        <li id="demo-2-tree">
+        <div class="content">
+                                                                                                                                                                                                                            <div class="toggle">
+                    <a data-bs-toggle="collapse"
+                       href="#demo-2-list"
+                       aria-expanded="true"
+                       aria-controls="demo-2-list"
+                       class=""
+                    >
+                        <span class="icon"></span>
+                    </a>
+                </div>
+                        <div class="label">
+                <a href="#demo-2">demo 2</a>
+                                                            , Type: string
+                                                                                , Default: <code class="code-inline" translate="no">&quot;Hello World&quot;</code>
+                                                </div>
+        </div>
+
+                    <ul class="collapse show" id="demo-2-list">
+                                        <li id="demo-2-1-tree">
+        <div class="content">
+                                                                                                                                                                                                                            <div class="toggle">
+                    <a data-bs-toggle="collapse"
+                       href="#demo-2-1-list"
+                       aria-expanded="true"
+                       aria-controls="demo-2-1-list"
+                       class=""
+                    >
+                        <span class="icon"></span>
+                    </a>
+                </div>
+                        <div class="label">
+                <a href="#demo-2-1">demo 2.1</a>
+                                                            , Type: string
+                                                                                , Default: <code class="code-inline" translate="no">&quot;Hello World&quot;</code>
+                                                </div>
+        </div>
+
+                    <ul class="collapse show" id="demo-2-1-list">
+                                        <li id="demo-2-1-1-tree">
+        <div class="content">
+                                                                                            <div class="no-toggle">
+                </div>
+                        <div class="label">
+                <a href="#demo-2-1-1">demo 2.1.1</a>
+                                                            , Type: string
+                                                                                , Default: <code class="code-inline" translate="no">&quot;Hello World&quot;</code>
+                                                </div>
+        </div>
+
+            </li>
+
+                                        <li id="demo-2-1-2-tree">
+        <div class="content">
+                                                                                            <div class="no-toggle">
+                </div>
+                        <div class="label">
+                <a href="#demo-2-1-2">demo 2.1.2</a>
+                                                            , Type: string
+                                                                                , Default: <code class="code-inline" translate="no">&quot;Hello World&quot;</code>
+                                                </div>
+        </div>
+
+            </li>
+
+                            </ul>
+            </li>
+
+                                        <li id="demo-2-2-tree">
+        <div class="content">
+                                                                                            <div class="no-toggle">
+                </div>
+                        <div class="label">
+                <a href="#demo-2-2">demo 2.2</a>
+                                                            , Type: string
+                                                                                , Default: <code class="code-inline" translate="no">&quot;Hello World&quot;</code>
+                                                </div>
+        </div>
+
+            </li>
+
+                            </ul>
+            </li>
+
+                        <li id="demo-3-tree">
+        <div class="content">
+                                                                                            <div class="no-toggle">
+                </div>
+                        <div class="label">
+                <a href="#demo-3">demo 3</a>
+                                                            , Type: string
+                                                                                , Default: <code class="code-inline" translate="no">&quot;Hello World&quot;</code>
+                                                </div>
+        </div>
+
+            </li>
+
+                        <li id="demo-4-tree">
+        <div class="content">
+                                                                                            <div class="no-toggle">
+                </div>
+                        <div class="label">
+                <a href="#demo-4">demo 4</a>
+                                                            , Type: string
+                                                                                , Default: <code class="code-inline" translate="no">&quot;Hello World&quot;</code>
+                                                </div>
+        </div>
+
+            </li>
+
+                        <li id="exclude-in-table-tree">
+        <div class="content">
+                                                                                            <div class="no-toggle">
+                </div>
+                        <div class="label">
+                <a href="#exclude-in-table">exclude in table</a>
+                                                            , Type: string
+                                                                                , Default: <code class="code-inline" translate="no">&quot;Hello World&quot;</code>
+                                                </div>
+        </div>
+
+            </li>
+
+                </ul>
+    </div>
+
+    </section>
+            <section class="section" id="confval-menu-as-table">
+            <h2>Confval menu as table<a class="headerlink" href="#confval-menu-as-table" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h2>
+
+
+
+<table class="table table-hover">
+    <thead>
+    <tr>
+        <th scope="col">Name</th>
+
+                            <th scope="col">Type</th>
+
+                            <th scope="col">Default</th>
+
+                            <th scope="col">Level</th>
+                        </tr>
+    </thead>
+                <tr>
+        <td><div class="confval-label ps-0"><a href="#demo-1">demo 1</a></div></td>
+                                    <td>string</td>
+                                                <td><code class="code-inline" translate="no">&quot;Hello World&quot;</code></td>
+                                                <td>                            1
+                        </td>
+                        </tr>
+
+                <tr>
+        <td><div class="confval-label ps-0"><a href="#demo-2">demo 2</a></div></td>
+                                    <td>string</td>
+                                                <td><code class="code-inline" translate="no">&quot;Hello World&quot;</code></td>
+                                                <td>                            1
+                        </td>
+                        </tr>
+                                        <tr>
+        <td><div class="confval-label ps-2"><a href="#demo-2-1">demo 2.1</a></div></td>
+                                    <td>string</td>
+                                                <td><code class="code-inline" translate="no">&quot;Hello World&quot;</code></td>
+                                                <td>                            2
+                        </td>
+                        </tr>
+                                        <tr>
+        <td><div class="confval-label ps-4"><a href="#demo-2-1-1">demo 2.1.1</a></div></td>
+                                    <td>string</td>
+                                                <td><code class="code-inline" translate="no">&quot;Hello World&quot;</code></td>
+                                                <td>                            3
+                        </td>
+                        </tr>
+
+                                    <tr>
+        <td><div class="confval-label ps-4"><a href="#demo-2-1-2">demo 2.1.2</a></div></td>
+                                    <td>string</td>
+                                                <td><code class="code-inline" translate="no">&quot;Hello World&quot;</code></td>
+                                                <td>                            3
+                        </td>
+                        </tr>
+
+
+                                    <tr>
+        <td><div class="confval-label ps-2"><a href="#demo-2-2">demo 2.2</a></div></td>
+                                    <td>string</td>
+                                                <td><code class="code-inline" translate="no">&quot;Hello World&quot;</code></td>
+                                                <td>                            2
+                        </td>
+                        </tr>
+
+
+                <tr>
+        <td><div class="confval-label ps-0"><a href="#demo-3">demo 3</a></div></td>
+                                    <td>string</td>
+                                                <td><code class="code-inline" translate="no">&quot;Hello World&quot;</code></td>
+                                                <td>                            1
+                        </td>
+                        </tr>
+
+                <tr>
+        <td><div class="confval-label ps-0"><a href="#demo-4">demo 4</a></div></td>
+                                    <td>string</td>
+                                                <td><code class="code-inline" translate="no">&quot;Hello World&quot;</code></td>
+                                                <td>                            1
+                        </td>
+                        </tr>
+
+    </table>
+
+    </section>
+            <section class="section" id="confvals">
+            <h2>Confvals<a class="headerlink" href="#confvals" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h2>
+            <dl class="confval">
+    <dt id="demo-1">
+        <code class="sig-name descname"><span class="pre">demo 1</span></code>
+                <a class="headerlink" href="#confval-demo-1" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-demo-1" data-rstCode=":confval:`demo 1 &lt;somemanual:demo-1&gt;`"  title="Reference this configuration value">¶</a>
+        </dt>
+    <dd>
+                <dl class="field-list simple">
+                            <dt class="field-even">Type</dt>
+                <dd class="field-even">string
+                </dd>
+                        <dt class="field-odd">Required</dt>
+            <dd class="field-odd"><p>true</p>
+            </dd>
+                        <dt class="field-odd">Default</dt>
+            <dd class="field-odd"><code class="code-inline" translate="no">&quot;Hello World&quot;</code>
+            </dd>
+            <dt class="field-even">Level</dt>
+                <dd class="field-even">1
+                </dd>
+            </dl>
+                <div class="confval-description">
+
+    <p>Some Text</p>
+
+        </div>
+    </dd>
+</dl>
+            <dl class="confval">
+    <dt id="demo-2">
+        <code class="sig-name descname"><span class="pre">demo 2</span></code>
+                <a class="headerlink" href="#confval-demo-2" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-demo-2" data-rstCode=":confval:`demo 2 &lt;somemanual:demo-2&gt;`"  title="Reference this configuration value">¶</a>
+        </dt>
+    <dd>
+                <dl class="field-list simple">
+                            <dt class="field-even">Type</dt>
+                <dd class="field-even">string
+                </dd>
+                        <dt class="field-odd">Required</dt>
+            <dd class="field-odd"><p>true</p>
+            </dd>
+                        <dt class="field-odd">Default</dt>
+            <dd class="field-odd"><code class="code-inline" translate="no">&quot;Hello World&quot;</code>
+            </dd>
+            <dt class="field-even">Level</dt>
+                <dd class="field-even">1
+                </dd>
+            </dl>
+                <div class="confval-description">
+
+    <p>Some Text</p>
+<dl class="confval">
+    <dt id="demo-2-1">
+        <code class="sig-name descname"><span class="pre">demo 2.1</span></code>
+                <a class="headerlink" href="#confval-demo-2-1" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-demo-2-1" data-rstCode=":confval:`demo 2.1 &lt;somemanual:demo-2-1&gt;`"  title="Reference this configuration value">¶</a>
+        </dt>
+    <dd>
+                <dl class="field-list simple">
+                            <dt class="field-even">Type</dt>
+                <dd class="field-even">string
+                </dd>
+                        <dt class="field-odd">Required</dt>
+            <dd class="field-odd"><p>true</p>
+            </dd>
+                        <dt class="field-odd">Default</dt>
+            <dd class="field-odd"><code class="code-inline" translate="no">&quot;Hello World&quot;</code>
+            </dd>
+            <dt class="field-even">Level</dt>
+                <dd class="field-even">2
+                </dd>
+            </dl>
+                <div class="confval-description">
+
+    <p>Some Text</p>
+<dl class="confval">
+    <dt id="demo-2-1-1">
+        <code class="sig-name descname"><span class="pre">demo 2.1.1</span></code>
+                <a class="headerlink" href="#confval-demo-2-1-1" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-demo-2-1-1" data-rstCode=":confval:`demo 2.1.1 &lt;somemanual:demo-2-1-1&gt;`"  title="Reference this configuration value">¶</a>
+        </dt>
+    <dd>
+                <dl class="field-list simple">
+                            <dt class="field-even">Type</dt>
+                <dd class="field-even">string
+                </dd>
+                        <dt class="field-odd">Required</dt>
+            <dd class="field-odd"><p>true</p>
+            </dd>
+                        <dt class="field-odd">Default</dt>
+            <dd class="field-odd"><code class="code-inline" translate="no">&quot;Hello World&quot;</code>
+            </dd>
+            <dt class="field-even">Level</dt>
+                <dd class="field-even">3
+                </dd>
+            </dl>
+                <div class="confval-description">
+
+    <p>Some Text</p>
+
+        </div>
+    </dd>
+</dl><dl class="confval">
+    <dt id="demo-2-1-2">
+        <code class="sig-name descname"><span class="pre">demo 2.1.2</span></code>
+                <a class="headerlink" href="#confval-demo-2-1-2" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-demo-2-1-2" data-rstCode=":confval:`demo 2.1.2 &lt;somemanual:demo-2-1-2&gt;`"  title="Reference this configuration value">¶</a>
+        </dt>
+    <dd>
+                <dl class="field-list simple">
+                            <dt class="field-even">Type</dt>
+                <dd class="field-even">string
+                </dd>
+                        <dt class="field-odd">Required</dt>
+            <dd class="field-odd"><p>true</p>
+            </dd>
+                        <dt class="field-odd">Default</dt>
+            <dd class="field-odd"><code class="code-inline" translate="no">&quot;Hello World&quot;</code>
+            </dd>
+            <dt class="field-even">Level</dt>
+                <dd class="field-even">3
+                </dd>
+            </dl>
+                <div class="confval-description">
+
+    <p>Some Text</p>
+
+        </div>
+    </dd>
+</dl>
+        </div>
+    </dd>
+</dl><dl class="confval">
+    <dt id="demo-2-2">
+        <code class="sig-name descname"><span class="pre">demo 2.2</span></code>
+                <a class="headerlink" href="#confval-demo-2-2" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-demo-2-2" data-rstCode=":confval:`demo 2.2 &lt;somemanual:demo-2-2&gt;`"  title="Reference this configuration value">¶</a>
+        </dt>
+    <dd>
+                <dl class="field-list simple">
+                            <dt class="field-even">Type</dt>
+                <dd class="field-even">string
+                </dd>
+                        <dt class="field-odd">Required</dt>
+            <dd class="field-odd"><p>true</p>
+            </dd>
+                        <dt class="field-odd">Default</dt>
+            <dd class="field-odd"><code class="code-inline" translate="no">&quot;Hello World&quot;</code>
+            </dd>
+            <dt class="field-even">Level</dt>
+                <dd class="field-even">2
+                </dd>
+            </dl>
+                <div class="confval-description">
+
+    <p>Some Text</p>
+
+        </div>
+    </dd>
+</dl>
+        </div>
+    </dd>
+</dl>
+            <dl class="confval">
+    <dt id="demo-3">
+        <code class="sig-name descname"><span class="pre">demo 3</span></code>
+                <a class="headerlink" href="#confval-demo-3" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-demo-3" data-rstCode=":confval:`demo 3 &lt;somemanual:demo-3&gt;`"  title="Reference this configuration value">¶</a>
+        </dt>
+    <dd>
+                <dl class="field-list simple">
+                            <dt class="field-even">Type</dt>
+                <dd class="field-even">string
+                </dd>
+                        <dt class="field-odd">Required</dt>
+            <dd class="field-odd"><p>true</p>
+            </dd>
+                        <dt class="field-odd">Default</dt>
+            <dd class="field-odd"><code class="code-inline" translate="no">&quot;Hello World&quot;</code>
+            </dd>
+            <dt class="field-even">Level</dt>
+                <dd class="field-even">1
+                </dd>
+            </dl>
+                <div class="confval-description">
+
+    <p>Some Text</p>
+
+        </div>
+    </dd>
+</dl>
+            <dl class="confval">
+    <dt id="demo-4">
+        <code class="sig-name descname"><span class="pre">demo 4</span></code>
+                <a class="headerlink" href="#confval-demo-4" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-demo-4" data-rstCode=":confval:`demo 4 &lt;somemanual:demo-4&gt;`"  title="Reference this configuration value">¶</a>
+        </dt>
+    <dd>
+                <dl class="field-list simple">
+                            <dt class="field-even">Type</dt>
+                <dd class="field-even">string
+                </dd>
+                        <dt class="field-odd">Required</dt>
+            <dd class="field-odd"><p>true</p>
+            </dd>
+                        <dt class="field-odd">Default</dt>
+            <dd class="field-odd"><code class="code-inline" translate="no">&quot;Hello World&quot;</code>
+            </dd>
+            <dt class="field-even">Level</dt>
+                <dd class="field-even">1
+                </dd>
+            </dl>
+                <div class="confval-description">
+
+    <p>Some Text</p>
+
+        </div>
+    </dd>
+</dl>
+            <dl class="confval">
+    <dt id="exclude-in-table">
+        <code class="sig-name descname"><span class="pre">exclude in table</span></code>
+                <a class="headerlink" href="#confval-exclude-in-table" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-exclude-in-table" data-rstCode=":confval:`exclude in table &lt;somemanual:exclude-in-table&gt;`"  title="Reference this configuration value">¶</a>
+        </dt>
+    <dd>
+                <dl class="field-list simple">
+                            <dt class="field-even">Type</dt>
+                <dd class="field-even">string
+                </dd>
+                        <dt class="field-odd">Required</dt>
+            <dd class="field-odd"><p>true</p>
+            </dd>
+                        <dt class="field-odd">Default</dt>
+            <dd class="field-odd"><code class="code-inline" translate="no">&quot;Hello World&quot;</code>
+            </dd>
+            <dt class="field-even">Level</dt>
+                <dd class="field-even">1
+                </dd>
+            </dl>
+                <div class="confval-description">
+
+    <p>Some Text</p>
+
+        </div>
+    </dd>
+</dl>
+    </section>
+    </section>
+        <!-- content end -->

--- a/tests/Integration/tests/confval/confval-menu-tree/input/index.rst
+++ b/tests/Integration/tests/confval/confval-menu-tree/input/index.rst
@@ -1,0 +1,117 @@
+=======
+Confval
+=======
+
+Confval menu as list
+====================
+
+..  confval-menu::
+
+Confval menu as list with more info
+===================================
+
+..  confval-menu::
+    :type:
+    :default:
+
+Confval menu as tree
+====================
+
+..  confval-menu::
+    :display: tree
+
+Confval menu as tree with more info
+===================================
+
+..  confval-menu::
+    :display: tree
+    :type:
+    :default:
+
+Confval menu as table
+=====================
+
+..  confval-menu::
+    :display: table
+    :type:
+    :default:
+    :Level:
+    :exclude: exclude in table
+
+
+Confvals
+========
+
+..  confval:: demo 1
+    :type: string
+    :default: ``"Hello World"``
+    :required: False
+    :Level: 1
+
+    Some Text
+
+
+..  confval:: demo 2
+    :type: string
+    :default: ``"Hello World"``
+    :required: False
+    :Level: 1
+
+    Some Text
+
+
+    ..  confval:: demo 2.1
+        :type: string
+        :default: ``"Hello World"``
+        :required: False
+        :Level: 2
+
+        Some Text
+
+        ..  confval:: demo 2.1.1
+            :type: string
+            :default: ``"Hello World"``
+            :required: False
+            :Level: 3
+
+            Some Text
+
+        ..  confval:: demo 2.1.2
+            :type: string
+            :default: ``"Hello World"``
+            :required: False
+            :Level: 3
+
+            Some Text
+
+    ..  confval:: demo 2.2
+        :type: string
+        :default: ``"Hello World"``
+        :required: False
+        :Level: 2
+
+        Some Text
+
+..  confval:: demo 3
+    :type: string
+    :default: ``"Hello World"``
+    :required: False
+    :Level: 1
+
+    Some Text
+
+..  confval:: demo 4
+    :type: string
+    :default: ``"Hello World"``
+    :required: False
+    :Level: 1
+
+    Some Text
+
+..  confval:: exclude in table
+    :type: string
+    :default: ``"Hello World"``
+    :required: False
+    :Level: 1
+
+    Some Text

--- a/tests/Integration/tests/confval/confval-noindex/expected/anotherDomain.html
+++ b/tests/Integration/tests/confval/confval-noindex/expected/anotherDomain.html
@@ -9,10 +9,13 @@
     <dd>
                 <dl class="field-list simple">
                             <dt class="field-even">Type</dt>
-                <dd class="field-even"><code class="code-inline" translate="no">&quot;Hello World&quot;</code>
+                <dd class="field-even">string
                 </dd>
                         <dt class="field-odd">Required</dt>
             <dd class="field-odd"><p>true</p>
+            </dd>
+                        <dt class="field-odd">Default</dt>
+            <dd class="field-odd"><code class="code-inline" translate="no">&quot;Hello World&quot;</code>
             </dd>
             </dl>
                 <div class="confval-description">

--- a/tests/Integration/tests/confval/confval-noindex/expected/index.html
+++ b/tests/Integration/tests/confval/confval-noindex/expected/index.html
@@ -9,10 +9,13 @@
     <dd>
                 <dl class="field-list simple">
                             <dt class="field-even">Type</dt>
-                <dd class="field-even"><code class="code-inline" translate="no">&quot;Hello World&quot;</code>
+                <dd class="field-even">string
                 </dd>
                         <dt class="field-odd">Required</dt>
             <dd class="field-odd"><p>true</p>
+            </dd>
+                        <dt class="field-odd">Default</dt>
+            <dd class="field-odd"><code class="code-inline" translate="no">&quot;Hello World&quot;</code>
             </dd>
             </dl>
                 <div class="confval-description">


### PR DESCRIPTION
Displays all confvals of the current page as list, tree or table. Additional info can be displayed, confvals can be excluded. Recursively nested confvals are treated as tree.

![image](https://github.com/TYPO3-Documentation/render-guides/assets/48202465/772d4ab0-8237-49e3-ab4d-8256c022dc27)
![image](https://github.com/TYPO3-Documentation/render-guides/assets/48202465/59523281-cbde-45d7-bf85-1f4123b68317)
![image](https://github.com/TYPO3-Documentation/render-guides/assets/48202465/c008b5d6-80d2-4223-814f-0637493918b4)
