### PR TITLE
Clarify project

### DIFF
--- a/Documentation/Developer/Building.rst
+++ b/Documentation/Developer/Building.rst
@@ -32,6 +32,8 @@ For macOS you may need to specify the argument ``user``:
 
     docker run --rm -v $(pwd):/project --user=$(id -u):$(id -g) typo3-docs:local --progress
 
+..  include:: ../_Includes/NoteProjectDirectoryName.rst.txt
+
 Using PHP
 ---------
 

--- a/Documentation/Installation/Index.rst
+++ b/Documentation/Installation/Index.rst
@@ -64,7 +64,9 @@ project. This means that the files created by the Docker image will have the
 same owner as the files in your project. No more permission issues should occur,
 when files are getting generated inside the image.
 
-If this fail, you can resort to specifying the user:
+..  include:: ../_Includes/NoteProjectDirectoryName.rst.txt
+
+If this fails, you can resort to specifying the user:
 
 ..  code-block:: shell
 

--- a/Documentation/Migration/Index.rst
+++ b/Documentation/Migration/Index.rst
@@ -36,6 +36,8 @@ The last option is the folder (here: :file:`Documentation`). When running the
 command from another folder than the project's root folder, adapt the given
 path accordingly.
 
+..  include:: ../_Includes/NoteProjectDirectoryName.rst.txt
+
 With make
 =========
 

--- a/Documentation/_Includes/NoteProjectDirectoryName.rst.txt
+++ b/Documentation/_Includes/NoteProjectDirectoryName.rst.txt
@@ -1,0 +1,6 @@
+..  note::
+
+    Note that the parameter :bash:`-v $(pwd):/project` always uses `project` as
+    the directory name. You do not need to replace that directory name with
+    anything else, because the container rendering depends on this.
+

--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@ render-guides
 =============
 
 This is the documentation rendering tool for TYPO3 projects. It is based on
-`phpDocumentor/guides <https://github.com/phpDocumentor/guides>`__ 
+`phpDocumentor/guides <https://github.com/phpDocumentor/guides>`__
 and can be used as a drop-in replacement for Sphinx.
 The tool is used by the automated documentation rendering system of the
 TYPO3 project. And can be used by documentation authors to validate their
@@ -29,6 +29,7 @@ Usage with Docker (via supplied container)
 (see :ref:`_Setup_Docker:Docker containers` for complete documentation. You
 can also use a specific version of the `render-guides` Docker container, i.e. `:1` for the latest `1.x` version.)
 
+.. include: Documentation/_Includes/NoteProjectDirectoryName.rst.txt
 
 Usage with Docker (via custom container)
 ========================================
@@ -41,6 +42,8 @@ Usage with Docker (via custom container)
     # Execute the Docker container that is provided locally, build Documentation
     # On macOS you need to specify the parameter "--user=$(id -u):$(id -g)"
     docker run --rm -v ${PWD}:/project -it typo3-docs:local --progress
+
+.. include:: Documentation/_Includes/NoteProjectDirectoryName.rst.txt
 
 (see :ref:`_Setup_Docker:Docker containers` for complete documentation)
 

--- a/README.rst
+++ b/README.rst
@@ -24,12 +24,12 @@ Usage with Docker (via supplied container)
     # Execute the Docker container that is provided remotely.
     # Renders all files in the `Documentation` and store in `Documentation-GENERATED-temp`.
     # On macOS you need to specify the parameter "--user=$(id -u):$(id -g)"
+    # "/project" is a fixed directory name, not a placeholder.
     docker run --rm --pull always -v $(pwd):/project -it ghcr.io/typo3-documentation/render-guides:latest --config=Documentation
 
 (see :ref:`_Setup_Docker:Docker containers` for complete documentation. You
 can also use a specific version of the `render-guides` Docker container, i.e. `:1` for the latest `1.x` version.)
 
-.. include: Documentation/_Includes/NoteProjectDirectoryName.rst.txt
 
 Usage with Docker (via custom container)
 ========================================
@@ -41,9 +41,8 @@ Usage with Docker (via custom container)
 
     # Execute the Docker container that is provided locally, build Documentation
     # On macOS you need to specify the parameter "--user=$(id -u):$(id -g)"
+    # "/project" is a fixed directory name, not a placeholder.
     docker run --rm -v ${PWD}:/project -it typo3-docs:local --progress
-
-.. include:: Documentation/_Includes/NoteProjectDirectoryName.rst.txt
 
 (see :ref:`_Setup_Docker:Docker containers` for complete documentation)
 


### PR DESCRIPTION
People may think that "/project" is a directory they need to replace with the name of their project. Clarify this.

(Open for different wording)

Note: The README.rst.txt does not handle "include::" so instead I opted for a inline code note about "/project".