### PR TITLE
[TASK] Unify the appearance of horizontal buttons

### DIFF
--- a/packages/typo3-docs-theme/resources/public/css/theme.css
+++ b/packages/typo3-docs-theme/resources/public/css/theme.css
@@ -24805,6 +24805,7 @@ ul[class*=horizbuttons-] > li {
 ul[class*=horizbuttons-] > li a {
   color: inherit;
   font-weight: bold;
+  text-decoration: none;
 }
 ul[class*=horizbuttons-] > li p {
   display: inline;
@@ -24815,25 +24816,29 @@ ul[class*=horizbuttons-][class*=-xxxl] {
 ul[class*=horizbuttons-][class*=-xxl] {
   font-size: 1.25em;
 }
-ul[class*=horizbuttons-][class*=-warning-] > li, ul[class*=horizbuttons-][class*=-attention-] > li {
-  color: #000;
-  background-color: #f0ad4e;
-}
-ul[class*=horizbuttons-][class*=-tip-] > li, ul[class*=horizbuttons-][class*=-important-] > li {
-  color: #000;
-  background-color: #5cb85c;
-}
-ul[class*=horizbuttons-][class*=-note-] > li {
-  color: #000;
-  background-color: #319fc0;
-}
-ul[class*=horizbuttons-][class*=-typo3-] > li, ul[class*=horizbuttons-][class*=-primary-] > li {
-  color: #000;
-  background-color: #ff8700;
-}
-ul[class*=horizbuttons-][class*=-striking-] > li {
+ul[class*=horizbuttons-][class*=-attention-] > li,
+ul[class*=horizbuttons-][class*=-important-] > li,
+ul[class*=horizbuttons-][class*=-primary-] > li,
+ul[class*=horizbuttons-][class*=-typo3-] > li,
+ul[class*=horizbuttons-][class*=-striking-] > li,
+ul[class*=horizbuttons-][class*=-warning-] > li {
   color: #fff;
-  background-color: #333333;
+  background-color: #333;
+}
+ul[class*=horizbuttons-][class*=-attention-] > li:hover,
+ul[class*=horizbuttons-][class*=-important-] > li:hover,
+ul[class*=horizbuttons-][class*=-primary-] > li:hover,
+ul[class*=horizbuttons-][class*=-typo3-] > li:hover,
+ul[class*=horizbuttons-][class*=-striking-] > li:hover,
+ul[class*=horizbuttons-][class*=-warning-] > li:hover {
+  background-color: #f2f2f2;
+  color: #333;
+  outline: 2px solid #333;
+}
+ul[class*=horizbuttons-][class*=-note-] > li,
+ul[class*=horizbuttons-][class*=-tip-] > li {
+  color: #000;
+  background-color: #f2f2f2;
 }
 
 .admonition {
@@ -25129,6 +25134,15 @@ dl.field-list > dt:after {
 .breadcrumb-bar .breadcrumb-additions {
   margin-bottom: 1rem;
   display: none;
+}
+.breadcrumb-bar .breadcrumb-additions > a.btn-light:hover {
+  background: #f2f2f2;
+  outline: 2px solid #333;
+}
+.breadcrumb-bar .breadcrumb-additions > a.btn-secondary:hover {
+  background: #f2f2f2;
+  color: #333;
+  outline: 2px solid #333;
 }
 @media (min-width: 768px) {
   .breadcrumb-bar .breadcrumb-additions {
@@ -25494,6 +25508,11 @@ a.toc-title-project:hover {
 
 .search__scope {
   flex: 0.4 !important;
+}
+
+.search__submit:hover {
+  background: #f2f2f2;
+  outline: 2px solid #333;
 }
 
 .page {

--- a/packages/typo3-docs-theme/resources/template/structure/layoutParts/editOnGithubButtons.html.twig
+++ b/packages/typo3-docs-theme/resources/template/structure/layoutParts/editOnGithubButtons.html.twig
@@ -15,7 +15,7 @@
     {% endif -%}
     {%- set gitHubLink = getEditOnGitHubLink() -%}
     {%- if (gitHubLink)  %}
-    <a class="btn btn-sm btn-primary" href="{{ gitHubLink }}" id="btnEditOnGitHub" rel="nofollow noopener" target="_blank">
+    <a class="btn btn-sm btn-secondary" href="{{ gitHubLink }}" id="btnEditOnGitHub" rel="nofollow noopener" target="_blank">
         <span class="btn-icon"><span class="fab fa-github"></span></span>
         <span class="btn-text">Edit on GitHub</span>
     </a>

--- a/packages/typo3-docs-theme/resources/template/structure/layoutParts/pageHeader.html.twig
+++ b/packages/typo3-docs-theme/resources/template/structure/layoutParts/pageHeader.html.twig
@@ -24,7 +24,7 @@
                                     <option value="">Search all</option>
                                 </select>
                                 <input autocomplete="off" class="form-control shadow-none" id="globalsearchinput" name="q" placeholder="TYPO3 documentation..." type="text" value="">
-                                <button class="btn btn-primary" type="submit"><i class="fa fa-search"></i>&nbsp;<span class="d-none d-md-inline">Search</span></button>
+                                <button class="btn btn-light search__submit" type="submit"><i class="fa fa-search"></i>&nbsp;<span class="d-none d-md-inline">Search</span></button>
                             </div>
                         </form>
                     </search>

--- a/tests/Integration/tests-full/breadcrumb/expected/index.html
+++ b/tests/Integration/tests-full/breadcrumb/expected/index.html
@@ -50,7 +50,7 @@
                                     <option value="">Search all</option>
                                 </select>
                                 <input autocomplete="off" class="form-control shadow-none" id="globalsearchinput" name="q" placeholder="TYPO3 documentation..." type="text" value="">
-                                <button class="btn btn-primary" type="submit"><i class="fa fa-search"></i>&nbsp;<span class="d-none d-md-inline">Search</span></button>
+                                <button class="btn btn-light search__submit" type="submit"><i class="fa fa-search"></i>&nbsp;<span class="d-none d-md-inline">Search</span></button>
                             </div>
                         </form>
                     </search>

--- a/tests/Integration/tests-full/breadcrumb/expected/page.html
+++ b/tests/Integration/tests-full/breadcrumb/expected/page.html
@@ -51,7 +51,7 @@
                                     <option value="">Search all</option>
                                 </select>
                                 <input autocomplete="off" class="form-control shadow-none" id="globalsearchinput" name="q" placeholder="TYPO3 documentation..." type="text" value="">
-                                <button class="btn btn-primary" type="submit"><i class="fa fa-search"></i>&nbsp;<span class="d-none d-md-inline">Search</span></button>
+                                <button class="btn btn-light search__submit" type="submit"><i class="fa fa-search"></i>&nbsp;<span class="d-none d-md-inline">Search</span></button>
                             </div>
                         </form>
                     </search>

--- a/tests/Integration/tests-full/breadcrumb/expected/yetAnotherPage.html
+++ b/tests/Integration/tests-full/breadcrumb/expected/yetAnotherPage.html
@@ -50,7 +50,7 @@
                                     <option value="">Search all</option>
                                 </select>
                                 <input autocomplete="off" class="form-control shadow-none" id="globalsearchinput" name="q" placeholder="TYPO3 documentation..." type="text" value="">
-                                <button class="btn btn-primary" type="submit"><i class="fa fa-search"></i>&nbsp;<span class="d-none d-md-inline">Search</span></button>
+                                <button class="btn btn-light search__submit" type="submit"><i class="fa fa-search"></i>&nbsp;<span class="d-none d-md-inline">Search</span></button>
                             </div>
                         </form>
                     </search>

--- a/tests/Integration/tests-full/edit-on-github/edit-on-github-per-page/expected/index.html
+++ b/tests/Integration/tests-full/edit-on-github/edit-on-github-per-page/expected/index.html
@@ -50,7 +50,7 @@
                                     <option value="">Search all</option>
                                 </select>
                                 <input autocomplete="off" class="form-control shadow-none" id="globalsearchinput" name="q" placeholder="TYPO3 documentation..." type="text" value="">
-                                <button class="btn btn-primary" type="submit"><i class="fa fa-search"></i>&nbsp;<span class="d-none d-md-inline">Search</span></button>
+                                <button class="btn btn-light search__submit" type="submit"><i class="fa fa-search"></i>&nbsp;<span class="d-none d-md-inline">Search</span></button>
                             </div>
                         </form>
                     </search>
@@ -116,7 +116,7 @@
         <span class="btn-icon"><span class="fas fa-info-circle"></span></span>
         <span class="btn-text">How to edit</span>
     </a>
-        <a class="btn btn-sm btn-primary" href="https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-CoreApi/edit/documentation-draft/Documentation/index.rst" id="btnEditOnGitHub" rel="nofollow noopener" target="_blank">
+        <a class="btn btn-sm btn-secondary" href="https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-CoreApi/edit/documentation-draft/Documentation/index.rst" id="btnEditOnGitHub" rel="nofollow noopener" target="_blank">
         <span class="btn-icon"><span class="fab fa-github"></span></span>
         <span class="btn-text">Edit on GitHub</span>
     </a>

--- a/tests/Integration/tests-full/edit-on-github/edit-on-github-per-page/expected/page1.html
+++ b/tests/Integration/tests-full/edit-on-github/edit-on-github-per-page/expected/page1.html
@@ -50,7 +50,7 @@
                                     <option value="">Search all</option>
                                 </select>
                                 <input autocomplete="off" class="form-control shadow-none" id="globalsearchinput" name="q" placeholder="TYPO3 documentation..." type="text" value="">
-                                <button class="btn btn-primary" type="submit"><i class="fa fa-search"></i>&nbsp;<span class="d-none d-md-inline">Search</span></button>
+                                <button class="btn btn-light search__submit" type="submit"><i class="fa fa-search"></i>&nbsp;<span class="d-none d-md-inline">Search</span></button>
                             </div>
                         </form>
                     </search>
@@ -117,7 +117,7 @@
         <span class="btn-icon"><span class="fas fa-info-circle"></span></span>
         <span class="btn-text">How to edit</span>
     </a>
-        <a class="btn btn-sm btn-primary" href="https://github.com/TYPO3/typo3/edit/main/typo3/sysext/backend/Classes/ViewHelpers/AvatarViewHelper.php" id="btnEditOnGitHub" rel="nofollow noopener" target="_blank">
+        <a class="btn btn-sm btn-secondary" href="https://github.com/TYPO3/typo3/edit/main/typo3/sysext/backend/Classes/ViewHelpers/AvatarViewHelper.php" id="btnEditOnGitHub" rel="nofollow noopener" target="_blank">
         <span class="btn-icon"><span class="fab fa-github"></span></span>
         <span class="btn-text">Edit on GitHub</span>
     </a>

--- a/tests/Integration/tests-full/external-menu/expected/index.html
+++ b/tests/Integration/tests-full/external-menu/expected/index.html
@@ -108,7 +108,7 @@
         <span class="btn-icon"><span class="fas fa-info-circle"></span></span>
         <span class="btn-text">How to edit</span>
     </a>
-        <a class="btn btn-sm btn-primary" href="https://github.com/TYPO3-Documentation/render-guides/edit/main/Documentation/index.rst" id="btnEditOnGitHub" rel="nofollow noopener" target="_blank">
+        <a class="btn btn-sm btn-secondary" href="https://github.com/TYPO3-Documentation/render-guides/edit/main/Documentation/index.rst" id="btnEditOnGitHub" rel="nofollow noopener" target="_blank">
         <span class="btn-icon"><span class="fab fa-github"></span></span>
         <span class="btn-text">Edit on GitHub</span>
     </a>

--- a/tests/Integration/tests-full/index/expected/index.html
+++ b/tests/Integration/tests-full/index/expected/index.html
@@ -49,7 +49,7 @@
                                     <option value="">Search all</option>
                                 </select>
                                 <input autocomplete="off" class="form-control shadow-none" id="globalsearchinput" name="q" placeholder="TYPO3 documentation..." type="text" value="">
-                                <button class="btn btn-primary" type="submit"><i class="fa fa-search"></i>&nbsp;<span class="d-none d-md-inline">Search</span></button>
+                                <button class="btn btn-light search__submit" type="submit"><i class="fa fa-search"></i>&nbsp;<span class="d-none d-md-inline">Search</span></button>
                             </div>
                         </form>
                     </search>
@@ -118,7 +118,7 @@
         <span class="btn-icon"><span class="fas fa-info-circle"></span></span>
         <span class="btn-text">How to edit</span>
     </a>
-        <a class="btn btn-sm btn-primary" href="https://github.com/TYPO3-Documentation/render-guides/edit/main/Documentation/index.rst" id="btnEditOnGitHub" rel="nofollow noopener" target="_blank">
+        <a class="btn btn-sm btn-secondary" href="https://github.com/TYPO3-Documentation/render-guides/edit/main/Documentation/index.rst" id="btnEditOnGitHub" rel="nofollow noopener" target="_blank">
         <span class="btn-icon"><span class="fab fa-github"></span></span>
         <span class="btn-text">Edit on GitHub</span>
     </a>

--- a/tests/Integration/tests-full/link-wizard/expected/index.html
+++ b/tests/Integration/tests-full/link-wizard/expected/index.html
@@ -49,7 +49,7 @@
                                     <option value="">Search all</option>
                                 </select>
                                 <input autocomplete="off" class="form-control shadow-none" id="globalsearchinput" name="q" placeholder="TYPO3 documentation..." type="text" value="">
-                                <button class="btn btn-primary" type="submit"><i class="fa fa-search"></i>&nbsp;<span class="d-none d-md-inline">Search</span></button>
+                                <button class="btn btn-light search__submit" type="submit"><i class="fa fa-search"></i>&nbsp;<span class="d-none d-md-inline">Search</span></button>
                             </div>
                         </form>
                     </search>

--- a/tests/Integration/tests-full/menu-subpages-max-1/expected/index.html
+++ b/tests/Integration/tests-full/menu-subpages-max-1/expected/index.html
@@ -50,7 +50,7 @@
                                     <option value="">Search all</option>
                                 </select>
                                 <input autocomplete="off" class="form-control shadow-none" id="globalsearchinput" name="q" placeholder="TYPO3 documentation..." type="text" value="">
-                                <button class="btn btn-primary" type="submit"><i class="fa fa-search"></i>&nbsp;<span class="d-none d-md-inline">Search</span></button>
+                                <button class="btn btn-light search__submit" type="submit"><i class="fa fa-search"></i>&nbsp;<span class="d-none d-md-inline">Search</span></button>
                             </div>
                         </form>
                     </search>

--- a/tests/Integration/tests-full/menu-subpages-no-titlesonly-maxdepth-1/expected/index.html
+++ b/tests/Integration/tests-full/menu-subpages-no-titlesonly-maxdepth-1/expected/index.html
@@ -50,7 +50,7 @@
                                     <option value="">Search all</option>
                                 </select>
                                 <input autocomplete="off" class="form-control shadow-none" id="globalsearchinput" name="q" placeholder="TYPO3 documentation..." type="text" value="">
-                                <button class="btn btn-primary" type="submit"><i class="fa fa-search"></i>&nbsp;<span class="d-none d-md-inline">Search</span></button>
+                                <button class="btn btn-light search__submit" type="submit"><i class="fa fa-search"></i>&nbsp;<span class="d-none d-md-inline">Search</span></button>
                             </div>
                         </form>
                     </search>

--- a/tests/Integration/tests-full/menu-subpages-no-titlesonly-maxdepth-2/expected/index.html
+++ b/tests/Integration/tests-full/menu-subpages-no-titlesonly-maxdepth-2/expected/index.html
@@ -50,7 +50,7 @@
                                     <option value="">Search all</option>
                                 </select>
                                 <input autocomplete="off" class="form-control shadow-none" id="globalsearchinput" name="q" placeholder="TYPO3 documentation..." type="text" value="">
-                                <button class="btn btn-primary" type="submit"><i class="fa fa-search"></i>&nbsp;<span class="d-none d-md-inline">Search</span></button>
+                                <button class="btn btn-light search__submit" type="submit"><i class="fa fa-search"></i>&nbsp;<span class="d-none d-md-inline">Search</span></button>
                             </div>
                         </form>
                     </search>

--- a/tests/Integration/tests-full/menu-subpages/expected/index.html
+++ b/tests/Integration/tests-full/menu-subpages/expected/index.html
@@ -50,7 +50,7 @@
                                     <option value="">Search all</option>
                                 </select>
                                 <input autocomplete="off" class="form-control shadow-none" id="globalsearchinput" name="q" placeholder="TYPO3 documentation..." type="text" value="">
-                                <button class="btn btn-primary" type="submit"><i class="fa fa-search"></i>&nbsp;<span class="d-none d-md-inline">Search</span></button>
+                                <button class="btn btn-light search__submit" type="submit"><i class="fa fa-search"></i>&nbsp;<span class="d-none d-md-inline">Search</span></button>
                             </div>
                         </form>
                     </search>

--- a/tests/Integration/tests-full/meta-data/expected/index.html
+++ b/tests/Integration/tests-full/meta-data/expected/index.html
@@ -49,7 +49,7 @@
                                     <option value="">Search all</option>
                                 </select>
                                 <input autocomplete="off" class="form-control shadow-none" id="globalsearchinput" name="q" placeholder="TYPO3 documentation..." type="text" value="">
-                                <button class="btn btn-primary" type="submit"><i class="fa fa-search"></i>&nbsp;<span class="d-none d-md-inline">Search</span></button>
+                                <button class="btn btn-light search__submit" type="submit"><i class="fa fa-search"></i>&nbsp;<span class="d-none d-md-inline">Search</span></button>
                             </div>
                         </form>
                     </search>
@@ -118,7 +118,7 @@
         <span class="btn-icon"><span class="fas fa-info-circle"></span></span>
         <span class="btn-text">How to edit</span>
     </a>
-        <a class="btn btn-sm btn-primary" href="https://github.com/TYPO3-Documentation/render-guides/edit/main/Documentation/index.rst" id="btnEditOnGitHub" rel="nofollow noopener" target="_blank">
+        <a class="btn btn-sm btn-secondary" href="https://github.com/TYPO3-Documentation/render-guides/edit/main/Documentation/index.rst" id="btnEditOnGitHub" rel="nofollow noopener" target="_blank">
         <span class="btn-icon"><span class="fab fa-github"></span></span>
         <span class="btn-text">Edit on GitHub</span>
     </a>

--- a/tests/Integration/tests-full/navigation-title/expected/anotherPage.html
+++ b/tests/Integration/tests-full/navigation-title/expected/anotherPage.html
@@ -51,7 +51,7 @@
                                     <option value="">Search all</option>
                                 </select>
                                 <input autocomplete="off" class="form-control shadow-none" id="globalsearchinput" name="q" placeholder="TYPO3 documentation..." type="text" value="">
-                                <button class="btn btn-primary" type="submit"><i class="fa fa-search"></i>&nbsp;<span class="d-none d-md-inline">Search</span></button>
+                                <button class="btn btn-light search__submit" type="submit"><i class="fa fa-search"></i>&nbsp;<span class="d-none d-md-inline">Search</span></button>
                             </div>
                         </form>
                     </search>
@@ -132,7 +132,7 @@
         <span class="btn-icon"><span class="fas fa-info-circle"></span></span>
         <span class="btn-text">How to edit</span>
     </a>
-        <a class="btn btn-sm btn-primary" href="https://github.com/TYPO3-Documentation/render-guides/edit/main/Documentation/anotherPage.rst" id="btnEditOnGitHub" rel="nofollow noopener" target="_blank">
+        <a class="btn btn-sm btn-secondary" href="https://github.com/TYPO3-Documentation/render-guides/edit/main/Documentation/anotherPage.rst" id="btnEditOnGitHub" rel="nofollow noopener" target="_blank">
         <span class="btn-icon"><span class="fab fa-github"></span></span>
         <span class="btn-text">Edit on GitHub</span>
     </a>

--- a/tests/Integration/tests-full/navigation-title/expected/index.html
+++ b/tests/Integration/tests-full/navigation-title/expected/index.html
@@ -50,7 +50,7 @@
                                     <option value="">Search all</option>
                                 </select>
                                 <input autocomplete="off" class="form-control shadow-none" id="globalsearchinput" name="q" placeholder="TYPO3 documentation..." type="text" value="">
-                                <button class="btn btn-primary" type="submit"><i class="fa fa-search"></i>&nbsp;<span class="d-none d-md-inline">Search</span></button>
+                                <button class="btn btn-light search__submit" type="submit"><i class="fa fa-search"></i>&nbsp;<span class="d-none d-md-inline">Search</span></button>
                             </div>
                         </form>
                     </search>
@@ -130,7 +130,7 @@
         <span class="btn-icon"><span class="fas fa-info-circle"></span></span>
         <span class="btn-text">How to edit</span>
     </a>
-        <a class="btn btn-sm btn-primary" href="https://github.com/TYPO3-Documentation/render-guides/edit/main/Documentation/index.rst" id="btnEditOnGitHub" rel="nofollow noopener" target="_blank">
+        <a class="btn btn-sm btn-secondary" href="https://github.com/TYPO3-Documentation/render-guides/edit/main/Documentation/index.rst" id="btnEditOnGitHub" rel="nofollow noopener" target="_blank">
         <span class="btn-icon"><span class="fab fa-github"></span></span>
         <span class="btn-text">Edit on GitHub</span>
     </a>

--- a/tests/Integration/tests-full/navigation-title/expected/yetAnotherPage.html
+++ b/tests/Integration/tests-full/navigation-title/expected/yetAnotherPage.html
@@ -50,7 +50,7 @@
                                     <option value="">Search all</option>
                                 </select>
                                 <input autocomplete="off" class="form-control shadow-none" id="globalsearchinput" name="q" placeholder="TYPO3 documentation..." type="text" value="">
-                                <button class="btn btn-primary" type="submit"><i class="fa fa-search"></i>&nbsp;<span class="d-none d-md-inline">Search</span></button>
+                                <button class="btn btn-light search__submit" type="submit"><i class="fa fa-search"></i>&nbsp;<span class="d-none d-md-inline">Search</span></button>
                             </div>
                         </form>
                     </search>
@@ -131,7 +131,7 @@
         <span class="btn-icon"><span class="fas fa-info-circle"></span></span>
         <span class="btn-text">How to edit</span>
     </a>
-        <a class="btn btn-sm btn-primary" href="https://github.com/TYPO3-Documentation/render-guides/edit/main/Documentation/yetAnotherPage.rst" id="btnEditOnGitHub" rel="nofollow noopener" target="_blank">
+        <a class="btn btn-sm btn-secondary" href="https://github.com/TYPO3-Documentation/render-guides/edit/main/Documentation/yetAnotherPage.rst" id="btnEditOnGitHub" rel="nofollow noopener" target="_blank">
         <span class="btn-icon"><span class="fab fa-github"></span></span>
         <span class="btn-text">Edit on GitHub</span>
     </a>

--- a/tests/Integration/tests-full/next-prev-by-toctree/expected/four.html
+++ b/tests/Integration/tests-full/next-prev-by-toctree/expected/four.html
@@ -51,7 +51,7 @@
                                     <option value="">Search all</option>
                                 </select>
                                 <input autocomplete="off" class="form-control shadow-none" id="globalsearchinput" name="q" placeholder="TYPO3 documentation..." type="text" value="">
-                                <button class="btn btn-primary" type="submit"><i class="fa fa-search"></i>&nbsp;<span class="d-none d-md-inline">Search</span></button>
+                                <button class="btn btn-light search__submit" type="submit"><i class="fa fa-search"></i>&nbsp;<span class="d-none d-md-inline">Search</span></button>
                             </div>
                         </form>
                     </search>

--- a/tests/Integration/tests-full/next-prev-by-toctree/expected/i.html
+++ b/tests/Integration/tests-full/next-prev-by-toctree/expected/i.html
@@ -51,7 +51,7 @@
                                     <option value="">Search all</option>
                                 </select>
                                 <input autocomplete="off" class="form-control shadow-none" id="globalsearchinput" name="q" placeholder="TYPO3 documentation..." type="text" value="">
-                                <button class="btn btn-primary" type="submit"><i class="fa fa-search"></i>&nbsp;<span class="d-none d-md-inline">Search</span></button>
+                                <button class="btn btn-light search__submit" type="submit"><i class="fa fa-search"></i>&nbsp;<span class="d-none d-md-inline">Search</span></button>
                             </div>
                         </form>
                     </search>

--- a/tests/Integration/tests-full/next-prev-by-toctree/expected/index.html
+++ b/tests/Integration/tests-full/next-prev-by-toctree/expected/index.html
@@ -50,7 +50,7 @@
                                     <option value="">Search all</option>
                                 </select>
                                 <input autocomplete="off" class="form-control shadow-none" id="globalsearchinput" name="q" placeholder="TYPO3 documentation..." type="text" value="">
-                                <button class="btn btn-primary" type="submit"><i class="fa fa-search"></i>&nbsp;<span class="d-none d-md-inline">Search</span></button>
+                                <button class="btn btn-light search__submit" type="submit"><i class="fa fa-search"></i>&nbsp;<span class="d-none d-md-inline">Search</span></button>
                             </div>
                         </form>
                     </search>

--- a/tests/Integration/tests-full/next-prev-by-toctree/expected/one.html
+++ b/tests/Integration/tests-full/next-prev-by-toctree/expected/one.html
@@ -51,7 +51,7 @@
                                     <option value="">Search all</option>
                                 </select>
                                 <input autocomplete="off" class="form-control shadow-none" id="globalsearchinput" name="q" placeholder="TYPO3 documentation..." type="text" value="">
-                                <button class="btn btn-primary" type="submit"><i class="fa fa-search"></i>&nbsp;<span class="d-none d-md-inline">Search</span></button>
+                                <button class="btn btn-light search__submit" type="submit"><i class="fa fa-search"></i>&nbsp;<span class="d-none d-md-inline">Search</span></button>
                             </div>
                         </form>
                     </search>

--- a/tests/Integration/tests-full/next-prev-by-toctree/expected/three/index.html
+++ b/tests/Integration/tests-full/next-prev-by-toctree/expected/three/index.html
@@ -51,7 +51,7 @@
                                     <option value="">Search all</option>
                                 </select>
                                 <input autocomplete="off" class="form-control shadow-none" id="globalsearchinput" name="q" placeholder="TYPO3 documentation..." type="text" value="">
-                                <button class="btn btn-primary" type="submit"><i class="fa fa-search"></i>&nbsp;<span class="d-none d-md-inline">Search</span></button>
+                                <button class="btn btn-light search__submit" type="submit"><i class="fa fa-search"></i>&nbsp;<span class="d-none d-md-inline">Search</span></button>
                             </div>
                         </form>
                     </search>

--- a/tests/Integration/tests-full/next-prev-by-toctree/expected/three/pi.html
+++ b/tests/Integration/tests-full/next-prev-by-toctree/expected/three/pi.html
@@ -50,7 +50,7 @@
                                     <option value="">Search all</option>
                                 </select>
                                 <input autocomplete="off" class="form-control shadow-none" id="globalsearchinput" name="q" placeholder="TYPO3 documentation..." type="text" value="">
-                                <button class="btn btn-primary" type="submit"><i class="fa fa-search"></i>&nbsp;<span class="d-none d-md-inline">Search</span></button>
+                                <button class="btn btn-light search__submit" type="submit"><i class="fa fa-search"></i>&nbsp;<span class="d-none d-md-inline">Search</span></button>
                             </div>
                         </form>
                     </search>

--- a/tests/Integration/tests-full/next-prev-by-toctree/expected/three/three.html
+++ b/tests/Integration/tests-full/next-prev-by-toctree/expected/three/three.html
@@ -51,7 +51,7 @@
                                     <option value="">Search all</option>
                                 </select>
                                 <input autocomplete="off" class="form-control shadow-none" id="globalsearchinput" name="q" placeholder="TYPO3 documentation..." type="text" value="">
-                                <button class="btn btn-primary" type="submit"><i class="fa fa-search"></i>&nbsp;<span class="d-none d-md-inline">Search</span></button>
+                                <button class="btn btn-light search__submit" type="submit"><i class="fa fa-search"></i>&nbsp;<span class="d-none d-md-inline">Search</span></button>
                             </div>
                         </form>
                     </search>

--- a/tests/Integration/tests-full/next-prev-by-toctree/expected/three/threepointfive.html
+++ b/tests/Integration/tests-full/next-prev-by-toctree/expected/three/threepointfive.html
@@ -51,7 +51,7 @@
                                     <option value="">Search all</option>
                                 </select>
                                 <input autocomplete="off" class="form-control shadow-none" id="globalsearchinput" name="q" placeholder="TYPO3 documentation..." type="text" value="">
-                                <button class="btn btn-primary" type="submit"><i class="fa fa-search"></i>&nbsp;<span class="d-none d-md-inline">Search</span></button>
+                                <button class="btn btn-light search__submit" type="submit"><i class="fa fa-search"></i>&nbsp;<span class="d-none d-md-inline">Search</span></button>
                             </div>
                         </form>
                     </search>

--- a/tests/Integration/tests-full/next-prev-by-toctree/expected/two.html
+++ b/tests/Integration/tests-full/next-prev-by-toctree/expected/two.html
@@ -51,7 +51,7 @@
                                     <option value="">Search all</option>
                                 </select>
                                 <input autocomplete="off" class="form-control shadow-none" id="globalsearchinput" name="q" placeholder="TYPO3 documentation..." type="text" value="">
-                                <button class="btn btn-primary" type="submit"><i class="fa fa-search"></i>&nbsp;<span class="d-none d-md-inline">Search</span></button>
+                                <button class="btn btn-light search__submit" type="submit"><i class="fa fa-search"></i>&nbsp;<span class="d-none d-md-inline">Search</span></button>
                             </div>
                         </form>
                     </search>

--- a/tests/Integration/tests-full/next-prev/expected/index.html
+++ b/tests/Integration/tests-full/next-prev/expected/index.html
@@ -50,7 +50,7 @@
                                     <option value="">Search all</option>
                                 </select>
                                 <input autocomplete="off" class="form-control shadow-none" id="globalsearchinput" name="q" placeholder="TYPO3 documentation..." type="text" value="">
-                                <button class="btn btn-primary" type="submit"><i class="fa fa-search"></i>&nbsp;<span class="d-none d-md-inline">Search</span></button>
+                                <button class="btn btn-light search__submit" type="submit"><i class="fa fa-search"></i>&nbsp;<span class="d-none d-md-inline">Search</span></button>
                             </div>
                         </form>
                     </search>

--- a/tests/Integration/tests-full/next-prev/expected/page.html
+++ b/tests/Integration/tests-full/next-prev/expected/page.html
@@ -51,7 +51,7 @@
                                     <option value="">Search all</option>
                                 </select>
                                 <input autocomplete="off" class="form-control shadow-none" id="globalsearchinput" name="q" placeholder="TYPO3 documentation..." type="text" value="">
-                                <button class="btn btn-primary" type="submit"><i class="fa fa-search"></i>&nbsp;<span class="d-none d-md-inline">Search</span></button>
+                                <button class="btn btn-light search__submit" type="submit"><i class="fa fa-search"></i>&nbsp;<span class="d-none d-md-inline">Search</span></button>
                             </div>
                         </form>
                     </search>

--- a/tests/Integration/tests-full/next-prev/expected/yetAnotherPage.html
+++ b/tests/Integration/tests-full/next-prev/expected/yetAnotherPage.html
@@ -50,7 +50,7 @@
                                     <option value="">Search all</option>
                                 </select>
                                 <input autocomplete="off" class="form-control shadow-none" id="globalsearchinput" name="q" placeholder="TYPO3 documentation..." type="text" value="">
-                                <button class="btn btn-primary" type="submit"><i class="fa fa-search"></i>&nbsp;<span class="d-none d-md-inline">Search</span></button>
+                                <button class="btn btn-light search__submit" type="submit"><i class="fa fa-search"></i>&nbsp;<span class="d-none d-md-inline">Search</span></button>
                             </div>
                         </form>
                     </search>

--- a/tests/Integration/tests-full/page-with-subpages/expected/index.html
+++ b/tests/Integration/tests-full/page-with-subpages/expected/index.html
@@ -50,7 +50,7 @@
                                     <option value="">Search all</option>
                                 </select>
                                 <input autocomplete="off" class="form-control shadow-none" id="globalsearchinput" name="q" placeholder="TYPO3 documentation..." type="text" value="">
-                                <button class="btn btn-primary" type="submit"><i class="fa fa-search"></i>&nbsp;<span class="d-none d-md-inline">Search</span></button>
+                                <button class="btn btn-light search__submit" type="submit"><i class="fa fa-search"></i>&nbsp;<span class="d-none d-md-inline">Search</span></button>
                             </div>
                         </form>
                     </search>

--- a/tests/Integration/tests-full/page-with-subpages/expected/singlehtml/Index.html
+++ b/tests/Integration/tests-full/page-with-subpages/expected/singlehtml/Index.html
@@ -48,7 +48,7 @@
                                     <option value="">Search all</option>
                                 </select>
                                 <input autocomplete="off" class="form-control shadow-none" id="globalsearchinput" name="q" placeholder="TYPO3 documentation..." type="text" value="">
-                                <button class="btn btn-primary" type="submit"><i class="fa fa-search"></i>&nbsp;<span class="d-none d-md-inline">Search</span></button>
+                                <button class="btn btn-light search__submit" type="submit"><i class="fa fa-search"></i>&nbsp;<span class="d-none d-md-inline">Search</span></button>
                             </div>
                         </form>
                     </search>

--- a/tests/Integration/tests-full/page-with-subpages/expected/sub/index.html
+++ b/tests/Integration/tests-full/page-with-subpages/expected/sub/index.html
@@ -50,7 +50,7 @@
                                     <option value="">Search all</option>
                                 </select>
                                 <input autocomplete="off" class="form-control shadow-none" id="globalsearchinput" name="q" placeholder="TYPO3 documentation..." type="text" value="">
-                                <button class="btn btn-primary" type="submit"><i class="fa fa-search"></i>&nbsp;<span class="d-none d-md-inline">Search</span></button>
+                                <button class="btn btn-light search__submit" type="submit"><i class="fa fa-search"></i>&nbsp;<span class="d-none d-md-inline">Search</span></button>
                             </div>
                         </form>
                     </search>

--- a/tests/Integration/tests-full/sitemap/expected/Sitemap.html
+++ b/tests/Integration/tests-full/sitemap/expected/Sitemap.html
@@ -52,7 +52,7 @@
                                     <option value="">Search all</option>
                                 </select>
                                 <input autocomplete="off" class="form-control shadow-none" id="globalsearchinput" name="q" placeholder="TYPO3 documentation..." type="text" value="">
-                                <button class="btn btn-primary" type="submit"><i class="fa fa-search"></i>&nbsp;<span class="d-none d-md-inline">Search</span></button>
+                                <button class="btn btn-light search__submit" type="submit"><i class="fa fa-search"></i>&nbsp;<span class="d-none d-md-inline">Search</span></button>
                             </div>
                         </form>
                     </search>

--- a/tests/Integration/tests-full/sitemap/expected/index.html
+++ b/tests/Integration/tests-full/sitemap/expected/index.html
@@ -50,7 +50,7 @@
                                     <option value="">Search all</option>
                                 </select>
                                 <input autocomplete="off" class="form-control shadow-none" id="globalsearchinput" name="q" placeholder="TYPO3 documentation..." type="text" value="">
-                                <button class="btn btn-primary" type="submit"><i class="fa fa-search"></i>&nbsp;<span class="d-none d-md-inline">Search</span></button>
+                                <button class="btn btn-light search__submit" type="submit"><i class="fa fa-search"></i>&nbsp;<span class="d-none d-md-inline">Search</span></button>
                             </div>
                         </form>
                     </search>

--- a/tests/Integration/tests-full/two-toctrees/expected/index.html
+++ b/tests/Integration/tests-full/two-toctrees/expected/index.html
@@ -50,7 +50,7 @@
                                     <option value="">Search all</option>
                                 </select>
                                 <input autocomplete="off" class="form-control shadow-none" id="globalsearchinput" name="q" placeholder="TYPO3 documentation..." type="text" value="">
-                                <button class="btn btn-primary" type="submit"><i class="fa fa-search"></i>&nbsp;<span class="d-none d-md-inline">Search</span></button>
+                                <button class="btn btn-light search__submit" type="submit"><i class="fa fa-search"></i>&nbsp;<span class="d-none d-md-inline">Search</span></button>
                             </div>
                         </form>
                     </search>
@@ -132,7 +132,7 @@
         <span class="btn-icon"><span class="fas fa-info-circle"></span></span>
         <span class="btn-text">How to edit</span>
     </a>
-        <a class="btn btn-sm btn-primary" href="https://github.com/TYPO3-Documentation/render-guides/edit/main/Documentation/index.rst" id="btnEditOnGitHub" rel="nofollow noopener" target="_blank">
+        <a class="btn btn-sm btn-secondary" href="https://github.com/TYPO3-Documentation/render-guides/edit/main/Documentation/index.rst" id="btnEditOnGitHub" rel="nofollow noopener" target="_blank">
         <span class="btn-icon"><span class="fab fa-github"></span></span>
         <span class="btn-text">Edit on GitHub</span>
     </a>


### PR DESCRIPTION
Change search button variant to light
Change github button to dark background
Change horizbuttons to use only two colorschemes
Add different hover states to buttons

Resolves #474
___
1. search, view source, how to edit, github buttons
BEFORE:
![Zrzut ekranu 2024-05-27 o 15 51 19](https://github.com/TYPO3-Documentation/render-guides/assets/64216939/6a03c998-bcd0-4977-bb49-14141a95572f)
AFTER:
![Zrzut ekranu 2024-05-27 o 15 50 41](https://github.com/TYPO3-Documentation/render-guides/assets/64216939/d0930296-4919-4a20-9a7d-a68147a17f2d)

2. Secondary buttons hover state (same state applies to "Search", "Edit on Github" and all "dark" horizontal buttons)
BEFORE:
![Zrzut ekranu 2024-05-27 o 15 54 28](https://github.com/TYPO3-Documentation/render-guides/assets/64216939/17a9d253-5920-4513-9974-03e9d087f095)
AFTER:
![Zrzut ekranu 2024-05-27 o 15 55 08](https://github.com/TYPO3-Documentation/render-guides/assets/64216939/602c0d48-4342-48ff-8cc4-7eb32b70d70e)

3. Horizontal buttons (attention|important|primary|striking|warning use gray background with white text, note|tip light gray background with gray text)
BEFORE:
![Zrzut ekranu 2024-05-27 o 15 53 21](https://github.com/TYPO3-Documentation/render-guides/assets/64216939/f82f01db-c67d-4285-8c83-9360c5822047)
AFTER:
![Zrzut ekranu 2024-05-27 o 15 52 43](https://github.com/TYPO3-Documentation/render-guides/assets/64216939/81bde4c4-f570-41d1-88d1-5ace0afe67f9)
Dark horizontal button hover state (2nd from left):
![Zrzut ekranu 2024-05-27 o 15 57 54](https://github.com/TYPO3-Documentation/render-guides/assets/64216939/82d087c4-08cb-4a74-a914-f7df14b4921c)