### PR TITLE
[TASK] Improve nested links readability in main menu

### DIFF
--- a/packages/typo3-docs-theme/assets/sass/layout/navigation/_main_navigation.scss
+++ b/packages/typo3-docs-theme/assets/sass/layout/navigation/_main_navigation.scss
@@ -38,25 +38,32 @@
         padding: calc(#{$spacer} / 4) 0;
         padding-right: 1.5em;
         text-decoration: none;
-	&:hover {
-	    text-decoration: underline;
-	}
+        &:hover {
+            text-decoration: underline;
+        }
     }
     ul {
-        padding-left: $spacer;
+        padding-left: calc(#{$spacer} / 2);
         list-style-type: none;
+    }
+    > ul {
+        > li {
+            &.active {
+                border-left: 1px solid rgba(0, 0, 0, .15);
+                border-radius: 0;
+            }
+        }
     }
     li {
         border-radius: $border-radius;
         overflow: hidden;
-	padding-left: calc(#{$spacer} / 2) ;
-	&.active {
-	    border-left: 1px solid rgba(0, 0, 0, .15);
-	    border-radius: 0;
-	}
-	&.current {
-	    border-left: none;
-	}
+        padding-left: calc(#{$spacer} / 2) ;
+        &.current {
+            border-left: none;
+        }
+        @include media-breakpoint-up(lg) {
+            font-size: 1rem;
+        }
     }
     .toctree-expand {
         position: absolute;

--- a/packages/typo3-docs-theme/resources/public/css/theme.css
+++ b/packages/typo3-docs-theme/resources/public/css/theme.css
@@ -25371,20 +25371,25 @@ dl.field-list > dt:after {
   text-decoration: underline;
 }
 .main_menu ul {
-  padding-left: 1rem;
+  padding-left: calc(1rem / 2);
   list-style-type: none;
+}
+.main_menu > ul > li.active {
+  border-left: 1px solid rgba(0, 0, 0, 0.15);
+  border-radius: 0;
 }
 .main_menu li {
   border-radius: 0.375rem;
   overflow: hidden;
   padding-left: calc(1rem / 2);
 }
-.main_menu li.active {
-  border-left: 1px solid rgba(0, 0, 0, 0.15);
-  border-radius: 0;
-}
 .main_menu li.current {
   border-left: none;
+}
+@media (min-width: 992px) {
+  .main_menu li {
+    font-size: 1rem;
+  }
 }
 .main_menu .toctree-expand {
   position: absolute;


### PR DESCRIPTION
Resolves #562

Reduced the font-size of links in menu, changed vertical lines so that they appear only on first nesting level and reduced left offset for nested links

BEFORE:
<img width="1260" alt="Zrzut ekranu 2024-05-28 o 13 44 52" src="https://github.com/TYPO3-Documentation/render-guides/assets/64216939/03ddb98b-edfc-4e2d-99ff-7aca41fe473f">

AFTER:
<img width="1260" alt="Zrzut ekranu 2024-05-28 o 13 43 49" src="https://github.com/TYPO3-Documentation/render-guides/assets/64216939/7d2764eb-e210-4660-851f-787071f588c0">
