### PR TITLE
[FEATURE] Improve t3src and t3ext textroles

### DIFF
--- a/packages/typo3-docs-theme/resources/config/typo3-docs-theme.php
+++ b/packages/typo3-docs-theme/resources/config/typo3-docs-theme.php
@@ -45,6 +45,8 @@ use T3Docs\Typo3DocsTheme\TextRoles\PhpTextRole;
 use T3Docs\Typo3DocsTheme\TextRoles\RestructuredTextTextRole;
 use T3Docs\Typo3DocsTheme\TextRoles\ShellTextTextRole;
 use T3Docs\Typo3DocsTheme\TextRoles\SqlTextRole;
+use T3Docs\Typo3DocsTheme\TextRoles\T3extTextRole;
+use T3Docs\Typo3DocsTheme\TextRoles\T3srcTextRole;
 use T3Docs\Typo3DocsTheme\TextRoles\TSconfigTextRole;
 use T3Docs\Typo3DocsTheme\TextRoles\TypeScriptTextRole;
 use T3Docs\Typo3DocsTheme\TextRoles\TypoScriptTextTextRole;
@@ -92,9 +94,13 @@ return static function (ContainerConfigurator $container): void {
         ->tag('phpdoc.guides.parser.rst.text_role')
         ->set(RestructuredTextTextRole::class)
         ->tag('phpdoc.guides.parser.rst.text_role')
+        ->set(ShellTextTextRole::class)
+        ->tag('phpdoc.guides.parser.rst.text_role')
         ->set(SqlTextRole::class)
         ->tag('phpdoc.guides.parser.rst.text_role')
-        ->set(ShellTextTextRole::class)
+        ->set(T3extTextRole::class)
+        ->tag('phpdoc.guides.parser.rst.text_role')
+        ->set(T3srcTextRole::class)
         ->tag('phpdoc.guides.parser.rst.text_role')
         ->set(TSconfigTextRole::class)
         ->tag('phpdoc.guides.parser.rst.text_role')

--- a/packages/typo3-docs-theme/resources/template/inline/textroles/t3ext.html.twig
+++ b/packages/typo3-docs-theme/resources/template/inline/textroles/t3ext.html.twig
@@ -1,3 +1,0 @@
-{% apply spaceless %}
-    <a class="reference external" href="https://extensions.typo3.org/extension/{{ node.value }}" title="EXT:{{ node.value }} in the TER (TYPO3 extension repository)">EXT:{{ node.value }}</a>
-{% endapply %}

--- a/packages/typo3-docs-theme/resources/template/inline/textroles/t3src.html.twig
+++ b/packages/typo3-docs-theme/resources/template/inline/textroles/t3src.html.twig
@@ -1,3 +1,0 @@
-{% apply spaceless %}
-    <a class="reference external" href="https://github.com/typo3/typo3/blob/{{ getTYPO3Version() }}/typo3/sysext/{{ node.value }}" title="EXT:{{ node.value }} on GitHub">EXT:{{ node.value }} (GitHub)</a>
-{% endapply %}

--- a/packages/typo3-docs-theme/src/TextRoles/T3extTextRole.php
+++ b/packages/typo3-docs-theme/src/TextRoles/T3extTextRole.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace T3Docs\Typo3DocsTheme\TextRoles;
+
+use phpDocumentor\Guides\Nodes\Inline\HyperLinkNode;
+use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
+use phpDocumentor\Guides\RestructuredText\Parser\References\EmbeddedReferenceParser;
+use phpDocumentor\Guides\RestructuredText\TextRoles\TextRole;
+
+final class T3extTextRole implements TextRole
+{
+    use EmbeddedReferenceParser;
+    final public const NAME = 't3ext';
+
+    public function getName(): string
+    {
+        return self::NAME;
+    }
+
+    /** @inheritDoc */
+    public function getAliases(): array
+    {
+        return [];
+    }
+
+    public function processNode(
+        DocumentParserContext $documentParserContext,
+        string $role,
+        string $content,
+        string $rawContent,
+    ): HyperLinkNode {
+        $referenceData = $this->extractEmbeddedReference($content);
+
+        return $this->createNode($documentParserContext, $referenceData->reference, $referenceData->text, $role);
+    }
+
+    protected function createNode(
+        DocumentParserContext $documentParserContext,
+        string $referenceTarget,
+        string|null $referenceName,
+        string $role
+    ): HyperLinkNode {
+        $extKey = $referenceTarget;
+        if (str_starts_with($extKey, 'EXT:')) {
+            $extKey = str_replace('EXT:', '', $extKey);
+        }
+        $terLink = sprintf('https://extensions.typo3.org/extension/%s', $extKey);
+        $extName = $referenceName ?? 'EXT:' . $extKey;
+        return new HyperLinkNode($extName, $terLink);
+    }
+}

--- a/packages/typo3-docs-theme/src/TextRoles/T3srcTextRole.php
+++ b/packages/typo3-docs-theme/src/TextRoles/T3srcTextRole.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace T3Docs\Typo3DocsTheme\TextRoles;
+
+use phpDocumentor\Guides\Nodes\Inline\HyperLinkNode;
+use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
+use phpDocumentor\Guides\RestructuredText\Parser\References\EmbeddedReferenceParser;
+use phpDocumentor\Guides\RestructuredText\TextRoles\TextRole;
+use T3Docs\Typo3DocsTheme\Inventory\Typo3VersionService;
+
+final class T3srcTextRole implements TextRole
+{
+    use EmbeddedReferenceParser;
+    final public const NAME = 't3src';
+
+    public function __construct(
+        private readonly Typo3VersionService $typo3VersionService,
+    ) {}
+
+    public function getName(): string
+    {
+        return self::NAME;
+    }
+
+    /** @inheritDoc */
+    public function getAliases(): array
+    {
+        return [];
+    }
+
+    public function processNode(
+        DocumentParserContext $documentParserContext,
+        string $role,
+        string $content,
+        string $rawContent,
+    ): HyperLinkNode {
+        $referenceData = $this->extractEmbeddedReference($content);
+
+        return $this->createNode($documentParserContext, $referenceData->reference, $referenceData->text, $role);
+    }
+
+    protected function createNode(
+        DocumentParserContext $documentParserContext,
+        string $referenceTarget,
+        string|null $referenceName,
+        string $role
+    ): HyperLinkNode {
+        $typo3Version = $this->typo3VersionService->getPreferredVersion();
+        $fileLink = $referenceTarget;
+        if (str_starts_with($fileLink, 'EXT:')) {
+            $fileLink = str_replace('EXT:', 'typo3/sysext/', $fileLink);
+        }
+        if (!str_starts_with($fileLink, 'typo3/sysext/')) {
+            $fileLink = 'typo3/sysext/' . $fileLink;
+        }
+        $gitHubLink = sprintf('https://github.com/typo3/typo3/blob/%s/%s', $typo3Version, $fileLink);
+        $fileName = $referenceName ?? str_replace('typo3/sysext/', 'EXT:', $fileLink) . ' (GitHub)';
+        return new HyperLinkNode($fileName, $gitHubLink);
+    }
+}

--- a/tests/Integration/tests/roles/role-t3ext/expected/index.html
+++ b/tests/Integration/tests/roles/role-t3ext/expected/index.html
@@ -3,7 +3,7 @@
             <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
 
     <p>As an example, you may want to take a look at extension
-<a class="reference external" href="https://extensions.typo3.org/extension/fal_securedownload" title="EXT:fal_securedownload in the TER (TYPO3 extension repository)">EXT:fal_securedownload</a>.</p>
+<a href="https://extensions.typo3.org/extension/fal_securedownload">EXT:fal_securedownload</a> or <a href="https://extensions.typo3.org/extension/news">EXT:news</a>, <a href="https://extensions.typo3.org/extension/news">news</a>.</p>
 
     </section>
         <!-- content end -->

--- a/tests/Integration/tests/roles/role-t3ext/input/index.rst
+++ b/tests/Integration/tests/roles/role-t3ext/input/index.rst
@@ -3,4 +3,4 @@ Document Title
 ==============
 
 As an example, you may want to take a look at extension
-:t3ext:`fal_securedownload`.
+:t3ext:`fal_securedownload` or :t3ext:`EXT:news`, :t3ext:`news <EXT:news>`.

--- a/tests/Integration/tests/roles/role-t3src-core-prefered/expected/index.html
+++ b/tests/Integration/tests/roles/role-t3src-core-prefered/expected/index.html
@@ -2,7 +2,7 @@
                 <section class="section" id="document-title">
             <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
 
-    <p>Here is an extract of <a class="reference external" href="https://github.com/typo3/typo3/blob/main/typo3/sysext/backend/Configuration/Backend/Routes.php" title="EXT:backend/Configuration/Backend/Routes.php on GitHub">EXT:backend/Configuration/Backend/Routes.php (GitHub)</a>.</p>
+    <p>Here is an extract of <a href="https://github.com/typo3/typo3/blob/main/typo3/sysext/backend/Configuration/Backend/Routes.php">EXT:backend/Configuration/Backend/Routes.php (GitHub)</a>.</p>
 
     </section>
         <!-- content end -->

--- a/tests/Integration/tests/roles/role-t3src/expected/index.html
+++ b/tests/Integration/tests/roles/role-t3src/expected/index.html
@@ -2,7 +2,14 @@
                 <section class="section" id="document-title">
             <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
 
-    <p>Here is an extract of <a class="reference external" href="https://github.com/typo3/typo3/blob/12.4/typo3/sysext/backend/Configuration/Backend/Routes.php" title="EXT:backend/Configuration/Backend/Routes.php on GitHub">EXT:backend/Configuration/Backend/Routes.php (GitHub)</a>.</p>
+    <p>Here is an extract of <a href="https://github.com/typo3/typo3/blob/12.4/typo3/sysext/backend/Configuration/Backend/Routes.php">EXT:backend/Configuration/Backend/Routes.php (GitHub)</a>.</p>
+
+
+    <p>See also
+<a href="https://github.com/typo3/typo3/blob/12.4/typo3/sysext/core/Classes/Pagination/SlidingWindowPagination.php">EXT:core/Classes/Pagination/SlidingWindowPagination.php (GitHub)</a> and</p>
+
+
+    <p><a href="https://github.com/typo3/typo3/blob/12.4/typo3/sysext/core/Classes/Pagination/SlidingWindowPagination.php">SlidingWindowPagination.php</a>.</p>
 
     </section>
         <!-- content end -->

--- a/tests/Integration/tests/roles/role-t3src/input/index.rst
+++ b/tests/Integration/tests/roles/role-t3src/input/index.rst
@@ -4,3 +4,8 @@ Document Title
 
 
 Here is an extract of :t3src:`backend/Configuration/Backend/Routes.php`.
+
+See also
+:t3src:`typo3/sysext/core/Classes/Pagination/SlidingWindowPagination.php` and
+
+:t3src:`SlidingWindowPagination.php <typo3/sysext/core/Classes/Pagination/SlidingWindowPagination.php>`.


### PR DESCRIPTION
Interpret the link/reference syntax where a custom link text can be given. Interpret more different input possibilities

Resolves https://github.com/TYPO3-Documentation/render-guides/issues/609