### PR TITLE
[FEATURE] Offer sorting options for viewhelper arguments

### DIFF
--- a/packages/typo3-docs-theme/src/Directives/ViewHelperDirective.php
+++ b/packages/typo3-docs-theme/src/Directives/ViewHelperDirective.php
@@ -87,6 +87,8 @@ final class ViewHelperDirective extends BaseDirective
             return $this->getErrorNode();
         }
 
+        $sortBy = $directive->getOptionString('sortBy', 'name');
+
         $noindex = $directive->getOptionBool('noindex');
 
         $data = $json['viewHelpers'][$directive->getData()];
@@ -94,8 +96,11 @@ final class ViewHelperDirective extends BaseDirective
         $arguments = [];
         foreach ($json['viewHelpers'][$directive->getData()]['argumentDefinitions'] ?? [] as $argumentDefinition) {
             if (is_array($argumentDefinition)) {
-                $arguments[] = $this->getArgument($argumentDefinition, $viewHelperNode, $noindex);
+                $arguments[$this->getString($argumentDefinition, 'name')] = $this->getArgument($argumentDefinition, $viewHelperNode, $noindex);
             }
+        }
+        if ($sortBy === 'name') {
+            ksort($arguments);
         }
         $viewHelperNode->setArguments($arguments);
         $viewHelperNode->setValue($arguments);

--- a/tests/Integration/tests/viewhelper/expected/index.html
+++ b/tests/Integration/tests/viewhelper/expected/index.html
@@ -98,24 +98,24 @@ This ViewHelper mimicks PHP&#039;s <code class="code-inline" translate="no" aria
 
         <p>The following arguments are available for the split ViewHelper: </p>
             <dl class="confval">
-    <dt id="viewhelper-argument-typo3fluid-fluid-viewhelpers-splitviewhelper-value" class="d-flex justify-content-between">
+    <dt id="viewhelper-argument-typo3fluid-fluid-viewhelpers-splitviewhelper-limit" class="d-flex justify-content-between">
         <div class="confval-header">
-            <code class="sig-name descname"><span class="pre">value</span></code>
-                            <a class="headerlink" href="#viewhelper-argument-typo3fluid-fluid-viewhelpers-splitviewhelper-value" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="viewhelper-argument-typo3fluid-fluid-viewhelpers-splitviewhelper-value" data-rstCode=":typo3:viewhelper-argument:`value &lt;somemanual:typo3fluid-fluid-viewhelpers-splitviewhelper-value&gt;`"  title="Reference this configuration value">¶</a>
+            <code class="sig-name descname"><span class="pre">limit</span></code>
+                            <a class="headerlink" href="#viewhelper-argument-typo3fluid-fluid-viewhelpers-splitviewhelper-limit" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="viewhelper-argument-typo3fluid-fluid-viewhelpers-splitviewhelper-limit" data-rstCode=":typo3:viewhelper-argument:`limit &lt;somemanual:typo3fluid-fluid-viewhelpers-splitviewhelper-limit&gt;`"  title="Reference this configuration value">¶</a>
             </div>
         <div class="confval-back-to-top">                <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
     <dd>
         <dl class="field-list simple">
             <dt class="field">Type</dt>
-            <dd class="field">string
+            <dd class="field">int
             </dd>
                             <dt class="field">Default</dt>
-                <dd class="field">&#039;&#039;
+                <dd class="field">0
                 </dd>
                                 </dl>
         <div class="confval-description">
-            The string to explode
+            If limit is positive, a maximum of $limit items will be returned. If limit is negative, all items except for the last $limit items will be returned. 0 will be treated as 1.
         </div>
     </dd>
 </dl>            <dl class="confval">
@@ -140,10 +140,164 @@ This ViewHelper mimicks PHP&#039;s <code class="code-inline" translate="no" aria
         </div>
     </dd>
 </dl>            <dl class="confval">
-    <dt id="viewhelper-argument-typo3fluid-fluid-viewhelpers-splitviewhelper-limit" class="d-flex justify-content-between">
+    <dt id="viewhelper-argument-typo3fluid-fluid-viewhelpers-splitviewhelper-value" class="d-flex justify-content-between">
+        <div class="confval-header">
+            <code class="sig-name descname"><span class="pre">value</span></code>
+                            <a class="headerlink" href="#viewhelper-argument-typo3fluid-fluid-viewhelpers-splitviewhelper-value" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="viewhelper-argument-typo3fluid-fluid-viewhelpers-splitviewhelper-value" data-rstCode=":typo3:viewhelper-argument:`value &lt;somemanual:typo3fluid-fluid-viewhelpers-splitviewhelper-value&gt;`"  title="Reference this configuration value">¶</a>
+            </div>
+        <div class="confval-back-to-top">                <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
+    </dt>
+    <dd>
+        <dl class="field-list simple">
+            <dt class="field">Type</dt>
+            <dd class="field">string
+            </dd>
+                            <dt class="field">Default</dt>
+                <dd class="field">&#039;&#039;
+                </dd>
+                                </dl>
+        <div class="confval-description">
+            The string to explode
+        </div>
+    </dd>
+</dl>
+
+
+    <p>The SplitViewHelper splits a string by the specified separator, which
+results in an array. The number of values in the resulting array can
+be limited with the limit parameter, which results in an array where
+the last item contains the remaining unsplit string.
+This ViewHelper mimicks PHP&#039;s <code class="code-inline" translate="no" aria-description="PHP" aria-details="Dynamic server-side scripting language.">explode()</code> function.</p>
+<section class="section" id="examples">
+            <h2>Examples<a class="headerlink" href="#examples" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h2>
+            <section class="section" id="split-with-a-separator">
+            <h3>Split with a separator<a class="headerlink" href="#split-with-a-separator" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h3>
+            <div class="code-block-wrapper" translate="no">
+
+    <pre class="code-block"><code>&lt;f:split value=&quot;1,5,8&quot; separator=&quot;,&quot; /&gt;</code></pre>
+    <div>        <button class="code-block-copy" title="Copy to clipboard">
+            <i class="icon fa-regular fa-copy code-block-copy-icon"></i>
+            <i class="fa-solid fa-check code-block-check-icon code-block-hide"></i>
+        </button>
+        <span class="code-block-check-tooltip code-block-hide" aria-live="polite">Copied!</span>
+    </div>
+</div>
+            <div class="code-block-wrapper" translate="no">
+
+    <pre class="code-block"><code class="hljs plaintext">{0: '1', 1: '5', 2: '8'}</code></pre>
+    <div>        <button class="code-block-copy" title="Copy to clipboard">
+            <i class="icon fa-regular fa-copy code-block-copy-icon"></i>
+            <i class="fa-solid fa-check code-block-check-icon code-block-hide"></i>
+        </button>
+        <span class="code-block-check-tooltip code-block-hide" aria-live="polite">Copied!</span>
+    </div>
+</div>
+    </section>
+            <section class="section" id="split-using-tag-content-as-value">
+            <h3>Split using tag content as value<a class="headerlink" href="#split-using-tag-content-as-value" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h3>
+            <div class="code-block-wrapper" translate="no">
+
+    <pre class="code-block"><code>&lt;f:split separator=&quot;-&quot;&gt;1-5-8&lt;/f:split&gt;</code></pre>
+    <div>        <button class="code-block-copy" title="Copy to clipboard">
+            <i class="icon fa-regular fa-copy code-block-copy-icon"></i>
+            <i class="fa-solid fa-check code-block-check-icon code-block-hide"></i>
+        </button>
+        <span class="code-block-check-tooltip code-block-hide" aria-live="polite">Copied!</span>
+    </div>
+</div>
+            <div class="code-block-wrapper" translate="no">
+
+    <pre class="code-block"><code class="hljs plaintext">{0: '1', 1: '5', 2: '8'}</code></pre>
+    <div>        <button class="code-block-copy" title="Copy to clipboard">
+            <i class="icon fa-regular fa-copy code-block-copy-icon"></i>
+            <i class="fa-solid fa-check code-block-check-icon code-block-hide"></i>
+        </button>
+        <span class="code-block-check-tooltip code-block-hide" aria-live="polite">Copied!</span>
+    </div>
+</div>
+    </section>
+            <section class="section" id="split-with-a-limit">
+            <h3>Split with a limit<a class="headerlink" href="#split-with-a-limit" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h3>
+            <div class="code-block-wrapper" translate="no">
+
+    <pre class="code-block"><code>&lt;f:split value=&quot;1,5,8&quot; separator=&quot;,&quot; limit=&quot;2&quot; /&gt;</code></pre>
+    <div>        <button class="code-block-copy" title="Copy to clipboard">
+            <i class="icon fa-regular fa-copy code-block-copy-icon"></i>
+            <i class="fa-solid fa-check code-block-check-icon code-block-hide"></i>
+        </button>
+        <span class="code-block-check-tooltip code-block-hide" aria-live="polite">Copied!</span>
+    </div>
+</div>
+            <div class="code-block-wrapper" translate="no">
+
+    <pre class="code-block"><code class="hljs plaintext">{0: '1', 1: '5,8'}</code></pre>
+    <div>        <button class="code-block-copy" title="Copy to clipboard">
+            <i class="icon fa-regular fa-copy code-block-copy-icon"></i>
+            <i class="fa-solid fa-check code-block-check-icon code-block-hide"></i>
+        </button>
+        <span class="code-block-check-tooltip code-block-hide" aria-live="polite">Copied!</span>
+    </div>
+</div>
+    </section>
+    </section>
+
+    <h2>Source code</h2>
+
+<p>
+    Go to the source code of this ViewHelper:
+    <a href="https://github.com/TYPO3/Fluid/blob/main/src/ViewHelpers/SplitViewHelper.php">SplitViewHelper.php (GitHub)</a>.
+</p>
+
+    <h2>Arguments</h2>
+
+        <p>The following arguments are available for the split ViewHelper: </p>
+            <dl class="confval">
+    <dt class="d-flex justify-content-between">
+        <div class="confval-header">
+            <code class="sig-name descname"><span class="pre">value</span></code>
+                            <span class="headerNoindex" title="This configuration value cannot be linked directly. Consider to link to the section above."><i class="fa-solid fa-link-slash"></i></span>
+            </div>
+        <div class="confval-back-to-top">                <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
+    </dt>
+    <dd>
+        <dl class="field-list simple">
+            <dt class="field">Type</dt>
+            <dd class="field">string
+            </dd>
+                            <dt class="field">Default</dt>
+                <dd class="field">&#039;&#039;
+                </dd>
+                                </dl>
+        <div class="confval-description">
+            The string to explode
+        </div>
+    </dd>
+</dl>            <dl class="confval">
+    <dt class="d-flex justify-content-between">
+        <div class="confval-header">
+            <code class="sig-name descname"><span class="pre">separator</span></code>
+                            <span class="headerNoindex" title="This configuration value cannot be linked directly. Consider to link to the section above."><i class="fa-solid fa-link-slash"></i></span>
+            </div>
+        <div class="confval-back-to-top">                <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
+    </dt>
+    <dd>
+        <dl class="field-list simple">
+            <dt class="field">Type</dt>
+            <dd class="field">string
+            </dd>
+                                        <dt class="field">Required</dt>
+                <dd class="field">1
+                </dd>
+                    </dl>
+        <div class="confval-description">
+            Separator string to explode with
+        </div>
+    </dd>
+</dl>            <dl class="confval">
+    <dt class="d-flex justify-content-between">
         <div class="confval-header">
             <code class="sig-name descname"><span class="pre">limit</span></code>
-                            <a class="headerlink" href="#viewhelper-argument-typo3fluid-fluid-viewhelpers-splitviewhelper-limit" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="viewhelper-argument-typo3fluid-fluid-viewhelpers-splitviewhelper-limit" data-rstCode=":typo3:viewhelper-argument:`limit &lt;somemanual:typo3fluid-fluid-viewhelpers-splitviewhelper-limit&gt;`"  title="Reference this configuration value">¶</a>
+                            <span class="headerNoindex" title="This configuration value cannot be linked directly. Consider to link to the section above."><i class="fa-solid fa-link-slash"></i></span>
             </div>
         <div class="confval-back-to-top">                <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>

--- a/tests/Integration/tests/viewhelper/expected/objects.inv.json
+++ b/tests/Integration/tests/viewhelper/expected/objects.inv.json
@@ -67,11 +67,11 @@
         ]
     },
     "typo3:viewhelper-argument": {
-        "typo3fluid-fluid-viewhelpers-splitviewhelper-value": [
+        "typo3fluid-fluid-viewhelpers-splitviewhelper-limit": [
             "-",
             "-",
-            "index.html#typo3fluid-fluid-viewhelpers-splitviewhelper-value",
-            "value"
+            "index.html#typo3fluid-fluid-viewhelpers-splitviewhelper-limit",
+            "limit"
         ],
         "typo3fluid-fluid-viewhelpers-splitviewhelper-separator": [
             "-",
@@ -79,11 +79,11 @@
             "index.html#typo3fluid-fluid-viewhelpers-splitviewhelper-separator",
             "separator"
         ],
-        "typo3fluid-fluid-viewhelpers-splitviewhelper-limit": [
+        "typo3fluid-fluid-viewhelpers-splitviewhelper-value": [
             "-",
             "-",
-            "index.html#typo3fluid-fluid-viewhelpers-splitviewhelper-limit",
-            "limit"
+            "index.html#typo3fluid-fluid-viewhelpers-splitviewhelper-value",
+            "value"
         ],
         "typo3-cms-fluid-viewhelpers-link-externalviewhelper-uri": [
             "-",

--- a/tests/Integration/tests/viewhelper/input/index.rst
+++ b/tests/Integration/tests/viewhelper/input/index.rst
@@ -11,6 +11,11 @@ f:split
 ..  typo3:viewhelper:: split
     :source: resources/global_viewhelpers_demo.json
 
+..  typo3:viewhelper:: split
+    :source: resources/global_viewhelpers_demo.json
+    :sortBy: json
+    :noindex:
+
 f:link.external
 ===============
 


### PR DESCRIPTION
If option `:sortBy: name` or not sortBy is set, sort by name.

Otherwise the sorting from the json is preserved.

resolves https://github.com/TYPO3-Documentation/render-guides/issues/660