### PR TITLE
[TASK] Clarify TextRole popup titles

### DIFF
--- a/packages/typo3-docs-theme/src/TextRoles/FluidTextTextRole.php
+++ b/packages/typo3-docs-theme/src/TextRoles/FluidTextTextRole.php
@@ -21,6 +21,6 @@ final class FluidTextTextRole implements TextRole
 
     public function processNode(DocumentParserContext $documentParserContext, string $role, string $content, string $rawContent): InlineNode
     {
-        return new CodeInlineNode($rawContent, 'Fluid', 'Templating engine used by TYPO3.');
+        return new CodeInlineNode($rawContent, 'Code written in Fluid', 'Templating engine used by TYPO3.');
     }
 }

--- a/packages/typo3-docs-theme/src/TextRoles/HtmlTextTextRole.php
+++ b/packages/typo3-docs-theme/src/TextRoles/HtmlTextTextRole.php
@@ -21,6 +21,6 @@ final class HtmlTextTextRole implements TextRole
 
     public function processNode(DocumentParserContext $documentParserContext, string $role, string $content, string $rawContent): InlineNode
     {
-        return new CodeInlineNode($rawContent, 'HTML', 'HyperText Markup Language.');
+        return new CodeInlineNode($rawContent, 'Code written in HTML', 'HyperText Markup Language.');
     }
 }

--- a/packages/typo3-docs-theme/src/TextRoles/JavaScriptTextRole.php
+++ b/packages/typo3-docs-theme/src/TextRoles/JavaScriptTextRole.php
@@ -21,6 +21,6 @@ final class JavaScriptTextRole implements TextRole
 
     public function processNode(DocumentParserContext $documentParserContext, string $role, string $content, string $rawContent): InlineNode
     {
-        return new CodeInlineNode($rawContent, 'JavaScript', 'Dynamic client-side scripting language for dynamic applications.');
+        return new CodeInlineNode($rawContent, 'Code written in JavaScript', 'Dynamic client-side scripting language for dynamic applications.');
     }
 }

--- a/packages/typo3-docs-theme/src/TextRoles/PhpTextRole.php
+++ b/packages/typo3-docs-theme/src/TextRoles/PhpTextRole.php
@@ -21,6 +21,6 @@ final class PhpTextRole implements TextRole
 
     public function processNode(DocumentParserContext $documentParserContext, string $role, string $content, string $rawContent): InlineNode
     {
-        return new CodeInlineNode($rawContent, 'PHP', 'Dynamic server-side scripting language.');
+        return new CodeInlineNode($rawContent, 'Code written in PHP', 'Dynamic server-side scripting language.');
     }
 }

--- a/packages/typo3-docs-theme/src/TextRoles/RestructuredTextTextRole.php
+++ b/packages/typo3-docs-theme/src/TextRoles/RestructuredTextTextRole.php
@@ -21,6 +21,6 @@ final class RestructuredTextTextRole implements TextRole
 
     public function processNode(DocumentParserContext $documentParserContext, string $role, string $content, string $rawContent): InlineNode
     {
-        return new CodeInlineNode($rawContent, 'reStructuredText', 'Easy-to-read, what-you-see-is-what-you-get plaintext markup syntax and parser system.');
+        return new CodeInlineNode($rawContent, 'Code written in reStructuredText', 'Easy-to-read, what-you-see-is-what-you-get plaintext markup syntax and parser system.');
     }
 }

--- a/packages/typo3-docs-theme/src/TextRoles/ShellTextTextRole.php
+++ b/packages/typo3-docs-theme/src/TextRoles/ShellTextTextRole.php
@@ -21,6 +21,6 @@ final class ShellTextTextRole implements TextRole
 
     public function processNode(DocumentParserContext $documentParserContext, string $role, string $content, string $rawContent): InlineNode
     {
-        return new CodeInlineNode($rawContent, 'Shell Script', 'Raw command line interface code on operating-system level.');
+        return new CodeInlineNode($rawContent, 'Code written in Shell Script', 'Raw command line interface code on operating-system level.');
     }
 }

--- a/packages/typo3-docs-theme/src/TextRoles/SqlTextRole.php
+++ b/packages/typo3-docs-theme/src/TextRoles/SqlTextRole.php
@@ -21,6 +21,6 @@ final class SqlTextRole implements TextRole
 
     public function processNode(DocumentParserContext $documentParserContext, string $role, string $content, string $rawContent): InlineNode
     {
-        return new CodeInlineNode($rawContent, 'SQL', 'Structured Query Language for database queries.');
+        return new CodeInlineNode($rawContent, 'Code written in SQL', 'Structured Query Language for database queries.');
     }
 }

--- a/packages/typo3-docs-theme/src/TextRoles/TSconfigTextRole.php
+++ b/packages/typo3-docs-theme/src/TextRoles/TSconfigTextRole.php
@@ -21,6 +21,6 @@ final class TSconfigTextRole implements TextRole
 
     public function processNode(DocumentParserContext $documentParserContext, string $role, string $content, string $rawContent): InlineNode
     {
-        return new CodeInlineNode($rawContent, 'TSconfig', 'TypoScript Configuration directives.');
+        return new CodeInlineNode($rawContent, 'Code written in TSconfig', 'TypoScript Configuration directives.');
     }
 }

--- a/packages/typo3-docs-theme/src/TextRoles/TypeScriptTextRole.php
+++ b/packages/typo3-docs-theme/src/TextRoles/TypeScriptTextRole.php
@@ -21,6 +21,6 @@ final class TypeScriptTextRole implements TextRole
 
     public function processNode(DocumentParserContext $documentParserContext, string $role, string $content, string $rawContent): InlineNode
     {
-        return new CodeInlineNode($rawContent, 'TypeScript', 'Makes JavaScript utilize type declarations.');
+        return new CodeInlineNode($rawContent, 'Code written in TypeScript', 'Makes JavaScript utilize type declarations.');
     }
 }

--- a/packages/typo3-docs-theme/src/TextRoles/TypoScriptTextTextRole.php
+++ b/packages/typo3-docs-theme/src/TextRoles/TypoScriptTextTextRole.php
@@ -21,6 +21,6 @@ final class TypoScriptTextTextRole implements TextRole
 
     public function processNode(DocumentParserContext $documentParserContext, string $role, string $content, string $rawContent): InlineNode
     {
-        return new CodeInlineNode($rawContent, 'TypoScript', 'Directive-based configuration language used by TYPO3.');
+        return new CodeInlineNode($rawContent, 'Code written in TypoScript', 'Directive-based configuration language used by TYPO3.');
     }
 }

--- a/packages/typo3-docs-theme/src/TextRoles/XmlTextTextRole.php
+++ b/packages/typo3-docs-theme/src/TextRoles/XmlTextTextRole.php
@@ -21,6 +21,6 @@ final class XmlTextTextRole implements TextRole
 
     public function processNode(DocumentParserContext $documentParserContext, string $role, string $content, string $rawContent): InlineNode
     {
-        return new CodeInlineNode($rawContent, 'XML', 'Extensible Markup Language.');
+        return new CodeInlineNode($rawContent, 'Code written in XML', 'Extensible Markup Language.');
     }
 }

--- a/packages/typo3-docs-theme/src/TextRoles/YamlTextTextRole.php
+++ b/packages/typo3-docs-theme/src/TextRoles/YamlTextTextRole.php
@@ -21,6 +21,6 @@ final class YamlTextTextRole implements TextRole
 
     public function processNode(DocumentParserContext $documentParserContext, string $role, string $content, string $rawContent): InlineNode
     {
-        return new CodeInlineNode($rawContent, 'YAML', 'Yet Another Markup Language, used for key-value configuration.');
+        return new CodeInlineNode($rawContent, 'Code written in YAML', 'Yet Another Markup Language, used for key-value configuration.');
     }
 }

--- a/tests/Integration/tests-full/changelog/expected/Changelog/12.0/Breaking-87616-RemovedHookForAlteringPageLinks.html
+++ b/tests/Integration/tests-full/changelog/expected/Changelog/12.0/Breaking-87616-RemovedHookForAlteringPageLinks.html
@@ -161,12 +161,12 @@
             <section class="section" id="description">
             <h2>Description<a class="headerlink" href="#description" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h2>
             
-    <p>The hook <code class="code-inline" translate="no" aria-description="PHP" aria-details="Dynamic server-side scripting language.">$GLOBALS[&#039;TYPO3_CONF_VARS&#039;][&#039;SC_OPTIONS&#039;][&#039;typolinkProcessing&#039;][&#039;typolinkModifyParameterForPageLinks&#039;]</code>
-has been removed in favor of a new PSR-14 event <code class="code-inline" translate="no" aria-description="PHP" aria-details="Dynamic server-side scripting language.">TYPO3\CMS\Frontend\Event\ModifyPageLinkConfigurationEvent</code>.</p>
+    <p>The hook <code class="code-inline" translate="no" aria-description="Code written in PHP" aria-details="Dynamic server-side scripting language.">$GLOBALS[&#039;TYPO3_CONF_VARS&#039;][&#039;SC_OPTIONS&#039;][&#039;typolinkProcessing&#039;][&#039;typolinkModifyParameterForPageLinks&#039;]</code>
+has been removed in favor of a new PSR-14 event <code class="code-inline" translate="no" aria-description="Code written in PHP" aria-details="Dynamic server-side scripting language.">TYPO3\CMS\Frontend\Event\ModifyPageLinkConfigurationEvent</code>.</p>
 
             
     <p>The event is called after TYPO3 has already prepared some functionality
-within the <code class="code-inline" translate="no" aria-description="PHP" aria-details="Dynamic server-side scripting language.">PageLinkBuilder</code>. This therefore allows to modify more
+within the <code class="code-inline" translate="no" aria-description="Code written in PHP" aria-details="Dynamic server-side scripting language.">PageLinkBuilder</code>. This therefore allows to modify more
 properties, if needed.</p>
 
     </section>

--- a/tests/Integration/tests-full/edit-on-github/edit-on-github-per-page/expected/page1.html
+++ b/tests/Integration/tests-full/edit-on-github/edit-on-github-per-page/expected/page1.html
@@ -130,7 +130,7 @@
             <a id="typo3-backend-avatar"></a>
             <h1>Avatar ViewHelper <code>&lt;be:avatar&gt;</code><a class="headerlink" href="#avatar-viewhelper-be-avatar" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
             
-    <p>Render the avatar markup, including the <code class="code-inline" translate="no" aria-description="HTML" aria-details="HyperText Markup Language.">&lt;img&gt;</code> tag, for a given backend user.</p>
+    <p>Render the avatar markup, including the <code class="code-inline" translate="no" aria-description="Code written in HTML" aria-details="HyperText Markup Language.">&lt;img&gt;</code> tag, for a given backend user.</p>
 
     </section>
         <!-- content end -->

--- a/tests/Integration/tests/code-inline/expected/index.html
+++ b/tests/Integration/tests/code-inline/expected/index.html
@@ -2,13 +2,13 @@
                 <section class="section" id="inline-code">
             <h1>Inline code<a class="headerlink" href="#inline-code" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
 
-    <p><code class="code-inline" translate="no" aria-description="Shell Script" aria-details="Raw command line interface code on operating-system level.">echo &#039;Hello&#039;</code></p>
+    <p><code class="code-inline" translate="no" aria-description="Code written in Shell Script" aria-details="Raw command line interface code on operating-system level.">echo &#039;Hello&#039;</code></p>
 
 
     <p><code class="code-inline">body { background: red; }</code></p>
 
 
-    <p><code class="code-inline" translate="no" aria-description="PHP" aria-details="Dynamic server-side scripting language.">$var = 1;</code></p>
+    <p><code class="code-inline" translate="no" aria-description="Code written in PHP" aria-details="Dynamic server-side scripting language.">$var = 1;</code></p>
 
     </section>
         <!-- content end -->

--- a/tests/Integration/tests/code/code-php/expected/index.html
+++ b/tests/Integration/tests/code/code-php/expected/index.html
@@ -2,7 +2,7 @@
                 <section class="section" id="php-code">
             <h1>PHP Code<a class="headerlink" href="#php-code" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
 
-    <p><code class="code-inline" translate="no" aria-description="PHP" aria-details="Dynamic server-side scripting language.">\T3Docs\Typo3DocsTheme\TextRoles\PhpTextRole</code>.</p>
+    <p><code class="code-inline" translate="no" aria-description="Code written in PHP" aria-details="Dynamic server-side scripting language.">\T3Docs\Typo3DocsTheme\TextRoles\PhpTextRole</code>.</p>
 
     </section>
         <!-- content end -->

--- a/tests/Integration/tests/viewhelper/expected/index.html
+++ b/tests/Integration/tests/viewhelper/expected/index.html
@@ -13,7 +13,7 @@
 results in an array. The number of values in the resulting array can
 be limited with the limit parameter, which results in an array where
 the last item contains the remaining unsplit string.
-This ViewHelper mimicks PHP&#039;s <code class="code-inline" translate="no" aria-description="PHP" aria-details="Dynamic server-side scripting language.">explode()</code> function.</p>
+This ViewHelper mimicks PHP&#039;s <code class="code-inline" translate="no" aria-description="Code written in PHP" aria-details="Dynamic server-side scripting language.">explode()</code> function.</p>
 <section class="section" id="examples">
             <h2>Examples<a class="headerlink" href="#examples" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h2>
             <section class="section" id="split-with-a-separator">
@@ -167,7 +167,7 @@ This ViewHelper mimicks PHP&#039;s <code class="code-inline" translate="no" aria
 results in an array. The number of values in the resulting array can
 be limited with the limit parameter, which results in an array where
 the last item contains the remaining unsplit string.
-This ViewHelper mimicks PHP&#039;s <code class="code-inline" translate="no" aria-description="PHP" aria-details="Dynamic server-side scripting language.">explode()</code> function.</p>
+This ViewHelper mimicks PHP&#039;s <code class="code-inline" translate="no" aria-description="Code written in PHP" aria-details="Dynamic server-side scripting language.">explode()</code> function.</p>
 <section class="section" id="examples">
             <h2>Examples<a class="headerlink" href="#examples" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h2>
             <section class="section" id="split-with-a-separator">


### PR DESCRIPTION
As noted in https://github.com/TYPO3-Documentation/DocsTypo3Org-Homepage/issues/243 this uses a more verbose
tooltip title for specifically highlighted code, see:

![Screenshot 2024-07-25 at 12 33 31](https://github.com/user-attachments/assets/e5af282a-acf0-40d5-a338-2e09c2c5da89)
