### PR TITLE
[TASK] Unify caption styles for images, tables and codeblocks

### DIFF
--- a/packages/typo3-docs-theme/assets/sass/components/_code.scss
+++ b/packages/typo3-docs-theme/assets/sass/components/_code.scss
@@ -27,12 +27,23 @@ code {
 
 .code-block-caption {
     @extend .text-break;
+    @extend .figure-caption;
     hyphens: auto;
+    padding: .4rem .6rem;
+    border: 1px solid $gray-300;
+    border-bottom: none;
+    border-radius: .2rem .2rem 0 0;
+}
+
+.code-block-caption ~ .code-block-wrapper {
+    border-top: none;
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
 }
 
 .code-block-wrapper {
     background: $gray-100;
-    border: 1px solid $gray-100;
+    border: 1px solid $gray-300;
     border-radius: .2rem;
     display: flex;
     font-size: 92%;

--- a/packages/typo3-docs-theme/assets/sass/components/_table.scss
+++ b/packages/typo3-docs-theme/assets/sass/components/_table.scss
@@ -3,6 +3,11 @@
     td :last-child {
         margin-bottom: 0;
     }
+    > caption {
+        @extend .figure-caption;
+        @extend .pb-2;
+        padding-top: 0;
+    }
 }
 
 .table-responsive {

--- a/packages/typo3-docs-theme/resources/public/css/theme.css
+++ b/packages/typo3-docs-theme/resources/public/css/theme.css
@@ -11776,7 +11776,7 @@ progress {
   line-height: 1;
 }
 
-.figure-caption, figure figcaption {
+.figure-caption, .table > caption, figure figcaption, .code-block-caption {
   font-size: 0.875em;
   color: var(--bs-secondary-color);
 }
@@ -19599,7 +19599,7 @@ textarea.form-control-lg {
   padding-bottom: 0.25rem !important;
 }
 
-.pb-2 {
+.pb-2, .table > caption {
   padding-bottom: 0.5rem !important;
 }
 
@@ -23638,11 +23638,21 @@ code {
 
 .code-block-caption {
   hyphens: auto;
+  padding: 0.4rem 0.6rem;
+  border: 1px solid #e6e6e6;
+  border-bottom: none;
+  border-radius: 0.2rem 0.2rem 0 0;
+}
+
+.code-block-caption ~ .code-block-wrapper {
+  border-top: none;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
 }
 
 .code-block-wrapper {
   background: #f7f7f7;
-  border: 1px solid #f7f7f7;
+  border: 1px solid #e6e6e6;
   border-radius: 0.2rem;
   display: flex;
   font-size: 92%;
@@ -24678,6 +24688,9 @@ article *:hover > a.headerlink:after, article *:hover > a.permalink:after, artic
 .table th :last-child,
 .table td :last-child {
   margin-bottom: 0;
+}
+.table > caption {
+  padding-top: 0;
 }
 
 .table-responsive {


### PR DESCRIPTION
Resolves #564 
___

1. Image figure caption remains unchanged
![image](https://github.com/user-attachments/assets/6c0406ef-2d4c-44ae-a4d7-1fd60f6a442d)

2. Table caption gets the exact same styling as image caption
BEFORE:
![image](https://github.com/user-attachments/assets/c57d0422-da2d-4816-90ec-87d01b143620)
AFTER:
![image](https://github.com/user-attachments/assets/9d7f6e68-84b0-4fb9-b31a-f350f1b5c8ad)

3. Codeblocks caption gets the same styling as image caption, with additional border to contain caption within context
BEFORE:
![image](https://github.com/user-attachments/assets/0e9bec87-adf4-4b72-a566-2409df9f5be7)
AFTER:
![image](https://github.com/user-attachments/assets/dd7cfa52-e6e4-4a9f-882d-fc83bfb3d8d9)

4. Due to the change above, codeblocks without captions are also bordered to keep elements consistent
BEFORE:
![image](https://github.com/user-attachments/assets/b4e4a178-d85b-4ede-b58b-6690424824c2)
AFTER:
![image](https://github.com/user-attachments/assets/4276ae71-3378-4144-acf7-9dccc65d4154)
