### PR TITLE
[FEATURE] Help texts for inline PHP code snippets

### DIFF
--- a/Documentation-rendertest/PhpInline/Index.rst
+++ b/Documentation-rendertest/PhpInline/Index.rst
@@ -1,0 +1,42 @@
+..  include:: /Includes.rst.txt
+
+..  _php-inline:
+
+==========
+PHP Inline
+==========
+
+The hook :php:`$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['typolinkProcessing']['typolinkModifyParameterForPageLinks']`
+has been removed in favor of a new PSR-14 event :php:`\TYPO3\CMS\Frontend\Event\ModifyPageLinkConfigurationEvent`.
+
+Accessing these properties via TypoScript `getData` or via PHP will trigger a PHP :php:`E_USER_DEPRECATED` error.
+
+In TypoScript you can access the TypoScript properties directly via
+:typoscript:`.data = TSFE:config|config|fileTarget` and in PHP code via
+:php:`$GLOBALS['TSFE']->config['config']['fileTarget']`.
+
+Set it in :php:`$GLOBALS['TCA'][$table]['ctrl']['enablecolumns']`.
+
+Some examples:
+
+*   :php:`\TYPO3\CMS\Adminpanel\Controller\AjaxController`
+*   :php:`\TYPO3\CMS\Core\Http\Dispatcher`
+*   :php:`\TYPO3\CMS\Adminpanel\ModuleApi\ContentProviderInterface`
+*   :php:`\TYPO3\CMS\Backend\Search\LiveSearch\SearchDemand\DemandPropertyName`
+*   :php:`\TYPO3\CMS\Backend\Form\Behavior\OnFieldChangeTrait`
+*   :php:`\Psr\Log\LoggerInterface`
+*   :php:`\TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper`
+*   :php:`\MyVendor\MyExtension\FooBar`
+*   :php:`\Foo\Bar\Something`
+
+In short:
+
+*   :php-short:`\TYPO3\CMS\Adminpanel\Controller\AjaxController`
+*   :php-short:`\TYPO3\CMS\Core\Http\Dispatcher`
+*   :php-short:`\TYPO3\CMS\Adminpanel\ModuleApi\ContentProviderInterface`
+*   :php-short:`\TYPO3\CMS\Backend\Search\LiveSearch\SearchDemand\DemandPropertyName`
+*   :php-short:`\TYPO3\CMS\Backend\Form\Behavior\OnFieldChangeTrait`
+*   :php-short:`\Psr\Log\LoggerInterface`
+*   :php-short:`\TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper`
+*   :php-short:`\MyVendor\MyExtension\FooBar`
+*   :php-short:`\Foo\Bar\Something`

--- a/packages/typo3-docs-theme/assets/sass/components/_code.scss
+++ b/packages/typo3-docs-theme/assets/sass/components/_code.scss
@@ -111,7 +111,10 @@ code {
 
 /** uses "popover" for all code roles that have tooltips **/
 .code-inline[aria-description] {
-    cursor: pointer;
+    a {
+        text-decoration: none;
+    }
+
 }
 
 /** popover styling **/
@@ -119,6 +122,8 @@ code {
     display: flex;
     flex-direction: row;
     max-width: 30vw;
+    overflow-wrap: break-word;
+    word-wrap: anywhere;
 }
 .popover-header{
     padding: var(--bs-popover-body-padding-y) var(--bs-popover-body-padding-x);
@@ -127,6 +132,7 @@ code {
     border-bottom-left-radius: var(--bs-popover-inner-border-radius);
     border-top-right-radius: 0;
     border-bottom: 0;
+    word-wrap: break-word;
 }
 
 @media only screen and (max-width: 576px) {

--- a/packages/typo3-docs-theme/resources/config/typo3-docs-theme.php
+++ b/packages/typo3-docs-theme/resources/config/typo3-docs-theme.php
@@ -15,6 +15,7 @@ use phpDocumentor\Guides\RestructuredText\Parser\Interlink\InterlinkParser;
 use phpDocumentor\Guides\RestructuredText\Parser\Productions\DirectiveContentRule;
 use phpDocumentor\Guides\RestructuredText\Parser\Productions\DocumentRule;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use T3Docs\Typo3DocsTheme\Api\Typo3ApiService;
 use T3Docs\Typo3DocsTheme\Compiler\NodeTransformers\ConfvalMenuNodeTransformer;
 use T3Docs\Typo3DocsTheme\Directives\ConfvalMenuDirective;
 use T3Docs\Typo3DocsTheme\Directives\DirectoryTreeDirective;
@@ -159,6 +160,7 @@ return static function (ContainerConfigurator $container): void {
 
         ->set(PackagistService::class)
         ->set(Typo3VersionService::class)
+        ->set(Typo3ApiService::class)
 
         // Register Event Listeners
         ->set(AddThemeSettingsToProjectNode::class)

--- a/packages/typo3-docs-theme/resources/public/css/theme.css
+++ b/packages/typo3-docs-theme/resources/public/css/theme.css
@@ -23758,8 +23758,8 @@ code {
 }
 
 /** uses "popover" for all code roles that have tooltips **/
-.code-inline[aria-description] {
-  cursor: pointer;
+.code-inline[aria-description] a {
+  text-decoration: none;
 }
 
 /** popover styling **/
@@ -23767,6 +23767,8 @@ code {
   display: flex;
   flex-direction: row;
   max-width: 30vw;
+  overflow-wrap: break-word;
+  word-wrap: anywhere;
 }
 
 .popover-header {
@@ -23776,6 +23778,7 @@ code {
   border-bottom-left-radius: var(--bs-popover-inner-border-radius);
   border-top-right-radius: 0;
   border-bottom: 0;
+  word-wrap: break-word;
 }
 
 @media only screen and (max-width: 576px) {

--- a/packages/typo3-docs-theme/resources/template/inline/textroles/code.html.twig
+++ b/packages/typo3-docs-theme/resources/template/inline/textroles/code.html.twig
@@ -1,3 +1,11 @@
 {% apply spaceless %}
-    <code class="code-inline" translate="no" aria-description="{{ node.language }}" aria-details="{{ node.helpText }}">{{ node.value }}</code>
+    <code class="code-inline" translate="no" aria-description="{{ node.language|raw }}" aria-details="{{ node.helpText|raw }}" data-bs-html="true">
+        {%- if node.info.url %}
+            <a href="{{ node.info['url'] }}" target="_blank">
+                {{- node.value }} <span class="text-secondary"><i class="fa-regular fa-circle-question"></i></span></a>
+        {%- else -%}
+             {{ node.value }}
+        {%- endif -%}
+    </code>
+
 {% endapply %}

--- a/packages/typo3-docs-theme/src/Api/Typo3ApiService.php
+++ b/packages/typo3-docs-theme/src/Api/Typo3ApiService.php
@@ -1,0 +1,186 @@
+<?php
+
+namespace T3Docs\Typo3DocsTheme\Api;
+
+use Psr\Log\LoggerInterface;
+use T3Docs\Typo3DocsTheme\Inventory\Typo3VersionService;
+
+final class Typo3ApiService
+{
+    /** @var array<string, array<string, string>>|null  */
+    private ?array $apiData = null;
+
+    public function __construct(
+        private readonly LoggerInterface $logger,
+        private readonly Typo3VersionService $typo3VersionService,
+    ) {}
+
+    /**
+     * @return array<string, string>
+     */
+    public function getClassInfo(string $fqn): array
+    {
+        if ($this->apiData === null) {
+            $version = $this->typo3VersionService->getPreferredVersion();
+            $this->apiData = $this->loadApi('https://api.typo3.org/' . $version . '/api-info.json');
+        }
+        return $this->apiData[$fqn] ?? [];
+    }
+
+    /**
+     * @return array<string, array<string, string>>
+     */
+    private function loadApi(string $url = 'https://api.typo3.org/main/api-info.json'): array
+    {
+        $jsonData = $this->fetchJsonData($url);
+        if ($jsonData === null) {
+            return [];
+        }
+
+        $apiData = $this->decodeJson($jsonData);
+        if ($apiData === null) {
+            return [];
+        }
+
+        if (!$this->validateApiData($apiData)) {
+            return [];
+        }
+
+        return $this->processApiData($apiData);
+    }
+
+    /**
+     * Fetch JSON data from the given URL.
+     *
+     * @return string|null
+     */
+    private function fetchJsonData(string $url): ?string
+    {
+        $ch = curl_init($url);
+
+        if ($ch === false) {
+            $this->logger->warning(
+                sprintf(
+                    'TYPO3 API could not be loaded from %s, curl is not available.',
+                    $url
+                )
+            );
+            return null;
+        }
+
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
+        curl_setopt($ch, CURLOPT_TIMEOUT, 30);
+
+        $jsonData = curl_exec($ch);
+        $httpStatus = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+
+        if (curl_errno($ch)) {
+            $this->logger->warning(
+                sprintf(
+                    'TYPO3 API could not be loaded from %s, cURL error: %s',
+                    $url,
+                    curl_error($ch)
+                )
+            );
+            curl_close($ch);
+            return null;
+        }
+
+        if ($httpStatus !== 200) {
+            $this->logger->warning(
+                sprintf(
+                    'TYPO3 API could not be loaded from %s, HTTP request failed with status code %s',
+                    $url,
+                    $httpStatus
+                )
+            );
+            curl_close($ch);
+            return null;
+        }
+
+        curl_close($ch);
+        if (!is_string($jsonData)) {
+            $this->logger->warning(
+                'TYPO3 API data is not a valid string.'
+            );
+            return null;
+        }
+        return $jsonData;
+    }
+
+    /**
+     * Decode JSON data into an array.
+     *
+     * @param string $jsonData
+     * @return array<string, array<string, string>>|null
+     */
+    private function decodeJson(string $jsonData): ?array
+    {
+        $apiData = json_decode($jsonData, true);
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            $this->logger->warning(
+                sprintf(
+                    'Error decoding JSON: %s',
+                    json_last_error_msg()
+                )
+            );
+            return null;
+        }
+
+        if (!is_array($apiData)) {
+            $this->logger->warning(
+                'Decoded JSON data is not a valid array.'
+            );
+            return null;
+        }
+
+        return $apiData;
+    }
+
+    /**
+     * Validate the structure of the API data.
+     *
+     * @param array<string, array<string, string>> $apiData
+     * @return bool
+     */
+    private function validateApiData(array $apiData): bool
+    {
+        foreach ($apiData as $key => $class) {
+            if (!is_string($key) || !is_array($class)) {
+                $this->logger->warning(
+                    'API data is malformed. Key should be a string and value should be an array.'
+                );
+                return false;
+            }
+
+            foreach ($class as $fqn => $info) {
+                if (!is_string($fqn) || !is_scalar($info)) {
+                    $this->logger->warning(
+                        'API data is malformed. FQN should be a string and info should be scalar.'
+                    );
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Process the API data to ensure correct types.
+     *
+     * @param array<string, array<string, string>> $apiData
+     * @return array<string, array<string, string>>
+     */
+    private function processApiData(array $apiData): array
+    {
+        foreach ($apiData as $key => &$class) {
+            foreach ($class as $fqn => $info) {
+                $class[$fqn] = (string) $info;
+            }
+        }
+        return $apiData;
+    }
+
+}

--- a/packages/typo3-docs-theme/src/Nodes/Inline/CodeInlineNode.php
+++ b/packages/typo3-docs-theme/src/Nodes/Inline/CodeInlineNode.php
@@ -8,7 +8,10 @@ final class CodeInlineNode extends InlineNode
 {
     public const TYPE = 'code';
 
-    public function __construct(string $value, private string $language, private string $helpText = '')
+    /**
+     * @param array<string, string> $info
+     */
+    public function __construct(string $value, private string $language, private string $helpText = '', private array $info = [])
     {
         parent::__construct(self::TYPE, $value);
     }
@@ -23,4 +26,11 @@ final class CodeInlineNode extends InlineNode
         return $this->helpText;
     }
 
+    /**
+     * @return array<string, string>
+     */
+    public function getInfo(): array
+    {
+        return $this->info;
+    }
 }

--- a/packages/typo3-docs-theme/src/TextRoles/PhpTextRole.php
+++ b/packages/typo3-docs-theme/src/TextRoles/PhpTextRole.php
@@ -5,10 +5,19 @@ namespace T3Docs\Typo3DocsTheme\TextRoles;
 use phpDocumentor\Guides\Nodes\Inline\InlineNode;
 use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
 use phpDocumentor\Guides\RestructuredText\TextRoles\TextRole;
+use T3Docs\GuidesPhpDomain\PhpDomain\FullyQualifiedNameService;
+use T3Docs\Typo3DocsTheme\Api\Typo3ApiService;
+use T3Docs\Typo3DocsTheme\Inventory\Typo3VersionService;
 use T3Docs\Typo3DocsTheme\Nodes\Inline\CodeInlineNode;
 
 final class PhpTextRole implements TextRole
 {
+    public function __construct(
+        private readonly FullyQualifiedNameService $fullyQualifiedNameService,
+        private readonly Typo3ApiService $typo3ApiService,
+        private readonly Typo3VersionService $typo3VersionService,
+    ) {}
+
     public function getName(): string
     {
         return 'php';
@@ -16,11 +25,155 @@ final class PhpTextRole implements TextRole
 
     public function getAliases(): array
     {
-        return [];
+        return [
+            'php-short',
+        ];
     }
 
     public function processNode(DocumentParserContext $documentParserContext, string $role, string $content, string $rawContent): InlineNode
     {
+        $fqn = [];
+        $rawContent = trim($rawContent);
+        if (str_contains($rawContent, '\\') && $this->fullyQualifiedNameService->isFullyQualifiedName($rawContent, $fqn)) {
+            if (!str_starts_with($rawContent, '\\')) {
+                $rawContent = '\\' . $rawContent;
+            }
+            $type = 'class or interface';
+            $apiInfo = $this->typo3ApiService->getClassInfo($rawContent);
+            $name = $rawContent;
+            if ($role === 'php-short') {
+                $name = $fqn[2] ?? $rawContent;
+            }
+            return $this->getClassCodeNode($rawContent, $apiInfo, $role, $name, $type);
+        }
+        if (str_starts_with($rawContent, '$GLOBALS[\'TYPO3_CONF_VARS\']')) {
+            return $this->getTypo3ConfVarCodeNode($rawContent);
+        }
+        if (str_starts_with($rawContent, '$GLOBALS[\'TCA\']')) {
+            return $this->getTcaCodeNode($rawContent);
+        }
+        if (str_starts_with($rawContent, '$GLOBALS[\'TSFE\']')) {
+            return $this->getTsfeCodeNode($rawContent);
+        }
+        if ($rawContent === 'E_USER_DEPRECATED') {
+            return $this->getDeprecationErrorCodeNode($rawContent);
+        }
         return new CodeInlineNode($rawContent, 'Code written in PHP', 'Dynamic server-side scripting language.');
+    }
+
+    private function getDeprecationErrorCodeNode(string $rawContent): CodeInlineNode
+    {
+        return new CodeInlineNode(
+            $rawContent,
+            'Deprecation error',
+            'Deprecation errors are by default not logged, however you can enable logging them (see link) on development systems.
+                ',
+            ['url' => 'https://docs.typo3.org/m/typo3/reference-coreapi/' . $this->typo3VersionService->getPreferredVersion() . '/en-us/ApiOverview/Deprecation/Index.html#deprecation_enable_errors']
+        );
+    }
+
+    private function getTsfeCodeNode(string $rawContent): CodeInlineNode
+    {
+        return new CodeInlineNode(
+            $rawContent,
+            'TypoScript&shy;FrontendController',
+            'TSFE is short for \TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController,
+                    a class which exists in the system extension EXT:frontend.
+                    It is available as global array $GLOBALS[\'TSFE\'] in PHP.
+                ',
+            ['url' => 'https://docs.typo3.org/m/typo3/reference-coreapi/' . $this->typo3VersionService->getPreferredVersion() . '/en-us/ApiOverview/TSFE/Index.html']
+        );
+    }
+
+    private function getTcaCodeNode(string $rawContent): CodeInlineNode
+    {
+        return new CodeInlineNode(
+            $rawContent,
+            'Table Configuration Array',
+            'The TCA - Table Configuration Array - is a layer on
+                top of the database tables that TYPO3 can operate on.
+                It should be defined within the folder Configuration/TCA in an
+                extension.
+                ',
+            ['url' => 'https://docs.typo3.org/m/typo3/reference-tca/' . $this->typo3VersionService->getPreferredVersion() . '/en-us/']
+        );
+    }
+
+    private function getTypo3ConfVarCodeNode(string $rawContent): CodeInlineNode
+    {
+        return new CodeInlineNode(
+            $rawContent,
+            'Global PHP configuration',
+            'The main configuration is achieved via a set of global
+                settings stored in a global array called $GLOBALS[\'TYPO3_CONF_VARS\'].
+                They are commonly set in config/system/settings.php, config/system/additional.php,
+                or the ext_localconf.php file of an extension. ',
+            ['url' => 'https://docs.typo3.org/m/typo3/reference-coreapi/' . $this->typo3VersionService->getPreferredVersion() . '/en-us/Configuration/Typo3ConfVars/Index.html']
+        );
+    }
+
+    /**
+     * @param array<string, string> $apiInfo
+     */
+    private function getClassCodeNode(string $fqn, array $apiInfo, string $role, string $name, string $type): CodeInlineNode
+    {
+        if ($apiInfo !== []) {
+            if ($role === 'php-short') {
+                $name = $apiInfo['short'];
+            }
+            $type = $apiInfo['type'];
+            $modifiers = [];
+            if ((bool)$apiInfo['final']) {
+                $modifiers[] = 'final';
+            }
+            if ((bool)$apiInfo['abstract']) {
+                $modifiers[] = 'abstract';
+            }
+            if ((bool)$apiInfo['readonly']) {
+                $modifiers[] = 'readonly';
+            }
+            $modifiers[] = $apiInfo['type'];
+            $infoArray = [];
+            $infoArray[] = '<code>' . implode(' ', $modifiers) . ' ' . $apiInfo['short'] . '</code>: <code>' . $apiInfo['fqn'] . '</code>';
+            if ($apiInfo['internal']) {
+                $infoArray[] = 'internal!';
+            }
+            if ($apiInfo['deprecated']) {
+                $infoArray[] = 'deprecated!';
+            }
+            if ($apiInfo['summary']) {
+                $infoArray[] = '<em>' . $apiInfo['summary'] . '</em>';
+            }
+            $info = implode('<br>', $infoArray);
+            return new CodeInlineNode($name, 'PHP ' . $type, $info, $apiInfo);
+        } elseif(str_starts_with($fqn, '\\TYPO3Fluid')) {
+            $info = 'This PHP class or interface belongs to Fluid. ';
+            return new CodeInlineNode(
+                $name,
+                'PHP ' . $type,
+                $info,
+                ['url' => 'https://docs.typo3.org/m/typo3/reference-coreapi/' . $this->typo3VersionService->getPreferredVersion() . '/en-us/ApiOverview/Fluid/Index.html']
+            );
+        } elseif(str_starts_with($fqn, '\\Psr')) {
+            return new CodeInlineNode(
+                $name,
+                'PHP ' . $type,
+                'This PHP class or interface belongs to the PHP Standards Recommendations (PSR). ',
+                ['url' => 'https://www.php-fig.org/psr/']
+            );
+        } elseif(str_starts_with($fqn, '\\MyVendor') or str_starts_with($fqn, '\\Vendor')) {
+            return new CodeInlineNode(
+                $name,
+                'PHP ' . $type,
+                'PHP classes in this namespace are commonly used as examples. Replace with your own vendor and namespace on implementation. ',
+                []
+            );
+        }
+        return new CodeInlineNode(
+            $name,
+            'PHP ' . $type,
+            'Unknown PHP class or interface, try searching for ' . $fqn . ' in the internet.',
+            []
+        );
     }
 }

--- a/tests/Integration/tests-full/changelog/expected/Changelog/12.0/Breaking-87616-RemovedHookForAlteringPageLinks.html
+++ b/tests/Integration/tests-full/changelog/expected/Changelog/12.0/Breaking-87616-RemovedHookForAlteringPageLinks.html
@@ -165,12 +165,15 @@
             <section class="section" id="description">
             <h2>Description<a class="headerlink" href="#description" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h2>
             
-    <p>The hook <code class="code-inline" translate="no" aria-description="Code written in PHP" aria-details="Dynamic server-side scripting language.">$GLOBALS[&#039;TYPO3_CONF_VARS&#039;][&#039;SC_OPTIONS&#039;][&#039;typolinkProcessing&#039;][&#039;typolinkModifyParameterForPageLinks&#039;]</code>
-has been removed in favor of a new PSR-14 event <code class="code-inline" translate="no" aria-description="Code written in PHP" aria-details="Dynamic server-side scripting language.">TYPO3\CMS\Frontend\Event\ModifyPageLinkConfigurationEvent</code>.</p>
+    <p>The hook <code class="code-inline" translate="no" aria-description="Global PHP configuration" aria-details="The main configuration is achieved via a set of global
+                settings stored in a global array called $GLOBALS['TYPO3_CONF_VARS'].
+                They are commonly set in config/system/settings.php, config/system/additional.php,
+                or the ext_localconf.php file of an extension. " data-bs-html="true"><a href="https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/Configuration/Typo3ConfVars/Index.html" target="_blank">$GLOBALS[&#039;TYPO3_CONF_VARS&#039;][&#039;SC_OPTIONS&#039;][&#039;typolinkProcessing&#039;][&#039;typolinkModifyParameterForPageLinks&#039;] <span class="text-secondary"><i class="fa-regular fa-circle-question"></i></span></a></code>
+has been removed in favor of a new PSR-14 event <code class="code-inline" translate="no" aria-description="PHP class" aria-details="<code>final class ModifyPageLinkConfigurationEvent</code>: <code>\TYPO3\CMS\Frontend\Event\ModifyPageLinkConfigurationEvent</code><br><em>A generic PSR 14 Event to allow modifying the incoming (and resolved) page when building a &quot;page link&quot;.</em>" data-bs-html="true"><a href="https://api.typo3.org/main/classes/TYPO3-CMS-Frontend-Event-ModifyPageLinkConfigurationEvent.html" target="_blank">\TYPO3\CMS\Frontend\Event\ModifyPageLinkConfigurationEvent <span class="text-secondary"><i class="fa-regular fa-circle-question"></i></span></a></code>.</p>
 
             
     <p>The event is called after TYPO3 has already prepared some functionality
-within the <code class="code-inline" translate="no" aria-description="Code written in PHP" aria-details="Dynamic server-side scripting language.">PageLinkBuilder</code>. This therefore allows to modify more
+within the <code class="code-inline" translate="no" aria-description="Code written in PHP" aria-details="Dynamic server-side scripting language." data-bs-html="true">PageLinkBuilder</code>. This therefore allows to modify more
 properties, if needed.</p>
 
     </section>

--- a/tests/Integration/tests-full/edit-on-github/edit-on-github-per-page/expected/page1.html
+++ b/tests/Integration/tests-full/edit-on-github/edit-on-github-per-page/expected/page1.html
@@ -130,7 +130,7 @@
             <a id="typo3-backend-avatar"></a>
             <h1>Avatar ViewHelper <code>&lt;be:avatar&gt;</code><a class="headerlink" href="#avatar-viewhelper-be-avatar" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
             
-    <p>Render the avatar markup, including the <code class="code-inline" translate="no" aria-description="Code written in HTML" aria-details="HyperText Markup Language.">&lt;img&gt;</code> tag, for a given backend user.</p>
+    <p>Render the avatar markup, including the <code class="code-inline" translate="no" aria-description="Code written in HTML" aria-details="HyperText Markup Language." data-bs-html="true">&lt;img&gt;</code> tag, for a given backend user.</p>
 
     </section>
         <!-- content end -->

--- a/tests/Integration/tests/code-inline/expected/index.html
+++ b/tests/Integration/tests/code-inline/expected/index.html
@@ -2,13 +2,13 @@
                 <section class="section" id="inline-code">
             <h1>Inline code<a class="headerlink" href="#inline-code" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
 
-    <p><code class="code-inline" translate="no" aria-description="Code written in Shell Script" aria-details="Raw command line interface code on operating-system level.">echo &#039;Hello&#039;</code></p>
+    <p><code class="code-inline" translate="no" aria-description="Code written in Shell Script" aria-details="Raw command line interface code on operating-system level." data-bs-html="true">echo &#039;Hello&#039;</code></p>
 
 
     <p><code class="code-inline">body { background: red; }</code></p>
 
 
-    <p><code class="code-inline" translate="no" aria-description="Code written in PHP" aria-details="Dynamic server-side scripting language.">$var = 1;</code></p>
+    <p><code class="code-inline" translate="no" aria-description="Code written in PHP" aria-details="Dynamic server-side scripting language." data-bs-html="true">$var = 1;</code></p>
 
     </section>
         <!-- content end -->

--- a/tests/Integration/tests/code/code-php/expected/index.html
+++ b/tests/Integration/tests/code/code-php/expected/index.html
@@ -2,7 +2,7 @@
                 <section class="section" id="php-code">
             <h1>PHP Code<a class="headerlink" href="#php-code" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
 
-    <p><code class="code-inline" translate="no" aria-description="Code written in PHP" aria-details="Dynamic server-side scripting language.">\T3Docs\Typo3DocsTheme\TextRoles\PhpTextRole</code>.</p>
+    <p><code class="code-inline" translate="no" aria-description="PHP class or interface" aria-details="Unknown PHP class or interface, try searching for \T3Docs\Typo3DocsTheme\TextRoles\PhpTextRole in the internet." data-bs-html="true">\T3Docs\Typo3DocsTheme\TextRoles\PhpTextRole</code>.</p>
 
     </section>
         <!-- content end -->

--- a/tests/Integration/tests/viewhelper/expected/index.html
+++ b/tests/Integration/tests/viewhelper/expected/index.html
@@ -13,7 +13,7 @@
 results in an array. The number of values in the resulting array can
 be limited with the limit parameter, which results in an array where
 the last item contains the remaining unsplit string.
-This ViewHelper mimicks PHP&#039;s <code class="code-inline" translate="no" aria-description="Code written in PHP" aria-details="Dynamic server-side scripting language.">explode()</code> function.</p>
+This ViewHelper mimicks PHP&#039;s <code class="code-inline" translate="no" aria-description="Code written in PHP" aria-details="Dynamic server-side scripting language." data-bs-html="true">explode()</code> function.</p>
 <section class="section" id="examples">
             <h2>Examples<a class="headerlink" href="#examples" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h2>
             <section class="section" id="split-with-a-separator">
@@ -167,7 +167,7 @@ This ViewHelper mimicks PHP&#039;s <code class="code-inline" translate="no" aria
 results in an array. The number of values in the resulting array can
 be limited with the limit parameter, which results in an array where
 the last item contains the remaining unsplit string.
-This ViewHelper mimicks PHP&#039;s <code class="code-inline" translate="no" aria-description="Code written in PHP" aria-details="Dynamic server-side scripting language.">explode()</code> function.</p>
+This ViewHelper mimicks PHP&#039;s <code class="code-inline" translate="no" aria-description="Code written in PHP" aria-details="Dynamic server-side scripting language." data-bs-html="true">explode()</code> function.</p>
 <section class="section" id="examples">
             <h2>Examples<a class="headerlink" href="#examples" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h2>
             <section class="section" id="split-with-a-separator">


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/9cbaeec3-5602-4cce-ad24-fe5fc53e9fff)
![image](https://github.com/user-attachments/assets/53f77ed0-2c5c-4e2b-921b-c8639299da82)
![image](https://github.com/user-attachments/assets/6064a5a8-9327-4c20-8965-4a6f5bc7769b)
![image](https://github.com/user-attachments/assets/31d41397-9d4c-4104-8059-5d3865d74d82)
![image](https://github.com/user-attachments/assets/f2a125e6-3ff5-4f87-aa98-f55619031f81)

Short view is opt-in and can for example be used if the same class is mentioned several times in the same context:

```
:php-short:`\TYPO3\CMS\Adminpanel\ModuleApi\ContentProviderInterface``
``
