### PR TITLE
[FEATURE] JSON with class/interface API information

### DIFF
--- a/packages/typo3-api/template/api-info.json.twig
+++ b/packages/typo3-api/template/api-info.json.twig
@@ -1,0 +1,76 @@
+{%  set hasLooped = false %}
+{
+    {% for element in documentationSet.indexes.classes -%}
+        {% if loop.first and hasLooped %},{% endif %}
+        {% set hasLooped = false %}
+        {{  _self.link(project, element) }}
+        {% if not loop.last -%},
+        {% else %}
+        {% set hasLooped = true %}
+        {% endif %}
+    {% endfor %}
+
+    {% for element in documentationSet.indexes.interfaces -%}
+        {% if loop.first and hasLooped %},{% endif %}
+        {% set hasLooped = false %}
+        {{  _self.link(project, element) }}
+        {% if not loop.last -%},
+        {% else %}
+        {% set hasLooped = true %}
+        {% endif %}
+    {% endfor %}
+
+    {% for element in documentationSet.indexes.traits -%}
+        {% if loop.first and hasLooped %},{% endif %}
+        {% set hasLooped = false %}
+        {{  _self.link(project, element) }}
+        {% if not loop.last -%},
+        {% else %}
+        {% set hasLooped = true %}
+        {% endif %}
+    {% endfor %}
+
+    {% for element in documentationSet.indexes.enums -%}
+        {% if loop.first and hasLooped %},{% endif %}
+        {% set hasLooped = false %}
+        {{  _self.link(project, element) }}
+        {% if not loop.last -%},
+        {% else %}
+        {% set hasLooped = true %}
+        {% endif %}
+    {% endfor %}
+
+    {% for element in documentationSet.indexes.functions -%}
+        {% if loop.first and hasLooped %},{% endif %}
+        {% set hasLooped = false %}
+        {{  _self.link(project, element) }}
+        {% if not loop.last -%},
+        {% else %}
+        {% set hasLooped = true %}
+        {% endif %}
+    {% endfor %}
+}
+
+{% macro link(project, element) %}
+"{{ element.fullyQualifiedStructuralElementName|replace({'\\': '\\\\'}) }}":  {
+{% set internalTags = element.tags|filter((v,k) => k in ['internal']) %}
+    "url": "https://api.typo3.org/{{ parameter.typo3_version }}/{{ element | route('url') }}",
+    "short": "{{ element.name|replace({'\\': '\\\\'}) }}",
+    "fqn": "{{ element.fullyQualifiedStructuralElementName|replace({'\\': '\\\\'}) }}",
+    "github": "{{ parameter.typo3_github_url }}/{{ parameter.typo3_version }}/{{ element.file.path }}",
+    "file": "{{ element.file.path }}",
+    "type": "{% if element is class %}class{% endif %}{% if element is interface %}interface{% endif %}{% if element is trait %}trait{% endif %}{% if element is enum %}enum{% endif %}",
+    "final": "{{ element.isFinal }}",
+    "abstract": "{{ element.isAbstract }}",
+    "readonly": "{{ element.isReadonly }}",
+    "internal": "{% if internalTags|length > 0 and internalTags|first|length > 0 %}1{% endif %}",
+    "internal-message": "{% for tag in internalTags %}{{ tag.description|replace({'\\': '\\\\'})|replace({'\n': ' '})|replace({'	': ' '}) }}{% endfor %}",
+    "deprecated": "{% if element.deprecated %}1{% endif %}",
+    "deprecation": "{% for deprecation in element.deprecations %}{{ deprecation.description|replace({'\\': '\\\\'})|replace({'\n': ' '})|replace({'	': ' '})}} {% endfor %}",
+    "extends": "{% if element.parent %}{{ element.parent.fullyQualifiedStructuralElementName|replace({'\\': '\\\\'})|replace({'\n': ' '})|replace({'	': ' '}) }}{% endif %}",
+    "implements": "{% if element.interfaces is not empty -%}
+{%- for interface in element.interfaces %}{{ interface.fullyQualifiedStructuralElementName|replace({'\\': '\\\\'})|replace({'\n': ' '})|replace({'	': ' '}) }}{% if not loop.last %}, {% endif %}{% endfor -%}
+{% endif %}",
+    "summary": "{{ element.summary|replace({'\\': '\\\\'})|replace({'\n': ' '})|replace({'	': ' '}) }}"
+}
+{% endmacro %}

--- a/packages/typo3-api/template/template.xml
+++ b/packages/typo3-api/template/template.xml
@@ -7,6 +7,7 @@
     <extends>default</extends>
     <transformations>
         <transformation writer="twig" source="index.json.twig" artifact="objects.inv.json"/>
+        <transformation writer="twig" source="api-info.json.twig" artifact="api-info.json"/>
         <transformation writer="twig" source="404.html.twig" artifact="404.html"/>
     </transformations>
 </template>


### PR DESCRIPTION
Outputs information about all classes/interfaces in the TYPO3 Core in the following form, so that it can be consumed by the guides for help texts etc: 
```
"\\TYPO3\\CMS\\Adminpanel\\Log\\InMemoryLogWriter":  {
    "url": "https://api.typo3.org/12.4/classes/TYPO3-CMS-Adminpanel-Log-InMemoryLogWriter.html",
    "short": "InMemoryLogWriter",
    "fqn": "\\TYPO3\\CMS\\Adminpanel\\Log\\InMemoryLogWriter",
    "github": "https://github.com/TYPO3/typo3/blob/12.4/typo3/sysext/adminpanel/Classes/Log/InMemoryLogWriter.php",
    "file": "typo3/sysext/adminpanel/Classes/Log/InMemoryLogWriter.php",
    "type": "class",
    "final": "1",
    "abstract": "",
    "readonly": "",
    "internal": "1",
    "internal-message": "",
    "deprecated": "",
    "deprecation": "",
    "extends": "\\TYPO3\\CMS\\Core\\Log\\Writer\\AbstractWriter",
    "implements": " \\TYPO3\\CMS\\Core\\SingletonInterface",
    "summary": "Log writer that writes the log records into a static public class variable for InMemory processing. Note this implements SingletonInterface so multiple calls to this class can accumulate log records in the same instance."
}
```