### PR TITLE
[BUGFIX] Do not break short inline code

### DIFF
--- a/packages/typo3-docs-theme/assets/sass/components/_code.scss
+++ b/packages/typo3-docs-theme/assets/sass/components/_code.scss
@@ -100,13 +100,16 @@ code {
  * ":literal:" or ":php:"
  */
 .code-inline {
-    @extend .text-break;
     font-family: $font-family-monospace;
     border-radius: $border-radius;
     border: 2px solid $white;
     background: $gray-100;
     padding: 0.25em 0.5em;
     line-height: 27px;
+}
+
+.code-inline-long {
+    @extend .text-break;
 }
 
 /** uses "popover" for all code roles that have tooltips **/

--- a/packages/typo3-docs-theme/resources/public/css/theme.css
+++ b/packages/typo3-docs-theme/resources/public/css/theme.css
@@ -19857,7 +19857,7 @@ textarea.form-control-lg {
 }
 
 /* rtl:begin:remove */
-.text-break, .code-inline, .code-block-caption, article a:not([class*=btn]) {
+.text-break, .code-inline-long, .code-block-caption, article a:not([class*=btn]) {
   word-wrap: break-word !important;
   word-break: break-word !important;
 }

--- a/packages/typo3-docs-theme/resources/template/inline/textroles/code.html.twig
+++ b/packages/typo3-docs-theme/resources/template/inline/textroles/code.html.twig
@@ -1,11 +1,14 @@
 {% apply spaceless %}
-    <code class="code-inline" translate="no" aria-description="{{ node.language|raw }}" aria-details="{{ node.helpText|raw }}" data-bs-html="true">
+    <code class="code-inline{% if node.value|length > 10 %} code-inline-long{% endif %}"
+          translate="no"
+          aria-description="{{ node.language|raw }}"
+          aria-details="{{ node.helpText|raw }}"
+          data-bs-html="true">
         {%- if node.info.url %}
             <a href="{{ node.info['url'] }}" target="_blank">
                 {{- node.value }} <span class="text-secondary"><i class="fa-regular fa-circle-question"></i></span></a>
         {%- else -%}
-             {{ node.value }}
+            {{ node.value }}
         {%- endif -%}
     </code>
-
 {% endapply %}

--- a/tests/Integration/tests-full/changelog/expected/Changelog/12.0/Breaking-87616-RemovedHookForAlteringPageLinks.html
+++ b/tests/Integration/tests-full/changelog/expected/Changelog/12.0/Breaking-87616-RemovedHookForAlteringPageLinks.html
@@ -165,15 +165,27 @@
             <section class="section" id="description">
             <h2>Description<a class="headerlink" href="#description" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h2>
             
-    <p>The hook <code class="code-inline" translate="no" aria-description="Global PHP configuration" aria-details="The main configuration is achieved via a set of global
+    <p>The hook <code class="code-inline code-inline-long"
+          translate="no"
+          aria-description="Global PHP configuration"
+          aria-details="The main configuration is achieved via a set of global
                 settings stored in a global array called $GLOBALS['TYPO3_CONF_VARS'].
                 They are commonly set in config/system/settings.php, config/system/additional.php,
-                or the ext_localconf.php file of an extension. " data-bs-html="true"><a href="https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/Configuration/Typo3ConfVars/Index.html" target="_blank">$GLOBALS[&#039;TYPO3_CONF_VARS&#039;][&#039;SC_OPTIONS&#039;][&#039;typolinkProcessing&#039;][&#039;typolinkModifyParameterForPageLinks&#039;] <span class="text-secondary"><i class="fa-regular fa-circle-question"></i></span></a></code>
-has been removed in favor of a new PSR-14 event <code class="code-inline" translate="no" aria-description="PHP class" aria-details="<code>final class ModifyPageLinkConfigurationEvent</code><br><em>A generic PSR 14 Event to allow modifying the incoming (and resolved) page when building a &quot;page link&quot;.</em>" data-bs-html="true"><a href="https://api.typo3.org/main/classes/TYPO3-CMS-Frontend-Event-ModifyPageLinkConfigurationEvent.html" target="_blank">\TYPO3\CMS\Frontend\Event\ModifyPageLinkConfigurationEvent <span class="text-secondary"><i class="fa-regular fa-circle-question"></i></span></a></code>.</p>
+                or the ext_localconf.php file of an extension. "
+          data-bs-html="true"><a href="https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/Configuration/Typo3ConfVars/Index.html" target="_blank">$GLOBALS[&#039;TYPO3_CONF_VARS&#039;][&#039;SC_OPTIONS&#039;][&#039;typolinkProcessing&#039;][&#039;typolinkModifyParameterForPageLinks&#039;] <span class="text-secondary"><i class="fa-regular fa-circle-question"></i></span></a></code>
+has been removed in favor of a new PSR-14 event <code class="code-inline code-inline-long"
+          translate="no"
+          aria-description="PHP class"
+          aria-details="<code>final class ModifyPageLinkConfigurationEvent</code><br><em>A generic PSR 14 Event to allow modifying the incoming (and resolved) page when building a &quot;page link&quot;.</em>"
+          data-bs-html="true"><a href="https://api.typo3.org/main/classes/TYPO3-CMS-Frontend-Event-ModifyPageLinkConfigurationEvent.html" target="_blank">\TYPO3\CMS\Frontend\Event\ModifyPageLinkConfigurationEvent <span class="text-secondary"><i class="fa-regular fa-circle-question"></i></span></a></code>.</p>
 
             
     <p>The event is called after TYPO3 has already prepared some functionality
-within the <code class="code-inline" translate="no" aria-description="Code written in PHP" aria-details="Dynamic server-side scripting language." data-bs-html="true">PageLinkBuilder</code>. This therefore allows to modify more
+within the <code class="code-inline code-inline-long"
+          translate="no"
+          aria-description="Code written in PHP"
+          aria-details="Dynamic server-side scripting language."
+          data-bs-html="true">PageLinkBuilder</code>. This therefore allows to modify more
 properties, if needed.</p>
 
     </section>

--- a/tests/Integration/tests-full/edit-on-github/edit-on-github-per-page/expected/page1.html
+++ b/tests/Integration/tests-full/edit-on-github/edit-on-github-per-page/expected/page1.html
@@ -130,7 +130,11 @@
             <a id="typo3-backend-avatar"></a>
             <h1>Avatar ViewHelper <code>&lt;be:avatar&gt;</code><a class="headerlink" href="#avatar-viewhelper-be-avatar" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
             
-    <p>Render the avatar markup, including the <code class="code-inline" translate="no" aria-description="Code written in HTML" aria-details="HyperText Markup Language." data-bs-html="true">&lt;img&gt;</code> tag, for a given backend user.</p>
+    <p>Render the avatar markup, including the <code class="code-inline"
+          translate="no"
+          aria-description="Code written in HTML"
+          aria-details="HyperText Markup Language."
+          data-bs-html="true">&lt;img&gt;</code> tag, for a given backend user.</p>
 
     </section>
         <!-- content end -->

--- a/tests/Integration/tests/code-inline/expected/index.html
+++ b/tests/Integration/tests/code-inline/expected/index.html
@@ -2,13 +2,21 @@
                 <section class="section" id="inline-code">
             <h1>Inline code<a class="headerlink" href="#inline-code" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
 
-    <p><code class="code-inline" translate="no" aria-description="Code written in Shell Script" aria-details="Raw command line interface code on operating-system level." data-bs-html="true">echo &#039;Hello&#039;</code></p>
+    <p><code class="code-inline code-inline-long"
+          translate="no"
+          aria-description="Code written in Shell Script"
+          aria-details="Raw command line interface code on operating-system level."
+          data-bs-html="true">echo &#039;Hello&#039;</code></p>
 
 
     <p><code class="code-inline">body { background: red; }</code></p>
 
 
-    <p><code class="code-inline" translate="no" aria-description="Code written in PHP" aria-details="Dynamic server-side scripting language." data-bs-html="true">$var = 1;</code></p>
+    <p><code class="code-inline"
+          translate="no"
+          aria-description="Code written in PHP"
+          aria-details="Dynamic server-side scripting language."
+          data-bs-html="true">$var = 1;</code></p>
 
     </section>
         <!-- content end -->

--- a/tests/Integration/tests/code/code-php/expected/index.html
+++ b/tests/Integration/tests/code/code-php/expected/index.html
@@ -2,8 +2,12 @@
                 <section class="section" id="php-code">
             <h1>PHP Code<a class="headerlink" href="#php-code" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
 
-    <p><code class="code-inline" translate="no" aria-description="PHP class or interface" aria-details="This is a fully-qualified class or interface name,
-            try searching for \T3Docs\Typo3DocsTheme\TextRoles\PhpTextRole in the internet." data-bs-html="true">\T3Docs\Typo3DocsTheme\TextRoles\PhpTextRole</code>.</p>
+    <p><code class="code-inline code-inline-long"
+          translate="no"
+          aria-description="PHP class or interface"
+          aria-details="This is a fully-qualified class or interface name,
+            try searching for \T3Docs\Typo3DocsTheme\TextRoles\PhpTextRole in the internet."
+          data-bs-html="true">\T3Docs\Typo3DocsTheme\TextRoles\PhpTextRole</code>.</p>
 
     </section>
         <!-- content end -->

--- a/tests/Integration/tests/viewhelper/expected/index.html
+++ b/tests/Integration/tests/viewhelper/expected/index.html
@@ -13,7 +13,11 @@
 results in an array. The number of values in the resulting array can
 be limited with the limit parameter, which results in an array where
 the last item contains the remaining unsplit string.
-This ViewHelper mimicks PHP&#039;s <code class="code-inline" translate="no" aria-description="Code written in PHP" aria-details="Dynamic server-side scripting language." data-bs-html="true">explode()</code> function.</p>
+This ViewHelper mimicks PHP&#039;s <code class="code-inline"
+          translate="no"
+          aria-description="Code written in PHP"
+          aria-details="Dynamic server-side scripting language."
+          data-bs-html="true">explode()</code> function.</p>
 <section class="section" id="examples">
             <h2>Examples<a class="headerlink" href="#examples" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h2>
             <section class="section" id="split-with-a-separator">
@@ -167,7 +171,11 @@ This ViewHelper mimicks PHP&#039;s <code class="code-inline" translate="no" aria
 results in an array. The number of values in the resulting array can
 be limited with the limit parameter, which results in an array where
 the last item contains the remaining unsplit string.
-This ViewHelper mimicks PHP&#039;s <code class="code-inline" translate="no" aria-description="Code written in PHP" aria-details="Dynamic server-side scripting language." data-bs-html="true">explode()</code> function.</p>
+This ViewHelper mimicks PHP&#039;s <code class="code-inline"
+          translate="no"
+          aria-description="Code written in PHP"
+          aria-details="Dynamic server-side scripting language."
+          data-bs-html="true">explode()</code> function.</p>
 <section class="section" id="examples">
             <h2>Examples<a class="headerlink" href="#examples" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h2>
             <section class="section" id="split-with-a-separator">


### PR DESCRIPTION
By only breaking inline-code longer than
10 chars we prevent very short code like "string" to break when used in tables or other tight spaces.