### PR TITLE
[FEATURE] Allow "EXT:self" syntax for typo3:site-set-settings

### DIFF
--- a/tests/Integration/tests/roles/role-composer/expected/index.html
+++ b/tests/Integration/tests/roles/role-composer/expected/index.html
@@ -13,7 +13,7 @@
    data-homepage="https://typo3.org/"
    data-documentation=""
    data-issues="https://github.com/TYPO3/testing-framework/issues"
-   data-source="https://github.com/TYPO3/testing-framework/tree/8.2.0"
+   data-source="https://github.com/TYPO3/testing-framework/tree/8.2.1"
 >
     typo3/testing-framework
 </a> to test projects based on

--- a/tests/Integration/tests/site-set-ext-syntax/_root_include/settings.definitions.yaml
+++ b/tests/Integration/tests/site-set-ext-syntax/_root_include/settings.definitions.yaml
@@ -1,0 +1,129 @@
+settings:
+  styles.content.defaultHeaderType:
+    default: 2
+    label: 'Default Header type'
+    type: int
+    description: 'Enter the number of the header layout to be used by default'
+  styles.content.shortcut.tables:
+    default: tt_content
+    label: 'List of accepted tables'
+    type: string
+    description: ''
+  styles.content.allowTags:
+    default: 'a, abbr, acronym, address, article, aside, b, bdo, big, blockquote, br, caption, center, cite, code, col, colgroup, dd, del, dfn, dl, div, dt, em, figure, font, footer, header, h1, h2, h3, h4, h5, h6, hr, i, img, ins, kbd, label, li, link, meta, nav, ol, p, pre, q, s, samp, sdfield, section, small, span, strike, strong, style, sub, sup, table, thead, tbody, tfoot, td, th, tr, title, tt, u, ul, var'
+    label: 'List of allowed HTML tags when rendering RTE content'
+    type: string
+    description: ''
+  styles.content.image.lazyLoading:
+    default: lazy
+    label: 'Default settings for browser-native image lazy loading'
+    type: string
+    enum:
+      lazy: 'Lazy'
+      eager: 'Eager'
+      auto: 'Auto'
+    description: 'Can be "lazy" (browsers could choose to load images later), "eager" (load images right away) or "auto" (browser will determine whether the image should be lazy loaded or not)'
+  styles.content.image.imageDecoding:
+    default: ''
+    label: 'Default settings for an image decoding hint to the browser'
+    type: string
+    enum:
+      sync: 'Sync'
+      async: 'Asynchronous'
+      auto: 'Auto'
+    description: 'Can be "sync" (synchronously for atomic presentation with other content), "async" (asynchronously to avoid delaying presentation of other content), "auto" (no preference in decoding mode) or an empty value to omit the usage of the decoding attribute (same as "auto")'
+  styles.content.textmedia.maxW:
+    default: 600
+    label: 'Max Image/Media Width'
+    type: int
+    description: 'This indicates that maximum number of pixels (width) a block of media elements inserted as content is allowed to consume'
+  styles.content.textmedia.maxWInText:
+    default: 300
+    label: 'Max Image/Media Width (Text)'
+    type: int
+    description: 'Same as above, but this is the maximum width when text is wrapped around an block of media elements. Default is 50% of the normal Max Media Item Width'
+  styles.content.textmedia.columnSpacing:
+    default: 10
+    label: 'Advanced, Column space'
+    type: int
+    description: 'Horizontal distance between media elements in a block in content elements of type "Media & Images". If you change this manually in your CSS, you need to adjust this setting accordingly'
+  styles.content.textmedia.rowSpacing:
+    default: 10
+    label: 'Advanced, Row space'
+    type: int
+    description: 'Vertical distance after each media elements row in content elements of type ""Text & Media". If you change this manually in your CSS, you need to adjust this setting accordingly'
+  styles.content.textmedia.textMargin:
+    default: 10
+    label: 'Advanced, Margin to text'
+    type: int
+    description: 'Horizontal distance between an imageblock and text in content elements of type "Text & Images"'
+  styles.content.textmedia.borderColor:
+    default: '#000000'
+    label: 'Media element border, color'
+    type: color
+    description: 'Bordercolor of media elements in content elements when "Border"-option for an element is set'
+  styles.content.textmedia.borderWidth:
+    default: 2
+    label: 'Media element border, thickness'
+    type: int
+    description: 'Thickness of border around media elements in content elements when "Border"-option for element is set'
+  styles.content.textmedia.borderPadding:
+    default: 0
+    label: 'Media element border, padding'
+    type: int
+    description: 'Padding left and right to the media element, around the border'
+  styles.content.textmedia.linkWrap.width:
+    default: 800m
+    label: 'Click-enlarge Media Width'
+    type: string
+    description: 'This specifies the width of the enlarged media element when click-enlarge is enabled'
+  styles.content.textmedia.linkWrap.height:
+    default: 600m
+    label: 'Click-enlarge Media Height'
+    type: string
+    description: 'This specifies the height of the enlarged media element when click-enlarge is enabled'
+  styles.content.textmedia.linkWrap.newWindow:
+    default: false
+    label: 'Advanced, New window'
+    type: bool
+    description: "If set, every click-enlarged media element will open in it's own popup window and not the current popup window (which may have a wrong size for the media element to fit in)"
+  styles.content.textmedia.linkWrap.lightboxEnabled:
+    default: false
+    label: 'Lightbox click-enlarge rendering'
+    type: bool
+    description: 'Whether media elements with click-enlarge checked should be rendered lightbox-compliant'
+  styles.content.textmedia.linkWrap.lightboxCssClass:
+    default: lightbox
+    label: 'Lightbox CSS class'
+    type: string
+    description: 'Which CSS class to use for lightbox links (only applicable if lightbox rendering is enabled)'
+  styles.content.textmedia.linkWrap.lightboxRelAttribute:
+    default: 'lightbox[{field:uid}]'
+    label: 'Lightbox rel="" attribute'
+    type: string
+    description: 'Which rel="" attribute to use for lightbox links (only applicable if lightbox rendering is enabled)'
+  styles.content.links.extTarget:
+    default: _blank
+    label: 'Target for external links'
+    type: string
+    description: ''
+  styles.content.links.keep:
+    default: path
+    label: 'Parts to keep when building links'
+    type: string
+    description: 'Comma separated list of the link parts to show when building the link-text: scheme,path,query. Example: "" (empty) => www.example.com, "scheme,path" => http://www.example.com'
+  styles.templates.templateRootPath:
+    default: ''
+    label: 'Path of Fluid Templates for all defined content elements'
+    type: string
+    description: ''
+  styles.templates.partialRootPath:
+    default: ''
+    label: 'Path of Fluid Partials for all defined content elements'
+    type: string
+    description: ''
+  styles.templates.layoutRootPath:
+    default: ''
+    label: 'Path of Fluid Layouts for all defined content elements'
+    type: string
+    description: ''

--- a/tests/Integration/tests/site-set-ext-syntax/expected/index.html
+++ b/tests/Integration/tests/site-set-ext-syntax/expected/index.html
@@ -1,0 +1,1086 @@
+<!-- content start -->
+                <section class="section" id="site-set-configuration">
+            <h1>Site Set Configuration<a class="headerlink" href="#site-set-configuration" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+
+
+
+
+<div class="table-responsive confval-table" id="confval-menu-fluid-styled-content">
+    <table class="table table-hover caption-top">        <thead>
+        <tr>
+            <th scope="col">Name</th>
+
+                                    <th scope="col">Type</th>
+
+                                    <th scope="col">Label</th>
+                                    </tr>
+        </thead>
+                        <tr>
+        <td><div class="confval-label ps-0"><a href="#confval-fluid-styled-content-styles-content-defaultheadertype">styles.content.defaultHeaderType</a></div></td>
+                                    <td><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">int</code></td>
+                                                <td>                            Default Header type
+                        </td>
+                        </tr>
+
+                        <tr>
+        <td><div class="confval-label ps-0"><a href="#confval-fluid-styled-content-styles-content-shortcut-tables">styles.content.shortcut.tables</a></div></td>
+                                    <td><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">string</code></td>
+                                                <td>                            List of accepted tables
+                        </td>
+                        </tr>
+
+                        <tr>
+        <td><div class="confval-label ps-0"><a href="#confval-fluid-styled-content-styles-content-allowtags">styles.content.allowTags</a></div></td>
+                                    <td><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">string</code></td>
+                                                <td>                            List of allowed HTML tags when rendering RTE content
+                        </td>
+                        </tr>
+
+                        <tr>
+        <td><div class="confval-label ps-0"><a href="#confval-fluid-styled-content-styles-content-image-lazyloading">styles.content.image.lazyLoading</a></div></td>
+                                    <td><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">string</code></td>
+                                                <td>                            Default settings for browser-native image lazy loading
+                        </td>
+                        </tr>
+
+                        <tr>
+        <td><div class="confval-label ps-0"><a href="#confval-fluid-styled-content-styles-content-image-imagedecoding">styles.content.image.imageDecoding</a></div></td>
+                                    <td><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">string</code></td>
+                                                <td>                            Default settings for an image decoding hint to the browser
+                        </td>
+                        </tr>
+
+                        <tr>
+        <td><div class="confval-label ps-0"><a href="#confval-fluid-styled-content-styles-content-textmedia-maxw">styles.content.textmedia.maxW</a></div></td>
+                                    <td><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">int</code></td>
+                                                <td>                            Max Image/Media Width
+                        </td>
+                        </tr>
+
+                        <tr>
+        <td><div class="confval-label ps-0"><a href="#confval-fluid-styled-content-styles-content-textmedia-maxwintext">styles.content.textmedia.maxWInText</a></div></td>
+                                    <td><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">int</code></td>
+                                                <td>                            Max Image/Media Width (Text)
+                        </td>
+                        </tr>
+
+                        <tr>
+        <td><div class="confval-label ps-0"><a href="#confval-fluid-styled-content-styles-content-textmedia-columnspacing">styles.content.textmedia.columnSpacing</a></div></td>
+                                    <td><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">int</code></td>
+                                                <td>                            Advanced, Column space
+                        </td>
+                        </tr>
+
+                        <tr>
+        <td><div class="confval-label ps-0"><a href="#confval-fluid-styled-content-styles-content-textmedia-rowspacing">styles.content.textmedia.rowSpacing</a></div></td>
+                                    <td><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">int</code></td>
+                                                <td>                            Advanced, Row space
+                        </td>
+                        </tr>
+
+                        <tr>
+        <td><div class="confval-label ps-0"><a href="#confval-fluid-styled-content-styles-content-textmedia-textmargin">styles.content.textmedia.textMargin</a></div></td>
+                                    <td><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">int</code></td>
+                                                <td>                            Advanced, Margin to text
+                        </td>
+                        </tr>
+
+                        <tr>
+        <td><div class="confval-label ps-0"><a href="#confval-fluid-styled-content-styles-content-textmedia-bordercolor">styles.content.textmedia.borderColor</a></div></td>
+                                    <td><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">color</code></td>
+                                                <td>                            Media element border, color
+                        </td>
+                        </tr>
+
+                        <tr>
+        <td><div class="confval-label ps-0"><a href="#confval-fluid-styled-content-styles-content-textmedia-borderwidth">styles.content.textmedia.borderWidth</a></div></td>
+                                    <td><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">int</code></td>
+                                                <td>                            Media element border, thickness
+                        </td>
+                        </tr>
+
+                        <tr>
+        <td><div class="confval-label ps-0"><a href="#confval-fluid-styled-content-styles-content-textmedia-borderpadding">styles.content.textmedia.borderPadding</a></div></td>
+                                    <td><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">int</code></td>
+                                                <td>                            Media element border, padding
+                        </td>
+                        </tr>
+
+                        <tr>
+        <td><div class="confval-label ps-0"><a href="#confval-fluid-styled-content-styles-content-textmedia-linkwrap-width">styles.content.textmedia.linkWrap.width</a></div></td>
+                                    <td><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">string</code></td>
+                                                <td>                            Click-enlarge Media Width
+                        </td>
+                        </tr>
+
+                        <tr>
+        <td><div class="confval-label ps-0"><a href="#confval-fluid-styled-content-styles-content-textmedia-linkwrap-height">styles.content.textmedia.linkWrap.height</a></div></td>
+                                    <td><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">string</code></td>
+                                                <td>                            Click-enlarge Media Height
+                        </td>
+                        </tr>
+
+                        <tr>
+        <td><div class="confval-label ps-0"><a href="#confval-fluid-styled-content-styles-content-textmedia-linkwrap-newwindow">styles.content.textmedia.linkWrap.newWindow</a></div></td>
+                                    <td><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">bool</code></td>
+                                                <td>                            Advanced, New window
+                        </td>
+                        </tr>
+
+                        <tr>
+        <td><div class="confval-label ps-0"><a href="#confval-fluid-styled-content-styles-content-textmedia-linkwrap-lightboxenabled">styles.content.textmedia.linkWrap.lightboxEnabled</a></div></td>
+                                    <td><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">bool</code></td>
+                                                <td>                            Lightbox click-enlarge rendering
+                        </td>
+                        </tr>
+
+                        <tr>
+        <td><div class="confval-label ps-0"><a href="#confval-fluid-styled-content-styles-content-textmedia-linkwrap-lightboxcssclass">styles.content.textmedia.linkWrap.lightboxCssClass</a></div></td>
+                                    <td><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">string</code></td>
+                                                <td>                            Lightbox CSS class
+                        </td>
+                        </tr>
+
+                        <tr>
+        <td><div class="confval-label ps-0"><a href="#confval-fluid-styled-content-styles-content-textmedia-linkwrap-lightboxrelattribute">styles.content.textmedia.linkWrap.lightboxRelAttribute</a></div></td>
+                                    <td><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">string</code></td>
+                                                <td>                            Lightbox rel=&quot;&quot; attribute
+                        </td>
+                        </tr>
+
+                        <tr>
+        <td><div class="confval-label ps-0"><a href="#confval-fluid-styled-content-styles-content-links-exttarget">styles.content.links.extTarget</a></div></td>
+                                    <td><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">string</code></td>
+                                                <td>                            Target for external links
+                        </td>
+                        </tr>
+
+                        <tr>
+        <td><div class="confval-label ps-0"><a href="#confval-fluid-styled-content-styles-content-links-keep">styles.content.links.keep</a></div></td>
+                                    <td><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">string</code></td>
+                                                <td>                            Parts to keep when building links
+                        </td>
+                        </tr>
+
+                        <tr>
+        <td><div class="confval-label ps-0"><a href="#confval-fluid-styled-content-styles-templates-templaterootpath">styles.templates.templateRootPath</a></div></td>
+                                    <td><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">string</code></td>
+                                                <td>                            Path of Fluid Templates for all defined content elements
+                        </td>
+                        </tr>
+
+                        <tr>
+        <td><div class="confval-label ps-0"><a href="#confval-fluid-styled-content-styles-templates-partialrootpath">styles.templates.partialRootPath</a></div></td>
+                                    <td><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">string</code></td>
+                                                <td>                            Path of Fluid Partials for all defined content elements
+                        </td>
+                        </tr>
+
+                        <tr>
+        <td><div class="confval-label ps-0"><a href="#confval-fluid-styled-content-styles-templates-layoutrootpath">styles.templates.layoutRootPath</a></div></td>
+                                    <td><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">string</code></td>
+                                                <td>                            Path of Fluid Layouts for all defined content elements
+                        </td>
+                        </tr>
+
+            </table>
+</div>
+            <dl class="confval">
+    <dt id="confval-fluid-styled-content-styles-content-defaultheadertype" class="d-flex justify-content-between">
+        <div class="confval-header">
+        <code class="sig-name descname"><span class="pre">styles.content.defaultHeaderType</span></code>
+                <a class="headerlink" href="#confval-fluid-styled-content-styles-content-defaultheadertype" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-fluid-styled-content-styles-content-defaultheadertype" data-rstCode=":confval:`styles.content.defaultHeaderType &lt;somemanual:fluid-styled-content-styles-content-defaultheadertype&gt;`"  title="Reference this configuration value">¶</a>
+        </div>
+        <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
+    </dt>
+    <dd>
+                <dl class="field-list simple">
+                            <dt class="field-even">Type</dt>
+                <dd class="field-even"><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">int</code>
+                </dd>
+                        <dt class="field-odd">Default</dt>
+            <dd class="field-odd"><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">2</code>
+            </dd>
+            <dt class="field-even">Label</dt>
+                <dd class="field-even">Default Header type
+                </dd>
+            </dl>
+                <div class="confval-description">
+
+    <p>Enter the number of the header layout to be used by default</p>
+
+        </div>
+    </dd>
+</dl>
+                <dl class="confval">
+    <dt id="confval-fluid-styled-content-styles-content-shortcut-tables" class="d-flex justify-content-between">
+        <div class="confval-header">
+        <code class="sig-name descname"><span class="pre">styles.content.shortcut.tables</span></code>
+                <a class="headerlink" href="#confval-fluid-styled-content-styles-content-shortcut-tables" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-fluid-styled-content-styles-content-shortcut-tables" data-rstCode=":confval:`styles.content.shortcut.tables &lt;somemanual:fluid-styled-content-styles-content-shortcut-tables&gt;`"  title="Reference this configuration value">¶</a>
+        </div>
+        <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
+    </dt>
+    <dd>
+                <dl class="field-list simple">
+                            <dt class="field-even">Type</dt>
+                <dd class="field-even"><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">string</code>
+                </dd>
+                        <dt class="field-odd">Default</dt>
+            <dd class="field-odd"><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">tt_content</code>
+            </dd>
+            <dt class="field-even">Label</dt>
+                <dd class="field-even">List of accepted tables
+                </dd>
+            </dl>
+                <div class="confval-description">
+
+        </div>
+    </dd>
+</dl>
+                <dl class="confval">
+    <dt id="confval-fluid-styled-content-styles-content-allowtags" class="d-flex justify-content-between">
+        <div class="confval-header">
+        <code class="sig-name descname"><span class="pre">styles.content.allowTags</span></code>
+                <a class="headerlink" href="#confval-fluid-styled-content-styles-content-allowtags" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-fluid-styled-content-styles-content-allowtags" data-rstCode=":confval:`styles.content.allowTags &lt;somemanual:fluid-styled-content-styles-content-allowtags&gt;`"  title="Reference this configuration value">¶</a>
+        </div>
+        <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
+    </dt>
+    <dd>
+                <dl class="field-list simple">
+                            <dt class="field-even">Type</dt>
+                <dd class="field-even"><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">string</code>
+                </dd>
+                        <dt class="field-odd">Default</dt>
+            <dd class="field-odd"><code class="code-inline code-inline-long"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">a, abbr, acronym, address, article, aside, b, bdo, big, blockquote, br, caption, center, cite, code, col, colgroup, dd, del, dfn, dl, div, dt, em, figure, font, footer, header, h1, h2, h3, h4, h5, h6, hr, i, img, ins, kbd, label, li, link, meta, nav, ol, p, pre, q, s, samp, sdfield, section, small, span, strike, strong, style, sub, sup, table, thead, tbody, tfoot, td, th, tr, title, tt, u, ul, var</code>
+            </dd>
+            <dt class="field-even">Label</dt>
+                <dd class="field-even">List of allowed HTML tags when rendering RTE content
+                </dd>
+            </dl>
+                <div class="confval-description">
+
+        </div>
+    </dd>
+</dl>
+                <dl class="confval">
+    <dt id="confval-fluid-styled-content-styles-content-image-lazyloading" class="d-flex justify-content-between">
+        <div class="confval-header">
+        <code class="sig-name descname"><span class="pre">styles.content.image.lazyLoading</span></code>
+                <a class="headerlink" href="#confval-fluid-styled-content-styles-content-image-lazyloading" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-fluid-styled-content-styles-content-image-lazyloading" data-rstCode=":confval:`styles.content.image.lazyLoading &lt;somemanual:fluid-styled-content-styles-content-image-lazyloading&gt;`"  title="Reference this configuration value">¶</a>
+        </div>
+        <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
+    </dt>
+    <dd>
+                <dl class="field-list simple">
+                            <dt class="field-even">Type</dt>
+                <dd class="field-even"><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">string</code>
+                </dd>
+                        <dt class="field-odd">Default</dt>
+            <dd class="field-odd"><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">lazy</code>
+            </dd>
+            <dt class="field-even">Label</dt>
+                <dd class="field-even">Default settings for browser-native image lazy loading
+                </dd>
+            </dl>
+                <div class="confval-description">
+
+    <p>Can be &quot;lazy&quot; (browsers could choose to load images later), &quot;eager&quot; (load images right away) or &quot;auto&quot; (browser will determine whether the image should be lazy loaded or not)</p>
+
+        </div>
+    </dd>
+</dl>
+                <dl class="confval">
+    <dt id="confval-fluid-styled-content-styles-content-image-imagedecoding" class="d-flex justify-content-between">
+        <div class="confval-header">
+        <code class="sig-name descname"><span class="pre">styles.content.image.imageDecoding</span></code>
+                <a class="headerlink" href="#confval-fluid-styled-content-styles-content-image-imagedecoding" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-fluid-styled-content-styles-content-image-imagedecoding" data-rstCode=":confval:`styles.content.image.imageDecoding &lt;somemanual:fluid-styled-content-styles-content-image-imagedecoding&gt;`"  title="Reference this configuration value">¶</a>
+        </div>
+        <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
+    </dt>
+    <dd>
+                <dl class="field-list simple">
+                            <dt class="field-even">Type</dt>
+                <dd class="field-even"><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">string</code>
+                </dd>
+            <dt class="field-even">Label</dt>
+                <dd class="field-even">Default settings for an image decoding hint to the browser
+                </dd>
+            </dl>
+                <div class="confval-description">
+
+    <p>Can be &quot;sync&quot; (synchronously for atomic presentation with other content), &quot;async&quot; (asynchronously to avoid delaying presentation of other content), &quot;auto&quot; (no preference in decoding mode) or an empty value to omit the usage of the decoding attribute (same as &quot;auto&quot;)</p>
+
+        </div>
+    </dd>
+</dl>
+                <dl class="confval">
+    <dt id="confval-fluid-styled-content-styles-content-textmedia-maxw" class="d-flex justify-content-between">
+        <div class="confval-header">
+        <code class="sig-name descname"><span class="pre">styles.content.textmedia.maxW</span></code>
+                <a class="headerlink" href="#confval-fluid-styled-content-styles-content-textmedia-maxw" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-fluid-styled-content-styles-content-textmedia-maxw" data-rstCode=":confval:`styles.content.textmedia.maxW &lt;somemanual:fluid-styled-content-styles-content-textmedia-maxw&gt;`"  title="Reference this configuration value">¶</a>
+        </div>
+        <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
+    </dt>
+    <dd>
+                <dl class="field-list simple">
+                            <dt class="field-even">Type</dt>
+                <dd class="field-even"><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">int</code>
+                </dd>
+                        <dt class="field-odd">Default</dt>
+            <dd class="field-odd"><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">600</code>
+            </dd>
+            <dt class="field-even">Label</dt>
+                <dd class="field-even">Max Image/Media Width
+                </dd>
+            </dl>
+                <div class="confval-description">
+
+    <p>This indicates that maximum number of pixels (width) a block of media elements inserted as content is allowed to consume</p>
+
+        </div>
+    </dd>
+</dl>
+                <dl class="confval">
+    <dt id="confval-fluid-styled-content-styles-content-textmedia-maxwintext" class="d-flex justify-content-between">
+        <div class="confval-header">
+        <code class="sig-name descname"><span class="pre">styles.content.textmedia.maxWInText</span></code>
+                <a class="headerlink" href="#confval-fluid-styled-content-styles-content-textmedia-maxwintext" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-fluid-styled-content-styles-content-textmedia-maxwintext" data-rstCode=":confval:`styles.content.textmedia.maxWInText &lt;somemanual:fluid-styled-content-styles-content-textmedia-maxwintext&gt;`"  title="Reference this configuration value">¶</a>
+        </div>
+        <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
+    </dt>
+    <dd>
+                <dl class="field-list simple">
+                            <dt class="field-even">Type</dt>
+                <dd class="field-even"><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">int</code>
+                </dd>
+                        <dt class="field-odd">Default</dt>
+            <dd class="field-odd"><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">300</code>
+            </dd>
+            <dt class="field-even">Label</dt>
+                <dd class="field-even">Max Image/Media Width (Text)
+                </dd>
+            </dl>
+                <div class="confval-description">
+
+    <p>Same as above, but this is the maximum width when text is wrapped around an block of media elements. Default is 50% of the normal Max Media Item Width</p>
+
+        </div>
+    </dd>
+</dl>
+                <dl class="confval">
+    <dt id="confval-fluid-styled-content-styles-content-textmedia-columnspacing" class="d-flex justify-content-between">
+        <div class="confval-header">
+        <code class="sig-name descname"><span class="pre">styles.content.textmedia.columnSpacing</span></code>
+                <a class="headerlink" href="#confval-fluid-styled-content-styles-content-textmedia-columnspacing" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-fluid-styled-content-styles-content-textmedia-columnspacing" data-rstCode=":confval:`styles.content.textmedia.columnSpacing &lt;somemanual:fluid-styled-content-styles-content-textmedia-columnspacing&gt;`"  title="Reference this configuration value">¶</a>
+        </div>
+        <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
+    </dt>
+    <dd>
+                <dl class="field-list simple">
+                            <dt class="field-even">Type</dt>
+                <dd class="field-even"><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">int</code>
+                </dd>
+                        <dt class="field-odd">Default</dt>
+            <dd class="field-odd"><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">10</code>
+            </dd>
+            <dt class="field-even">Label</dt>
+                <dd class="field-even">Advanced, Column space
+                </dd>
+            </dl>
+                <div class="confval-description">
+
+    <p>Horizontal distance between media elements in a block in content elements of type &quot;Media &amp; Images&quot;. If you change this manually in your CSS, you need to adjust this setting accordingly</p>
+
+        </div>
+    </dd>
+</dl>
+                <dl class="confval">
+    <dt id="confval-fluid-styled-content-styles-content-textmedia-rowspacing" class="d-flex justify-content-between">
+        <div class="confval-header">
+        <code class="sig-name descname"><span class="pre">styles.content.textmedia.rowSpacing</span></code>
+                <a class="headerlink" href="#confval-fluid-styled-content-styles-content-textmedia-rowspacing" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-fluid-styled-content-styles-content-textmedia-rowspacing" data-rstCode=":confval:`styles.content.textmedia.rowSpacing &lt;somemanual:fluid-styled-content-styles-content-textmedia-rowspacing&gt;`"  title="Reference this configuration value">¶</a>
+        </div>
+        <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
+    </dt>
+    <dd>
+                <dl class="field-list simple">
+                            <dt class="field-even">Type</dt>
+                <dd class="field-even"><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">int</code>
+                </dd>
+                        <dt class="field-odd">Default</dt>
+            <dd class="field-odd"><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">10</code>
+            </dd>
+            <dt class="field-even">Label</dt>
+                <dd class="field-even">Advanced, Row space
+                </dd>
+            </dl>
+                <div class="confval-description">
+
+    <p>Vertical distance after each media elements row in content elements of type &quot;&quot;Text &amp; Media&quot;. If you change this manually in your CSS, you need to adjust this setting accordingly</p>
+
+        </div>
+    </dd>
+</dl>
+                <dl class="confval">
+    <dt id="confval-fluid-styled-content-styles-content-textmedia-textmargin" class="d-flex justify-content-between">
+        <div class="confval-header">
+        <code class="sig-name descname"><span class="pre">styles.content.textmedia.textMargin</span></code>
+                <a class="headerlink" href="#confval-fluid-styled-content-styles-content-textmedia-textmargin" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-fluid-styled-content-styles-content-textmedia-textmargin" data-rstCode=":confval:`styles.content.textmedia.textMargin &lt;somemanual:fluid-styled-content-styles-content-textmedia-textmargin&gt;`"  title="Reference this configuration value">¶</a>
+        </div>
+        <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
+    </dt>
+    <dd>
+                <dl class="field-list simple">
+                            <dt class="field-even">Type</dt>
+                <dd class="field-even"><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">int</code>
+                </dd>
+                        <dt class="field-odd">Default</dt>
+            <dd class="field-odd"><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">10</code>
+            </dd>
+            <dt class="field-even">Label</dt>
+                <dd class="field-even">Advanced, Margin to text
+                </dd>
+            </dl>
+                <div class="confval-description">
+
+    <p>Horizontal distance between an imageblock and text in content elements of type &quot;Text &amp; Images&quot;</p>
+
+        </div>
+    </dd>
+</dl>
+                <dl class="confval">
+    <dt id="confval-fluid-styled-content-styles-content-textmedia-bordercolor" class="d-flex justify-content-between">
+        <div class="confval-header">
+        <code class="sig-name descname"><span class="pre">styles.content.textmedia.borderColor</span></code>
+                <a class="headerlink" href="#confval-fluid-styled-content-styles-content-textmedia-bordercolor" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-fluid-styled-content-styles-content-textmedia-bordercolor" data-rstCode=":confval:`styles.content.textmedia.borderColor &lt;somemanual:fluid-styled-content-styles-content-textmedia-bordercolor&gt;`"  title="Reference this configuration value">¶</a>
+        </div>
+        <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
+    </dt>
+    <dd>
+                <dl class="field-list simple">
+                            <dt class="field-even">Type</dt>
+                <dd class="field-even"><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">color</code>
+                </dd>
+                        <dt class="field-odd">Default</dt>
+            <dd class="field-odd"><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">#000000</code>
+            </dd>
+            <dt class="field-even">Label</dt>
+                <dd class="field-even">Media element border, color
+                </dd>
+            </dl>
+                <div class="confval-description">
+
+    <p>Bordercolor of media elements in content elements when &quot;Border&quot;-option for an element is set</p>
+
+        </div>
+    </dd>
+</dl>
+                <dl class="confval">
+    <dt id="confval-fluid-styled-content-styles-content-textmedia-borderwidth" class="d-flex justify-content-between">
+        <div class="confval-header">
+        <code class="sig-name descname"><span class="pre">styles.content.textmedia.borderWidth</span></code>
+                <a class="headerlink" href="#confval-fluid-styled-content-styles-content-textmedia-borderwidth" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-fluid-styled-content-styles-content-textmedia-borderwidth" data-rstCode=":confval:`styles.content.textmedia.borderWidth &lt;somemanual:fluid-styled-content-styles-content-textmedia-borderwidth&gt;`"  title="Reference this configuration value">¶</a>
+        </div>
+        <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
+    </dt>
+    <dd>
+                <dl class="field-list simple">
+                            <dt class="field-even">Type</dt>
+                <dd class="field-even"><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">int</code>
+                </dd>
+                        <dt class="field-odd">Default</dt>
+            <dd class="field-odd"><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">2</code>
+            </dd>
+            <dt class="field-even">Label</dt>
+                <dd class="field-even">Media element border, thickness
+                </dd>
+            </dl>
+                <div class="confval-description">
+
+    <p>Thickness of border around media elements in content elements when &quot;Border&quot;-option for element is set</p>
+
+        </div>
+    </dd>
+</dl>
+                <dl class="confval">
+    <dt id="confval-fluid-styled-content-styles-content-textmedia-borderpadding" class="d-flex justify-content-between">
+        <div class="confval-header">
+        <code class="sig-name descname"><span class="pre">styles.content.textmedia.borderPadding</span></code>
+                <a class="headerlink" href="#confval-fluid-styled-content-styles-content-textmedia-borderpadding" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-fluid-styled-content-styles-content-textmedia-borderpadding" data-rstCode=":confval:`styles.content.textmedia.borderPadding &lt;somemanual:fluid-styled-content-styles-content-textmedia-borderpadding&gt;`"  title="Reference this configuration value">¶</a>
+        </div>
+        <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
+    </dt>
+    <dd>
+                <dl class="field-list simple">
+                            <dt class="field-even">Type</dt>
+                <dd class="field-even"><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">int</code>
+                </dd>
+                        <dt class="field-odd">Default</dt>
+            <dd class="field-odd"><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">0</code>
+            </dd>
+            <dt class="field-even">Label</dt>
+                <dd class="field-even">Media element border, padding
+                </dd>
+            </dl>
+                <div class="confval-description">
+
+    <p>Padding left and right to the media element, around the border</p>
+
+        </div>
+    </dd>
+</dl>
+                <dl class="confval">
+    <dt id="confval-fluid-styled-content-styles-content-textmedia-linkwrap-width" class="d-flex justify-content-between">
+        <div class="confval-header">
+        <code class="sig-name descname"><span class="pre">styles.content.textmedia.linkWrap.width</span></code>
+                <a class="headerlink" href="#confval-fluid-styled-content-styles-content-textmedia-linkwrap-width" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-fluid-styled-content-styles-content-textmedia-linkwrap-width" data-rstCode=":confval:`styles.content.textmedia.linkWrap.width &lt;somemanual:fluid-styled-content-styles-content-textmedia-linkwrap-width&gt;`"  title="Reference this configuration value">¶</a>
+        </div>
+        <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
+    </dt>
+    <dd>
+                <dl class="field-list simple">
+                            <dt class="field-even">Type</dt>
+                <dd class="field-even"><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">string</code>
+                </dd>
+                        <dt class="field-odd">Default</dt>
+            <dd class="field-odd"><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">800m</code>
+            </dd>
+            <dt class="field-even">Label</dt>
+                <dd class="field-even">Click-enlarge Media Width
+                </dd>
+            </dl>
+                <div class="confval-description">
+
+    <p>This specifies the width of the enlarged media element when click-enlarge is enabled</p>
+
+        </div>
+    </dd>
+</dl>
+                <dl class="confval">
+    <dt id="confval-fluid-styled-content-styles-content-textmedia-linkwrap-height" class="d-flex justify-content-between">
+        <div class="confval-header">
+        <code class="sig-name descname"><span class="pre">styles.content.textmedia.linkWrap.height</span></code>
+                <a class="headerlink" href="#confval-fluid-styled-content-styles-content-textmedia-linkwrap-height" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-fluid-styled-content-styles-content-textmedia-linkwrap-height" data-rstCode=":confval:`styles.content.textmedia.linkWrap.height &lt;somemanual:fluid-styled-content-styles-content-textmedia-linkwrap-height&gt;`"  title="Reference this configuration value">¶</a>
+        </div>
+        <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
+    </dt>
+    <dd>
+                <dl class="field-list simple">
+                            <dt class="field-even">Type</dt>
+                <dd class="field-even"><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">string</code>
+                </dd>
+                        <dt class="field-odd">Default</dt>
+            <dd class="field-odd"><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">600m</code>
+            </dd>
+            <dt class="field-even">Label</dt>
+                <dd class="field-even">Click-enlarge Media Height
+                </dd>
+            </dl>
+                <div class="confval-description">
+
+    <p>This specifies the height of the enlarged media element when click-enlarge is enabled</p>
+
+        </div>
+    </dd>
+</dl>
+                <dl class="confval">
+    <dt id="confval-fluid-styled-content-styles-content-textmedia-linkwrap-newwindow" class="d-flex justify-content-between">
+        <div class="confval-header">
+        <code class="sig-name descname"><span class="pre">styles.content.textmedia.linkWrap.newWindow</span></code>
+                <a class="headerlink" href="#confval-fluid-styled-content-styles-content-textmedia-linkwrap-newwindow" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-fluid-styled-content-styles-content-textmedia-linkwrap-newwindow" data-rstCode=":confval:`styles.content.textmedia.linkWrap.newWindow &lt;somemanual:fluid-styled-content-styles-content-textmedia-linkwrap-newwindow&gt;`"  title="Reference this configuration value">¶</a>
+        </div>
+        <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
+    </dt>
+    <dd>
+                <dl class="field-list simple">
+                            <dt class="field-even">Type</dt>
+                <dd class="field-even"><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">bool</code>
+                </dd>
+                        <dt class="field-odd">Default</dt>
+            <dd class="field-odd"><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true"></code>
+            </dd>
+            <dt class="field-even">Label</dt>
+                <dd class="field-even">Advanced, New window
+                </dd>
+            </dl>
+                <div class="confval-description">
+
+    <p>If set, every click-enlarged media element will open in it&#039;s own popup window and not the current popup window (which may have a wrong size for the media element to fit in)</p>
+
+        </div>
+    </dd>
+</dl>
+                <dl class="confval">
+    <dt id="confval-fluid-styled-content-styles-content-textmedia-linkwrap-lightboxenabled" class="d-flex justify-content-between">
+        <div class="confval-header">
+        <code class="sig-name descname"><span class="pre">styles.content.textmedia.linkWrap.lightboxEnabled</span></code>
+                <a class="headerlink" href="#confval-fluid-styled-content-styles-content-textmedia-linkwrap-lightboxenabled" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-fluid-styled-content-styles-content-textmedia-linkwrap-lightboxenabled" data-rstCode=":confval:`styles.content.textmedia.linkWrap.lightboxEnabled &lt;somemanual:fluid-styled-content-styles-content-textmedia-linkwrap-lightboxenabled&gt;`"  title="Reference this configuration value">¶</a>
+        </div>
+        <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
+    </dt>
+    <dd>
+                <dl class="field-list simple">
+                            <dt class="field-even">Type</dt>
+                <dd class="field-even"><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">bool</code>
+                </dd>
+                        <dt class="field-odd">Default</dt>
+            <dd class="field-odd"><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true"></code>
+            </dd>
+            <dt class="field-even">Label</dt>
+                <dd class="field-even">Lightbox click-enlarge rendering
+                </dd>
+            </dl>
+                <div class="confval-description">
+
+    <p>Whether media elements with click-enlarge checked should be rendered lightbox-compliant</p>
+
+        </div>
+    </dd>
+</dl>
+                <dl class="confval">
+    <dt id="confval-fluid-styled-content-styles-content-textmedia-linkwrap-lightboxcssclass" class="d-flex justify-content-between">
+        <div class="confval-header">
+        <code class="sig-name descname"><span class="pre">styles.content.textmedia.linkWrap.lightboxCssClass</span></code>
+                <a class="headerlink" href="#confval-fluid-styled-content-styles-content-textmedia-linkwrap-lightboxcssclass" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-fluid-styled-content-styles-content-textmedia-linkwrap-lightboxcssclass" data-rstCode=":confval:`styles.content.textmedia.linkWrap.lightboxCssClass &lt;somemanual:fluid-styled-content-styles-content-textmedia-linkwrap-lightboxcssclass&gt;`"  title="Reference this configuration value">¶</a>
+        </div>
+        <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
+    </dt>
+    <dd>
+                <dl class="field-list simple">
+                            <dt class="field-even">Type</dt>
+                <dd class="field-even"><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">string</code>
+                </dd>
+                        <dt class="field-odd">Default</dt>
+            <dd class="field-odd"><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">lightbox</code>
+            </dd>
+            <dt class="field-even">Label</dt>
+                <dd class="field-even">Lightbox CSS class
+                </dd>
+            </dl>
+                <div class="confval-description">
+
+    <p>Which CSS class to use for lightbox links (only applicable if lightbox rendering is enabled)</p>
+
+        </div>
+    </dd>
+</dl>
+                <dl class="confval">
+    <dt id="confval-fluid-styled-content-styles-content-textmedia-linkwrap-lightboxrelattribute" class="d-flex justify-content-between">
+        <div class="confval-header">
+        <code class="sig-name descname"><span class="pre">styles.content.textmedia.linkWrap.lightboxRelAttribute</span></code>
+                <a class="headerlink" href="#confval-fluid-styled-content-styles-content-textmedia-linkwrap-lightboxrelattribute" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-fluid-styled-content-styles-content-textmedia-linkwrap-lightboxrelattribute" data-rstCode=":confval:`styles.content.textmedia.linkWrap.lightboxRelAttribute &lt;somemanual:fluid-styled-content-styles-content-textmedia-linkwrap-lightboxrelattribute&gt;`"  title="Reference this configuration value">¶</a>
+        </div>
+        <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
+    </dt>
+    <dd>
+                <dl class="field-list simple">
+                            <dt class="field-even">Type</dt>
+                <dd class="field-even"><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">string</code>
+                </dd>
+                        <dt class="field-odd">Default</dt>
+            <dd class="field-odd"><code class="code-inline code-inline-long"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">lightbox[{field:uid}]</code>
+            </dd>
+            <dt class="field-even">Label</dt>
+                <dd class="field-even">Lightbox rel=&quot;&quot; attribute
+                </dd>
+            </dl>
+                <div class="confval-description">
+
+    <p>Which rel=&quot;&quot; attribute to use for lightbox links (only applicable if lightbox rendering is enabled)</p>
+
+        </div>
+    </dd>
+</dl>
+                <dl class="confval">
+    <dt id="confval-fluid-styled-content-styles-content-links-exttarget" class="d-flex justify-content-between">
+        <div class="confval-header">
+        <code class="sig-name descname"><span class="pre">styles.content.links.extTarget</span></code>
+                <a class="headerlink" href="#confval-fluid-styled-content-styles-content-links-exttarget" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-fluid-styled-content-styles-content-links-exttarget" data-rstCode=":confval:`styles.content.links.extTarget &lt;somemanual:fluid-styled-content-styles-content-links-exttarget&gt;`"  title="Reference this configuration value">¶</a>
+        </div>
+        <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
+    </dt>
+    <dd>
+                <dl class="field-list simple">
+                            <dt class="field-even">Type</dt>
+                <dd class="field-even"><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">string</code>
+                </dd>
+                        <dt class="field-odd">Default</dt>
+            <dd class="field-odd"><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">_blank</code>
+            </dd>
+            <dt class="field-even">Label</dt>
+                <dd class="field-even">Target for external links
+                </dd>
+            </dl>
+                <div class="confval-description">
+
+        </div>
+    </dd>
+</dl>
+                <dl class="confval">
+    <dt id="confval-fluid-styled-content-styles-content-links-keep" class="d-flex justify-content-between">
+        <div class="confval-header">
+        <code class="sig-name descname"><span class="pre">styles.content.links.keep</span></code>
+                <a class="headerlink" href="#confval-fluid-styled-content-styles-content-links-keep" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-fluid-styled-content-styles-content-links-keep" data-rstCode=":confval:`styles.content.links.keep &lt;somemanual:fluid-styled-content-styles-content-links-keep&gt;`"  title="Reference this configuration value">¶</a>
+        </div>
+        <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
+    </dt>
+    <dd>
+                <dl class="field-list simple">
+                            <dt class="field-even">Type</dt>
+                <dd class="field-even"><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">string</code>
+                </dd>
+                        <dt class="field-odd">Default</dt>
+            <dd class="field-odd"><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">path</code>
+            </dd>
+            <dt class="field-even">Label</dt>
+                <dd class="field-even">Parts to keep when building links
+                </dd>
+            </dl>
+                <div class="confval-description">
+
+    <p>Comma separated list of the link parts to show when building the link-text: scheme,path,query. Example: &quot;&quot; (empty) =&gt; www.example.com, &quot;scheme,path&quot; =&gt; http://www.example.com</p>
+
+        </div>
+    </dd>
+</dl>
+                <dl class="confval">
+    <dt id="confval-fluid-styled-content-styles-templates-templaterootpath" class="d-flex justify-content-between">
+        <div class="confval-header">
+        <code class="sig-name descname"><span class="pre">styles.templates.templateRootPath</span></code>
+                <a class="headerlink" href="#confval-fluid-styled-content-styles-templates-templaterootpath" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-fluid-styled-content-styles-templates-templaterootpath" data-rstCode=":confval:`styles.templates.templateRootPath &lt;somemanual:fluid-styled-content-styles-templates-templaterootpath&gt;`"  title="Reference this configuration value">¶</a>
+        </div>
+        <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
+    </dt>
+    <dd>
+                <dl class="field-list simple">
+                            <dt class="field-even">Type</dt>
+                <dd class="field-even"><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">string</code>
+                </dd>
+            <dt class="field-even">Label</dt>
+                <dd class="field-even">Path of Fluid Templates for all defined content elements
+                </dd>
+            </dl>
+                <div class="confval-description">
+
+        </div>
+    </dd>
+</dl>
+                <dl class="confval">
+    <dt id="confval-fluid-styled-content-styles-templates-partialrootpath" class="d-flex justify-content-between">
+        <div class="confval-header">
+        <code class="sig-name descname"><span class="pre">styles.templates.partialRootPath</span></code>
+                <a class="headerlink" href="#confval-fluid-styled-content-styles-templates-partialrootpath" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-fluid-styled-content-styles-templates-partialrootpath" data-rstCode=":confval:`styles.templates.partialRootPath &lt;somemanual:fluid-styled-content-styles-templates-partialrootpath&gt;`"  title="Reference this configuration value">¶</a>
+        </div>
+        <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
+    </dt>
+    <dd>
+                <dl class="field-list simple">
+                            <dt class="field-even">Type</dt>
+                <dd class="field-even"><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">string</code>
+                </dd>
+            <dt class="field-even">Label</dt>
+                <dd class="field-even">Path of Fluid Partials for all defined content elements
+                </dd>
+            </dl>
+                <div class="confval-description">
+
+        </div>
+    </dd>
+</dl>
+                <dl class="confval">
+    <dt id="confval-fluid-styled-content-styles-templates-layoutrootpath" class="d-flex justify-content-between">
+        <div class="confval-header">
+        <code class="sig-name descname"><span class="pre">styles.templates.layoutRootPath</span></code>
+                <a class="headerlink" href="#confval-fluid-styled-content-styles-templates-layoutrootpath" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-fluid-styled-content-styles-templates-layoutrootpath" data-rstCode=":confval:`styles.templates.layoutRootPath &lt;somemanual:fluid-styled-content-styles-templates-layoutrootpath&gt;`"  title="Reference this configuration value">¶</a>
+        </div>
+        <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
+    </dt>
+    <dd>
+                <dl class="field-list simple">
+                            <dt class="field-even">Type</dt>
+                <dd class="field-even"><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">string</code>
+                </dd>
+            <dt class="field-even">Label</dt>
+                <dd class="field-even">Path of Fluid Layouts for all defined content elements
+                </dd>
+            </dl>
+                <div class="confval-description">
+
+        </div>
+    </dd>
+</dl>
+
+    </section>
+        <!-- content end -->

--- a/tests/Integration/tests/site-set-ext-syntax/input/index.rst
+++ b/tests/Integration/tests/site-set-ext-syntax/input/index.rst
@@ -1,0 +1,9 @@
+
+======================
+Site Set Configuration
+======================
+
+..  typo3:site-set-settings:: EXT:self/_root_include/settings.definitions.yaml
+    :name: fluid-styled-content
+    :type:
+    :Label:

--- a/tests/Integration/tests/site-set-failure/expected/index.html
+++ b/tests/Integration/tests/site-set-failure/expected/index.html
@@ -1,0 +1,9 @@
+<!-- content start -->
+                <section class="section" id="site-set-configuration">
+            <h1>Site Set Configuration<a class="headerlink" href="#site-set-configuration" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+
+
+
+
+    </section>
+        <!-- content end -->

--- a/tests/Integration/tests/site-set-failure/expected/logs/error.log
+++ b/tests/Integration/tests/site-set-failure/expected/logs/error.log
@@ -1,0 +1,3 @@
+app.ERROR: Error while processing "typo3:site-set-settings" directive in "index": Path is outside of the defined root, path: [/../../../tests/Integration/tests/site-set/input/_includes/Sets/FluidStyledContent/settings.definitions.yaml] {"rst-file":"index.rst","currentLineNumber":1} []
+app.ERROR: Download not found "index.rst" {"rst-file":"index"} []
+app.ERROR: Download not found "index.rst" {"rst-file":"index"} []

--- a/tests/Integration/tests/site-set-failure/expected/logs/warning.log
+++ b/tests/Integration/tests/site-set-failure/expected/logs/warning.log
@@ -1,0 +1,3 @@
+app.ERROR: Error while processing "typo3:site-set-settings" directive in "index": Path is outside of the defined root, path: [/../../../tests/Integration/tests/site-set/input/_includes/Sets/FluidStyledContent/settings.definitions.yaml] {"rst-file":"index.rst","currentLineNumber":1} []
+app.ERROR: Download not found "index.rst" {"rst-file":"index"} []
+app.ERROR: Download not found "index.rst" {"rst-file":"index"} []

--- a/tests/Integration/tests/site-set-failure/input/index.rst
+++ b/tests/Integration/tests/site-set-failure/input/index.rst
@@ -1,0 +1,9 @@
+
+======================
+Site Set Configuration
+======================
+
+..  typo3:site-set-settings:: EXT:self/../../../tests/Integration/tests/site-set/input/_includes/Sets/FluidStyledContent/settings.definitions.yaml
+    :name: fluid-styled-content
+    :type:
+    :Label:


### PR DESCRIPTION
By default only files within a "Documentation/" directory can be read by the "typo3:site-set-settings" directive.

However in cases where extensions (Core or third party) provide additional files in their main directory, these should be accessible, to allow reading the ACTUAL file contents, and not requiring a copy to be placed inside Documentation/.

With this patch, a new syntax "EXT:self" allows to refer to this base "/project/" directory as a path prefix, instead of "/project/Documentation/". Other file traversal beyond this is forbidden.