### PR TITLE
[BUGIFIX] Improve margins before and after images and admonitions

### DIFF
--- a/Documentation-rendertest/ImagesAndFigures/Index.rst
+++ b/Documentation-rendertest/ImagesAndFigures/Index.rst
@@ -182,3 +182,48 @@ types[1] or the digital equivalents. Stored letters and other symbols
 (called sorts in mechanical systems and glyphs in digital systems)
 are retrieved and ordered according to a language's orthography for
 visual display.
+
+Images and Admonitions
+======================
+
+..  versionadded:: 13.3
+    EXT:form offers a site set that can be included as described here.
+    quickstartIntegrators are still possible
+    for compatibility reasons but not recommended anymore.
+
+Include the site set "Form Framework" via the :site set in the site
+configuration or the custom
+site package's site set.
+
+..  figure:: /images/q150_cccccc.png
+
+    Add the site set "Form Framework"
+
+..  note:: Include the site set "Form Framework" via the :site set in the site
+    configuration or the custom
+    site package's site set.
+
+..  image:: /images/q150_cccccc.png
+
+..  warning:: Include the site set "Form Framework" via the :site set in the site
+    configuration or the custom
+    site package's site set.
+
+#.  Include the site set
+
+    ..  versionadded:: 13.3
+        EXT:form offers a site set that can be included as described here.
+        quickstartIntegrators are still possible
+        for compatibility reasons but not recommended anymore.
+
+    Include the site set "Form Framework" via the :site set in the site
+    configuration or the custom
+    site package's site set.
+
+    ..  figure:: /images/q150_cccccc.png
+
+        Add the site set "Form Framework"
+
+    ..  note:: Include the site set "Form Framework" via the :site set in the site
+        configuration or the custom
+        site package's site set.

--- a/packages/typo3-docs-theme/assets/sass/components/_images.scss
+++ b/packages/typo3-docs-theme/assets/sass/components/_images.scss
@@ -14,4 +14,7 @@ figure {
             margin-bottom: 0;
         }
     }
+    &:not(:first-child) {
+        @extend .mt-3;
+    }
 }

--- a/packages/typo3-docs-theme/assets/sass/components/directives/_versionchanged.scss
+++ b/packages/typo3-docs-theme/assets/sass/components/directives/_versionchanged.scss
@@ -1,6 +1,7 @@
 @mixin version-changed($border-color: $info, $icon-color: darken($border-color, 15%), $background-color: lighten($border-color, 40%), $text-color: color-contrast($background-color)) {
     border-left: 5px solid $border-color;
     padding-left: 1em;
+    margin: 1em 0;
     .versionmodified {
         .versionicon {
             color: $icon-color;

--- a/packages/typo3-docs-theme/resources/public/css/theme.css
+++ b/packages/typo3-docs-theme/resources/public/css/theme.css
@@ -19379,7 +19379,7 @@ textarea.form-control-lg {
   margin-top: 0.5rem !important;
 }
 
-.mt-3 {
+.mt-3, figure:not(:first-child) {
   margin-top: 1rem !important;
 }
 
@@ -24439,7 +24439,6 @@ code {
 figure figcaption p:last-child {
   margin-bottom: 0;
 }
-
 span[id*=MathJax-Span] {
   color: #212529;
 }
@@ -25227,6 +25226,7 @@ dl.field-list > dt:after {
 .deprecated {
   border-left: 5px solid gray;
   padding-left: 1em;
+  margin: 1em 0;
 }
 .deprecated .versionmodified {
   color: #000;
@@ -25242,6 +25242,7 @@ dl.field-list > dt:after {
 .versionadded {
   border-left: 5px solid #5cb85c;
   padding-left: 1em;
+  margin: 1em 0;
 }
 .versionadded .versionmodified {
   color: #000;
@@ -25257,6 +25258,7 @@ dl.field-list > dt:after {
 .versionchanged {
   border-left: 5px solid #319fc0;
   padding-left: 1em;
+  margin: 1em 0;
 }
 .versionchanged .versionmodified {
   color: #000;


### PR DESCRIPTION
Especially in the context of lists, where last paragraphs miss the margin

Resolves https://github.com/TYPO3-Documentation/render-guides/issues/703

After:

![image](https://github.com/user-attachments/assets/5f621476-94ab-4ef4-99e6-cc7831a3cb39)
