### PR TITLE
[BUGFIX] Fix word wrapping for long confval titles

### DIFF
--- a/packages/typo3-docs-theme/assets/sass/components/directives/_confval.scss
+++ b/packages/typo3-docs-theme/assets/sass/components/directives/_confval.scss
@@ -6,6 +6,8 @@ dl.confval {
     padding-bottom: $spacer * .3;
     border: solid 3px $light;
     border-top-color: $gray-500;
+    word-wrap: anywhere;
+    white-space: normal;
     & > dt {
         display: block;
         background-color: $light;

--- a/packages/typo3-docs-theme/assets/sass/components/directives/_confval.scss
+++ b/packages/typo3-docs-theme/assets/sass/components/directives/_confval.scss
@@ -15,6 +15,8 @@ dl.confval {
         margin-bottom: .75em;
         code {
             color: color-contrast($light);
+            word-wrap: anywhere;
+            white-space: normal;
         }
     }
     & > dd {

--- a/packages/typo3-docs-theme/resources/public/css/theme.css
+++ b/packages/typo3-docs-theme/resources/public/css/theme.css
@@ -25110,6 +25110,8 @@ dl.confval > dt {
 }
 dl.confval > dt code {
   color: #000;
+  word-wrap: anywhere;
+  white-space: normal;
 }
 dl.confval > dd {
   margin-right: 1rem;

--- a/packages/typo3-docs-theme/resources/public/css/theme.css
+++ b/packages/typo3-docs-theme/resources/public/css/theme.css
@@ -25099,6 +25099,8 @@ dl.confval {
   padding-bottom: 0.3rem;
   border: solid 3px #f2f2f2;
   border-top-color: #b3b3b3;
+  word-wrap: anywhere;
+  white-space: normal;
 }
 dl.confval > dt {
   display: block;


### PR DESCRIPTION
Fixes #698
This rather simple fix makes confval titles break preferably by white space, if there is no white space present or word is too long it will break anywhere.

BEFORE:
![obraz](https://github.com/user-attachments/assets/948ce06f-46e1-491d-9986-b5a975f5ef44)

AFTER:
![obraz](https://github.com/user-attachments/assets/a7eede29-3f5a-4dc2-8d19-0315e9ce19c6)

Note: Non-alphanumeric signs like dots or dashes are not taken into account when wrapping - in order to break titles by them, it would be necessary to parse the title beforehand to insert the [Line Break Opportunity `<wbr>` tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/wbr) when needed (e.g. before a dot or a dash), like so:

```html
this.text.breaks.anywhere
this<wbr>.text<wbr>.breaks<wbr>.on<wbr>.dots
```

Here is the preview for titles using the `<wbr>` tags (inserted manually):
```html
email<wbr>.templateRootPaths
expose<wbr>Nonexistent<wbr>User<wbr>In<wbr>Forgot<wbr>Password<wbr>Dialog
```
![obraz](https://github.com/user-attachments/assets/75cb14c6-bc65-4526-b9d5-1e19e8dacf2f)
