### PR TITLE
[BUGFIX] Prevent duplicate escaping of abbreviated defaults

### DIFF
--- a/Documentation-rendertest/SiteSettings/Index.rst
+++ b/Documentation-rendertest/SiteSettings/Index.rst
@@ -1,0 +1,12 @@
+..  include:: /Includes.rst.txt
+..  _site_settings:
+
+=============
+Site settings
+=============
+
+..  literalinclude:: _siteSetSettings.rst.txt
+    :language: rst
+    :caption: Settings.rst
+
+..  include:: _siteSetSettings.rst.txt

--- a/Documentation-rendertest/SiteSettings/_siteSetSettings.rst.txt
+++ b/Documentation-rendertest/SiteSettings/_siteSetSettings.rst.txt
@@ -1,0 +1,5 @@
+..  typo3:site-set-settings:: settings.definitions.yaml
+    :name: my-set
+    :type:
+    :Label: max=20
+    :default: max=10

--- a/Documentation-rendertest/SiteSettings/settings.definitions.yaml
+++ b/Documentation-rendertest/SiteSettings/settings.definitions.yaml
@@ -1,0 +1,22 @@
+settings:
+  website.background.color:
+    label: 'Background color'
+    description: 'This will validate the given color string'
+    type: color
+    default: '#129845'
+
+  website.image.lazyLoading:
+    default: lazy
+    label: 'Browser-native image lazy loading'
+    type: string
+    enum:
+      lazy: 'Lazy'
+      eager: 'Eager'
+      auto: 'Auto'
+    description: 'Can be "lazy" (browsers could choose to load images later), "eager" (load images right away) or "auto" (browser will determine whether the image should be lazy loaded or not)'
+
+  website.rte.allowTags:
+    default: 'a, abbr, acronym, address, article, aside, b, bdo, big, blockquote, br, caption, center, cite, code, col, colgroup, dd, del, dfn, dl, div, dt, em, figure, font, footer, header, h1, h2, h3, h4, h5, h6, hr, i, img, ins, kbd, label, li, link, meta, nav, ol, p, pre, q, s, samp, sdfield, section, small, span, strike, strong, style, sub, sup, table, thead, tbody, tfoot, td, th, tr, title, tt, u, ul, var'
+    label: 'List of allowed HTML tags when rendering RTE content'
+    type: string
+    description: ''

--- a/packages/typo3-docs-theme/assets/sass/components/_table.scss
+++ b/packages/typo3-docs-theme/assets/sass/components/_table.scss
@@ -1,4 +1,7 @@
 .table {
+    td {
+        word-break: break-word;
+    }
     th :last-child,
     td :last-child {
         margin-bottom: 0;

--- a/packages/typo3-docs-theme/resources/public/css/theme.css
+++ b/packages/typo3-docs-theme/resources/public/css/theme.css
@@ -24735,6 +24735,9 @@ article *:hover > a.headerlink:after, article *:hover > a.permalink:after, artic
   padding: 0 !important;
 }
 
+.table td {
+  word-break: break-word;
+}
 .table th :last-child,
 .table td :last-child {
   margin-bottom: 0;

--- a/packages/typo3-docs-theme/resources/template/body/directive/confval-menu.html.twig
+++ b/packages/typo3-docs-theme/resources/template/body/directive/confval-menu.html.twig
@@ -116,21 +116,25 @@
 {% macro renderFieldContent(content, max) -%}
     {%- set rendered_content = renderNode(content) -%}
 
+    {# Strip tags but leave entities encoded #}
     {%- set stripped_content = rendered_content|striptags -%}
-    {%- set content_length = stripped_content|length -%}
+
+    {# Decode entities to get accurate length #}
+    {%- set decoded_content = stripped_content|replace({'&quot;': '"', '&amp;': '&', '&lt;': '<', '&gt;': '>'}) -%}
+    {%- set content_length = decoded_content|length -%}
 
     {# If max is defined and greater than 0, apply truncation #}
     {%- if max is defined and max > 0 -%}
         {% if content_length > max %}
-            <span title="{{ stripped_content|raw }}">
-                {{ stripped_content|slice(0, max)|raw ~ '...' }}
+            <span title="{{ decoded_content }}">
+                {{ decoded_content|slice(0, max) ~ '...' }}
             </span>
         {% else %}
-            <span>{{ stripped_content|raw }}</span>
+            <span>{{ decoded_content }}</span>
         {% endif %}
     {%- else -%}
         {{ rendered_content|raw }}
-    {%- endif -%}
+    {%- endif %}
 {%- endmacro %}
 
 {% macro renderCaption(node) %}


### PR DESCRIPTION
Generally allow word-breaks in table cells