### PR TITLE
[TASK] Support auto-registration of set labels from labels.xlf

### DIFF
--- a/packages/typo3-docs-theme/src/Directives/SiteSetSettingsDirective.php
+++ b/packages/typo3-docs-theme/src/Directives/SiteSetSettingsDirective.php
@@ -83,15 +83,16 @@ final class SiteSetSettingsDirective extends BaseDirective
         }
 
         $labelContents = '';
-        if ($labelsFile) {
-            // Asume all EXT: references are relative to the rendered PROJECT
-            $labelsFile = preg_replace('/^EXT:[^\/]*\//', 'PROJECT:/', $labelsFile);
-            try {
-                $labelContents = $this->loadFileFromDocumentation($blockContext, $labelsFile);
-            } catch (FileLoadingException $exception) {
-                // ignore, config.yaml isn't required
-            }
+        // Asume all EXT: references are relative to the rendered PROJECT
+        $labelsFile = $labelsFile ?
+            preg_replace('/^EXT:[^\/]*\//', 'PROJECT:/', $labelsFile) :
+            dirname($setConfigurationFile) . '/labels.xlf';
+        try {
+            $labelContents = $this->loadFileFromDocumentation($blockContext, $labelsFile);
+        } catch (FileLoadingException $exception) {
+            // ignore, labels.xlf isn't required
         }
+
         $labels = [];
         $descriptions = [];
         if ($labelContents) {

--- a/tests/Integration/tests/site-set-labels-autoload/expected/index.html
+++ b/tests/Integration/tests/site-set-labels-autoload/expected/index.html
@@ -1,0 +1,1188 @@
+<!-- content start -->
+                <section class="section" id="site-set-configuration">
+            <h1>Site Set Configuration<a class="headerlink" href="#site-set-configuration" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+
+
+
+
+
+<div class="table-responsive confval-table" id="confval-menu-felogin">
+    <table class="table table-hover caption-top">        <thead>
+        <tr>
+            <th scope="col">Name</th>
+
+                                    <th scope="col">Type</th>
+
+                                    <th scope="col">Label</th>
+                                    </tr>
+        </thead>
+                        <tr>
+        <td><div class="confval-label ps-0"><a href="#confval-felogin-felogin-pid">felogin.<wbr>pid</a></div></td>
+                    <td>
+                            <code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">string</code>
+                        </td>
+                    <td>
+                                    User Storage Page
+                                </td>
+            </tr>
+
+                        <tr>
+        <td><div class="confval-label ps-0"><a href="#confval-felogin-felogin-recursive">felogin.<wbr>recursive</a></div></td>
+                    <td>
+                            <code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">string</code>
+                        </td>
+                    <td>
+                                    Recursive
+                                </td>
+            </tr>
+
+                        <tr>
+        <td><div class="confval-label ps-0"><a href="#confval-felogin-felogin-showforgotpassword">felogin.<wbr>show<wbr>Forgot<wbr>Password</a></div></td>
+                    <td>
+                            <code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">bool</code>
+                        </td>
+                    <td>
+                                    Display Password Recovery Link
+                                </td>
+            </tr>
+
+                        <tr>
+        <td><div class="confval-label ps-0"><a href="#confval-felogin-felogin-showpermalogin">felogin.<wbr>show<wbr>Perma<wbr>Login</a></div></td>
+                    <td>
+                            <code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">bool</code>
+                        </td>
+                    <td>
+                                    Display Remember Login Option
+                                </td>
+            </tr>
+
+                        <tr>
+        <td><div class="confval-label ps-0"><a href="#confval-felogin-felogin-showlogoutformafterlogin">felogin.<wbr>show<wbr>Logout<wbr>Form<wbr>After<wbr>Login</a></div></td>
+                    <td>
+                            <code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">bool</code>
+                        </td>
+                    <td>
+                                    Disable redirect after successful login, but display logout-form
+                                </td>
+            </tr>
+
+                        <tr>
+        <td><div class="confval-label ps-0"><a href="#confval-felogin-felogin-emailfrom">felogin.<wbr>email<wbr>From</a></div></td>
+                    <td>
+                            <code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">string</code>
+                        </td>
+                    <td>
+                                    Email Sender Address
+                                </td>
+            </tr>
+
+                        <tr>
+        <td><div class="confval-label ps-0"><a href="#confval-felogin-felogin-emailfromname">felogin.<wbr>email<wbr>From<wbr>Name</a></div></td>
+                    <td>
+                            <code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">string</code>
+                        </td>
+                    <td>
+                                    Email Sender Name
+                                </td>
+            </tr>
+
+                        <tr>
+        <td><div class="confval-label ps-0"><a href="#confval-felogin-felogin-replytoemail">felogin.<wbr>reply<wbr>To<wbr>Email</a></div></td>
+                    <td>
+                            <code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">string</code>
+                        </td>
+                    <td>
+                                    Reply-to email Address
+                                </td>
+            </tr>
+
+                        <tr>
+        <td><div class="confval-label ps-0"><a href="#confval-felogin-felogin-dateformat">felogin.<wbr>date<wbr>Format</a></div></td>
+                    <td>
+                            <code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">string</code>
+                        </td>
+                    <td>
+                                    Date format
+                                </td>
+            </tr>
+
+                        <tr>
+        <td><div class="confval-label ps-0"><a href="#confval-felogin-felogin-email-layoutrootpath">felogin.<wbr>email.<wbr>layout<wbr>Root<wbr>Path</a></div></td>
+                    <td>
+                            <code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">string</code>
+                        </td>
+                    <td>
+                                    Layout root path
+                                </td>
+            </tr>
+
+                        <tr>
+        <td><div class="confval-label ps-0"><a href="#confval-felogin-felogin-email-templaterootpath">felogin.<wbr>email.<wbr>template<wbr>Root<wbr>Path</a></div></td>
+                    <td>
+                            <code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">string</code>
+                        </td>
+                    <td>
+                                    Template root path
+                                </td>
+            </tr>
+
+                        <tr>
+        <td><div class="confval-label ps-0"><a href="#confval-felogin-felogin-email-partialrootpath">felogin.<wbr>email.<wbr>partial<wbr>Root<wbr>Path</a></div></td>
+                    <td>
+                            <code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">string</code>
+                        </td>
+                    <td>
+                                    Partial root path
+                                </td>
+            </tr>
+
+                        <tr>
+        <td><div class="confval-label ps-0"><a href="#confval-felogin-felogin-email-templatename">felogin.<wbr>email.<wbr>template<wbr>Name</a></div></td>
+                    <td>
+                            <code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">string</code>
+                        </td>
+                    <td>
+                                    Template name for emails.
+                                </td>
+            </tr>
+
+                        <tr>
+        <td><div class="confval-label ps-0"><a href="#confval-felogin-felogin-redirectmode">felogin.<wbr>redirect<wbr>Mode</a></div></td>
+                    <td>
+                            <code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">string</code>
+                        </td>
+                    <td>
+                                    Redirect Mode
+                                </td>
+            </tr>
+
+                        <tr>
+        <td><div class="confval-label ps-0"><a href="#confval-felogin-felogin-redirectfirstmethod">felogin.<wbr>redirect<wbr>First<wbr>Method</a></div></td>
+                    <td>
+                            <code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">bool</code>
+                        </td>
+                    <td>
+                                    Use First Supported Mode from Selection
+                                </td>
+            </tr>
+
+                        <tr>
+        <td><div class="confval-label ps-0"><a href="#confval-felogin-felogin-redirectpagelogin">felogin.<wbr>redirect<wbr>Page<wbr>Login</a></div></td>
+                    <td>
+                            <code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">int</code>
+                        </td>
+                    <td>
+                                    After Successful Login Redirect to Page
+                                </td>
+            </tr>
+
+                        <tr>
+        <td><div class="confval-label ps-0"><a href="#confval-felogin-felogin-redirectpageloginerror">felogin.<wbr>redirect<wbr>Page<wbr>Login<wbr>Error</a></div></td>
+                    <td>
+                            <code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">int</code>
+                        </td>
+                    <td>
+                                    After Failed Login Redirect to Page
+                                </td>
+            </tr>
+
+                        <tr>
+        <td><div class="confval-label ps-0"><a href="#confval-felogin-felogin-redirectpagelogout">felogin.<wbr>redirect<wbr>Page<wbr>Logout</a></div></td>
+                    <td>
+                            <code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">int</code>
+                        </td>
+                    <td>
+                                    After Logout Redirect to Page
+                                </td>
+            </tr>
+
+                        <tr>
+        <td><div class="confval-label ps-0"><a href="#confval-felogin-felogin-redirectdisable">felogin.<wbr>redirect<wbr>Disable</a></div></td>
+                    <td>
+                            <code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">bool</code>
+                        </td>
+                    <td>
+                                    Disable Redirect
+                                </td>
+            </tr>
+
+                        <tr>
+        <td><div class="confval-label ps-0"><a href="#confval-felogin-felogin-forgotlinkhashvalidtime">felogin.<wbr>forgot<wbr>Link<wbr>Hash<wbr>Valid<wbr>Time</a></div></td>
+                    <td>
+                            <code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">int</code>
+                        </td>
+                    <td>
+                                    Time in hours how long the link for forgot password is valid
+                                </td>
+            </tr>
+
+                        <tr>
+        <td><div class="confval-label ps-0"><a href="#confval-felogin-felogin-domains">felogin.<wbr>domains</a></div></td>
+                    <td>
+                            <code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">string</code>
+                        </td>
+                    <td>
+                                    Allowed Referrer-Redirect-Domains
+                                </td>
+            </tr>
+
+                        <tr>
+        <td><div class="confval-label ps-0"><a href="#confval-felogin-felogin-exposenonexistentuserinforgotpassworddialog">felogin.<wbr>expose<wbr>Nonexistent<wbr>User<wbr>In<wbr>Forgot<wbr>Password<wbr>Dialog</a></div></td>
+                    <td>
+                            <code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">bool</code>
+                        </td>
+                    <td>
+                                    Expose existing users
+                                </td>
+            </tr>
+
+                        <tr>
+        <td><div class="confval-label ps-0"><a href="#confval-felogin-felogin-view-templaterootpath">felogin.<wbr>view.<wbr>template<wbr>Root<wbr>Path</a></div></td>
+                    <td>
+                            <code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">string</code>
+                        </td>
+                    <td>
+                                    Path to template root (frontend)
+                                </td>
+            </tr>
+
+                        <tr>
+        <td><div class="confval-label ps-0"><a href="#confval-felogin-felogin-view-partialrootpath">felogin.<wbr>view.<wbr>partial<wbr>Root<wbr>Path</a></div></td>
+                    <td>
+                            <code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">string</code>
+                        </td>
+                    <td>
+                                    Path to template partials (frontend)
+                                </td>
+            </tr>
+
+                        <tr>
+        <td><div class="confval-label ps-0"><a href="#confval-felogin-felogin-view-layoutrootpath">felogin.<wbr>view.<wbr>layout<wbr>Root<wbr>Path</a></div></td>
+                    <td>
+                            <code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">string</code>
+                        </td>
+                    <td>
+                                    Path to template layouts (frontend)
+                                </td>
+            </tr>
+
+            </table>
+</div>
+            <dl class="confval">
+    <dt id="confval-felogin-felogin-pid" class="d-flex justify-content-between">
+        <div class="confval-header">
+        <code class="sig-name descname"><span class="pre">felogin.<wbr>pid</span></code>
+                <a class="headerlink" href="#confval-felogin-felogin-pid" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-pid" data-rstCode=":confval:`felogin.pid &lt;somemanual:felogin-felogin-pid&gt;`"  title="Reference this configuration value">¶</a>
+        </div>
+        <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
+    </dt>
+    <dd>
+                <dl class="field-list simple">
+                            <dt class="field-even">Type</dt>
+                <dd class="field-even"><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">string</code>
+                </dd>
+                        <dt class="field-odd">Default</dt>
+            <dd class="field-odd"><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">&quot;0&quot;</code>
+            </dd>
+            <dt class="field-even">Label</dt>
+                <dd class="field-even">User Storage Page
+                </dd>
+            </dl>
+                <div class="confval-description">
+
+    <p>Define the Storage Folder with the Website User Records, using a comma separated list or single value</p>
+
+        </div>
+    </dd>
+</dl>
+                <dl class="confval">
+    <dt id="confval-felogin-felogin-recursive" class="d-flex justify-content-between">
+        <div class="confval-header">
+        <code class="sig-name descname"><span class="pre">felogin.<wbr>recursive</span></code>
+                <a class="headerlink" href="#confval-felogin-felogin-recursive" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-recursive" data-rstCode=":confval:`felogin.recursive &lt;somemanual:felogin-felogin-recursive&gt;`"  title="Reference this configuration value">¶</a>
+        </div>
+        <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
+    </dt>
+    <dd>
+                <dl class="field-list simple">
+                            <dt class="field-even">Type</dt>
+                <dd class="field-even"><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">string</code>
+                </dd>
+                        <dt class="field-odd">Default</dt>
+            <dd class="field-odd"><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">&quot;0&quot;</code>
+            </dd>
+            <dt class="field-even">Label</dt>
+                <dd class="field-even">Recursive
+                </dd>
+            <dt class="field-even">Enum</dt>
+                <dd class="field-even">{
+    &quot;0&quot;: &quot;0&quot;,
+    &quot;1&quot;: &quot;1&quot;,
+    &quot;2&quot;: &quot;2&quot;,
+    &quot;3&quot;: &quot;3&quot;,
+    &quot;4&quot;: &quot;4&quot;,
+    &quot;255&quot;: &quot;255&quot;
+}
+                </dd>
+            </dl>
+                <div class="confval-description">
+
+    <p>If set, also subfolder at configured recursive levels of the User Storage Page will be used</p>
+
+        </div>
+    </dd>
+</dl>
+                <dl class="confval">
+    <dt id="confval-felogin-felogin-showforgotpassword" class="d-flex justify-content-between">
+        <div class="confval-header">
+        <code class="sig-name descname"><span class="pre">felogin.<wbr>show<wbr>Forgot<wbr>Password</span></code>
+                <a class="headerlink" href="#confval-felogin-felogin-showforgotpassword" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-showforgotpassword" data-rstCode=":confval:`felogin.showForgotPassword &lt;somemanual:felogin-felogin-showforgotpassword&gt;`"  title="Reference this configuration value">¶</a>
+        </div>
+        <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
+    </dt>
+    <dd>
+                <dl class="field-list simple">
+                            <dt class="field-even">Type</dt>
+                <dd class="field-even"><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">bool</code>
+                </dd>
+                        <dt class="field-odd">Default</dt>
+            <dd class="field-odd"><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">false</code>
+            </dd>
+            <dt class="field-even">Label</dt>
+                <dd class="field-even">Display Password Recovery Link
+                </dd>
+            </dl>
+                <div class="confval-description">
+
+    <p>If set, the section in the template to display the link to the forgot password dialogue is visible.</p>
+
+        </div>
+    </dd>
+</dl>
+                <dl class="confval">
+    <dt id="confval-felogin-felogin-showpermalogin" class="d-flex justify-content-between">
+        <div class="confval-header">
+        <code class="sig-name descname"><span class="pre">felogin.<wbr>show<wbr>Perma<wbr>Login</span></code>
+                <a class="headerlink" href="#confval-felogin-felogin-showpermalogin" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-showpermalogin" data-rstCode=":confval:`felogin.showPermaLogin &lt;somemanual:felogin-felogin-showpermalogin&gt;`"  title="Reference this configuration value">¶</a>
+        </div>
+        <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
+    </dt>
+    <dd>
+                <dl class="field-list simple">
+                            <dt class="field-even">Type</dt>
+                <dd class="field-even"><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">bool</code>
+                </dd>
+                        <dt class="field-odd">Default</dt>
+            <dd class="field-odd"><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">false</code>
+            </dd>
+            <dt class="field-even">Label</dt>
+                <dd class="field-even">Display Remember Login Option
+                </dd>
+            </dl>
+                <div class="confval-description">
+
+    <p>If set, the section in the template to display the option to remember the login (with a cookie) is visible.</p>
+
+        </div>
+    </dd>
+</dl>
+                <dl class="confval">
+    <dt id="confval-felogin-felogin-showlogoutformafterlogin" class="d-flex justify-content-between">
+        <div class="confval-header">
+        <code class="sig-name descname"><span class="pre">felogin.<wbr>show<wbr>Logout<wbr>Form<wbr>After<wbr>Login</span></code>
+                <a class="headerlink" href="#confval-felogin-felogin-showlogoutformafterlogin" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-showlogoutformafterlogin" data-rstCode=":confval:`felogin.showLogoutFormAfterLogin &lt;somemanual:felogin-felogin-showlogoutformafterlogin&gt;`"  title="Reference this configuration value">¶</a>
+        </div>
+        <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
+    </dt>
+    <dd>
+                <dl class="field-list simple">
+                            <dt class="field-even">Type</dt>
+                <dd class="field-even"><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">bool</code>
+                </dd>
+                        <dt class="field-odd">Default</dt>
+            <dd class="field-odd"><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">false</code>
+            </dd>
+            <dt class="field-even">Label</dt>
+                <dd class="field-even">Disable redirect after successful login, but display logout-form
+                </dd>
+            </dl>
+                <div class="confval-description">
+
+    <p>If set, the logout form will be displayed immediately after successful login.</p>
+
+        </div>
+    </dd>
+</dl>
+                <dl class="confval">
+    <dt id="confval-felogin-felogin-emailfrom" class="d-flex justify-content-between">
+        <div class="confval-header">
+        <code class="sig-name descname"><span class="pre">felogin.<wbr>email<wbr>From</span></code>
+                <a class="headerlink" href="#confval-felogin-felogin-emailfrom" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-emailfrom" data-rstCode=":confval:`felogin.emailFrom &lt;somemanual:felogin-felogin-emailfrom&gt;`"  title="Reference this configuration value">¶</a>
+        </div>
+        <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
+    </dt>
+    <dd>
+                <dl class="field-list simple">
+                            <dt class="field-even">Type</dt>
+                <dd class="field-even"><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">string</code>
+                </dd>
+            <dt class="field-even">Label</dt>
+                <dd class="field-even">Email Sender Address
+                </dd>
+            </dl>
+                <div class="confval-description">
+
+    <p>email address used as sender of the change password emails</p>
+
+        </div>
+    </dd>
+</dl>
+                <dl class="confval">
+    <dt id="confval-felogin-felogin-emailfromname" class="d-flex justify-content-between">
+        <div class="confval-header">
+        <code class="sig-name descname"><span class="pre">felogin.<wbr>email<wbr>From<wbr>Name</span></code>
+                <a class="headerlink" href="#confval-felogin-felogin-emailfromname" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-emailfromname" data-rstCode=":confval:`felogin.emailFromName &lt;somemanual:felogin-felogin-emailfromname&gt;`"  title="Reference this configuration value">¶</a>
+        </div>
+        <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
+    </dt>
+    <dd>
+                <dl class="field-list simple">
+                            <dt class="field-even">Type</dt>
+                <dd class="field-even"><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">string</code>
+                </dd>
+            <dt class="field-even">Label</dt>
+                <dd class="field-even">Email Sender Name
+                </dd>
+            </dl>
+                <div class="confval-description">
+
+    <p>Name used as sender of the change password emails</p>
+
+        </div>
+    </dd>
+</dl>
+                <dl class="confval">
+    <dt id="confval-felogin-felogin-replytoemail" class="d-flex justify-content-between">
+        <div class="confval-header">
+        <code class="sig-name descname"><span class="pre">felogin.<wbr>reply<wbr>To<wbr>Email</span></code>
+                <a class="headerlink" href="#confval-felogin-felogin-replytoemail" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-replytoemail" data-rstCode=":confval:`felogin.replyToEmail &lt;somemanual:felogin-felogin-replytoemail&gt;`"  title="Reference this configuration value">¶</a>
+        </div>
+        <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
+    </dt>
+    <dd>
+                <dl class="field-list simple">
+                            <dt class="field-even">Type</dt>
+                <dd class="field-even"><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">string</code>
+                </dd>
+            <dt class="field-even">Label</dt>
+                <dd class="field-even">Reply-to email Address
+                </dd>
+            </dl>
+                <div class="confval-description">
+
+    <p>Reply-to address used in the change password emails</p>
+
+        </div>
+    </dd>
+</dl>
+                <dl class="confval">
+    <dt id="confval-felogin-felogin-dateformat" class="d-flex justify-content-between">
+        <div class="confval-header">
+        <code class="sig-name descname"><span class="pre">felogin.<wbr>date<wbr>Format</span></code>
+                <a class="headerlink" href="#confval-felogin-felogin-dateformat" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-dateformat" data-rstCode=":confval:`felogin.dateFormat &lt;somemanual:felogin-felogin-dateformat&gt;`"  title="Reference this configuration value">¶</a>
+        </div>
+        <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
+    </dt>
+    <dd>
+                <dl class="field-list simple">
+                            <dt class="field-even">Type</dt>
+                <dd class="field-even"><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">string</code>
+                </dd>
+                        <dt class="field-odd">Default</dt>
+            <dd class="field-odd"><code class="code-inline code-inline-long"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">&quot;Y-<wbr>m-<wbr>d H:<wbr>i&quot;</code>
+            </dd>
+            <dt class="field-even">Label</dt>
+                <dd class="field-even">Date format
+                </dd>
+            </dl>
+                <div class="confval-description">
+
+    <p>Format for the link is valid until message (forgot password email)</p>
+
+        </div>
+    </dd>
+</dl>
+                <dl class="confval">
+    <dt id="confval-felogin-felogin-email-layoutrootpath" class="d-flex justify-content-between">
+        <div class="confval-header">
+        <code class="sig-name descname"><span class="pre">felogin.<wbr>email.<wbr>layout<wbr>Root<wbr>Path</span></code>
+                <a class="headerlink" href="#confval-felogin-felogin-email-layoutrootpath" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-email-layoutrootpath" data-rstCode=":confval:`felogin.email.layoutRootPath &lt;somemanual:felogin-felogin-email-layoutrootpath&gt;`"  title="Reference this configuration value">¶</a>
+        </div>
+        <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
+    </dt>
+    <dd>
+                <dl class="field-list simple">
+                            <dt class="field-even">Type</dt>
+                <dd class="field-even"><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">string</code>
+                </dd>
+            <dt class="field-even">Label</dt>
+                <dd class="field-even">Layout root path
+                </dd>
+            </dl>
+                <div class="confval-description">
+
+    <p>Path to layout directory used for emails</p>
+
+        </div>
+    </dd>
+</dl>
+                <dl class="confval">
+    <dt id="confval-felogin-felogin-email-templaterootpath" class="d-flex justify-content-between">
+        <div class="confval-header">
+        <code class="sig-name descname"><span class="pre">felogin.<wbr>email.<wbr>template<wbr>Root<wbr>Path</span></code>
+                <a class="headerlink" href="#confval-felogin-felogin-email-templaterootpath" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-email-templaterootpath" data-rstCode=":confval:`felogin.email.templateRootPath &lt;somemanual:felogin-felogin-email-templaterootpath&gt;`"  title="Reference this configuration value">¶</a>
+        </div>
+        <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
+    </dt>
+    <dd>
+                <dl class="field-list simple">
+                            <dt class="field-even">Type</dt>
+                <dd class="field-even"><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">string</code>
+                </dd>
+                        <dt class="field-odd">Default</dt>
+            <dd class="field-odd"><code class="code-inline code-inline-long"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">&quot;EXT:<wbr>felogin/<wbr>Resources/<wbr>Private/<wbr>Email/<wbr>Templates/&quot;</code>
+            </dd>
+            <dt class="field-even">Label</dt>
+                <dd class="field-even">Template root path
+                </dd>
+            </dl>
+                <div class="confval-description">
+
+    <p>Path to template directory used for emails</p>
+
+        </div>
+    </dd>
+</dl>
+                <dl class="confval">
+    <dt id="confval-felogin-felogin-email-partialrootpath" class="d-flex justify-content-between">
+        <div class="confval-header">
+        <code class="sig-name descname"><span class="pre">felogin.<wbr>email.<wbr>partial<wbr>Root<wbr>Path</span></code>
+                <a class="headerlink" href="#confval-felogin-felogin-email-partialrootpath" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-email-partialrootpath" data-rstCode=":confval:`felogin.email.partialRootPath &lt;somemanual:felogin-felogin-email-partialrootpath&gt;`"  title="Reference this configuration value">¶</a>
+        </div>
+        <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
+    </dt>
+    <dd>
+                <dl class="field-list simple">
+                            <dt class="field-even">Type</dt>
+                <dd class="field-even"><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">string</code>
+                </dd>
+            <dt class="field-even">Label</dt>
+                <dd class="field-even">Partial root path
+                </dd>
+            </dl>
+                <div class="confval-description">
+
+    <p>Path to partial directory used for emails</p>
+
+        </div>
+    </dd>
+</dl>
+                <dl class="confval">
+    <dt id="confval-felogin-felogin-email-templatename" class="d-flex justify-content-between">
+        <div class="confval-header">
+        <code class="sig-name descname"><span class="pre">felogin.<wbr>email.<wbr>template<wbr>Name</span></code>
+                <a class="headerlink" href="#confval-felogin-felogin-email-templatename" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-email-templatename" data-rstCode=":confval:`felogin.email.templateName &lt;somemanual:felogin-felogin-email-templatename&gt;`"  title="Reference this configuration value">¶</a>
+        </div>
+        <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
+    </dt>
+    <dd>
+                <dl class="field-list simple">
+                            <dt class="field-even">Type</dt>
+                <dd class="field-even"><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">string</code>
+                </dd>
+                        <dt class="field-odd">Default</dt>
+            <dd class="field-odd"><code class="code-inline code-inline-long"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">&quot;Password<wbr>Recovery&quot;</code>
+            </dd>
+            <dt class="field-even">Label</dt>
+                <dd class="field-even">Template name for emails.
+                </dd>
+            </dl>
+                <div class="confval-description">
+
+    <p>HTML emails get the .html file extension, plaintext emails get the .txt file extension.</p>
+
+        </div>
+    </dd>
+</dl>
+                <dl class="confval">
+    <dt id="confval-felogin-felogin-redirectmode" class="d-flex justify-content-between">
+        <div class="confval-header">
+        <code class="sig-name descname"><span class="pre">felogin.<wbr>redirect<wbr>Mode</span></code>
+                <a class="headerlink" href="#confval-felogin-felogin-redirectmode" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-redirectmode" data-rstCode=":confval:`felogin.redirectMode &lt;somemanual:felogin-felogin-redirectmode&gt;`"  title="Reference this configuration value">¶</a>
+        </div>
+        <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
+    </dt>
+    <dd>
+                <dl class="field-list simple">
+                            <dt class="field-even">Type</dt>
+                <dd class="field-even"><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">string</code>
+                </dd>
+            <dt class="field-even">Label</dt>
+                <dd class="field-even">Redirect Mode
+                </dd>
+            </dl>
+                <div class="confval-description">
+
+    <p>Comma separated list of redirect modes. Possible values: groupLogin, userLogin, login, getpost, referer, refererDomains, loginError, logout. Warning: redirects only work if neither the plugin nor the page it is displayed on are set to `hide at login`.</p>
+
+        </div>
+    </dd>
+</dl>
+                <dl class="confval">
+    <dt id="confval-felogin-felogin-redirectfirstmethod" class="d-flex justify-content-between">
+        <div class="confval-header">
+        <code class="sig-name descname"><span class="pre">felogin.<wbr>redirect<wbr>First<wbr>Method</span></code>
+                <a class="headerlink" href="#confval-felogin-felogin-redirectfirstmethod" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-redirectfirstmethod" data-rstCode=":confval:`felogin.redirectFirstMethod &lt;somemanual:felogin-felogin-redirectfirstmethod&gt;`"  title="Reference this configuration value">¶</a>
+        </div>
+        <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
+    </dt>
+    <dd>
+                <dl class="field-list simple">
+                            <dt class="field-even">Type</dt>
+                <dd class="field-even"><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">bool</code>
+                </dd>
+                        <dt class="field-odd">Default</dt>
+            <dd class="field-odd"><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">false</code>
+            </dd>
+            <dt class="field-even">Label</dt>
+                <dd class="field-even">Use First Supported Mode from Selection
+                </dd>
+            </dl>
+                <div class="confval-description">
+
+    <p>If set the first method from redirectMode which is possible will be used</p>
+
+        </div>
+    </dd>
+</dl>
+                <dl class="confval">
+    <dt id="confval-felogin-felogin-redirectpagelogin" class="d-flex justify-content-between">
+        <div class="confval-header">
+        <code class="sig-name descname"><span class="pre">felogin.<wbr>redirect<wbr>Page<wbr>Login</span></code>
+                <a class="headerlink" href="#confval-felogin-felogin-redirectpagelogin" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-redirectpagelogin" data-rstCode=":confval:`felogin.redirectPageLogin &lt;somemanual:felogin-felogin-redirectpagelogin&gt;`"  title="Reference this configuration value">¶</a>
+        </div>
+        <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
+    </dt>
+    <dd>
+                <dl class="field-list simple">
+                            <dt class="field-even">Type</dt>
+                <dd class="field-even"><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">int</code>
+                </dd>
+                        <dt class="field-odd">Default</dt>
+            <dd class="field-odd"><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">0</code>
+            </dd>
+            <dt class="field-even">Label</dt>
+                <dd class="field-even">After Successful Login Redirect to Page
+                </dd>
+            </dl>
+                <div class="confval-description">
+
+    <p>Page id to redirect to after Login</p>
+
+        </div>
+    </dd>
+</dl>
+                <dl class="confval">
+    <dt id="confval-felogin-felogin-redirectpageloginerror" class="d-flex justify-content-between">
+        <div class="confval-header">
+        <code class="sig-name descname"><span class="pre">felogin.<wbr>redirect<wbr>Page<wbr>Login<wbr>Error</span></code>
+                <a class="headerlink" href="#confval-felogin-felogin-redirectpageloginerror" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-redirectpageloginerror" data-rstCode=":confval:`felogin.redirectPageLoginError &lt;somemanual:felogin-felogin-redirectpageloginerror&gt;`"  title="Reference this configuration value">¶</a>
+        </div>
+        <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
+    </dt>
+    <dd>
+                <dl class="field-list simple">
+                            <dt class="field-even">Type</dt>
+                <dd class="field-even"><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">int</code>
+                </dd>
+                        <dt class="field-odd">Default</dt>
+            <dd class="field-odd"><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">0</code>
+            </dd>
+            <dt class="field-even">Label</dt>
+                <dd class="field-even">After Failed Login Redirect to Page
+                </dd>
+            </dl>
+                <div class="confval-description">
+
+    <p>Page id to redirect to after Login Error</p>
+
+        </div>
+    </dd>
+</dl>
+                <dl class="confval">
+    <dt id="confval-felogin-felogin-redirectpagelogout" class="d-flex justify-content-between">
+        <div class="confval-header">
+        <code class="sig-name descname"><span class="pre">felogin.<wbr>redirect<wbr>Page<wbr>Logout</span></code>
+                <a class="headerlink" href="#confval-felogin-felogin-redirectpagelogout" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-redirectpagelogout" data-rstCode=":confval:`felogin.redirectPageLogout &lt;somemanual:felogin-felogin-redirectpagelogout&gt;`"  title="Reference this configuration value">¶</a>
+        </div>
+        <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
+    </dt>
+    <dd>
+                <dl class="field-list simple">
+                            <dt class="field-even">Type</dt>
+                <dd class="field-even"><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">int</code>
+                </dd>
+                        <dt class="field-odd">Default</dt>
+            <dd class="field-odd"><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">0</code>
+            </dd>
+            <dt class="field-even">Label</dt>
+                <dd class="field-even">After Logout Redirect to Page
+                </dd>
+            </dl>
+                <div class="confval-description">
+
+    <p>Page id to redirect to after Logout</p>
+
+        </div>
+    </dd>
+</dl>
+                <dl class="confval">
+    <dt id="confval-felogin-felogin-redirectdisable" class="d-flex justify-content-between">
+        <div class="confval-header">
+        <code class="sig-name descname"><span class="pre">felogin.<wbr>redirect<wbr>Disable</span></code>
+                <a class="headerlink" href="#confval-felogin-felogin-redirectdisable" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-redirectdisable" data-rstCode=":confval:`felogin.redirectDisable &lt;somemanual:felogin-felogin-redirectdisable&gt;`"  title="Reference this configuration value">¶</a>
+        </div>
+        <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
+    </dt>
+    <dd>
+                <dl class="field-list simple">
+                            <dt class="field-even">Type</dt>
+                <dd class="field-even"><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">bool</code>
+                </dd>
+                        <dt class="field-odd">Default</dt>
+            <dd class="field-odd"><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">false</code>
+            </dd>
+            <dt class="field-even">Label</dt>
+                <dd class="field-even">Disable Redirect
+                </dd>
+            </dl>
+                <div class="confval-description">
+
+    <p>If set redirecting is disabled</p>
+
+        </div>
+    </dd>
+</dl>
+                <dl class="confval">
+    <dt id="confval-felogin-felogin-forgotlinkhashvalidtime" class="d-flex justify-content-between">
+        <div class="confval-header">
+        <code class="sig-name descname"><span class="pre">felogin.<wbr>forgot<wbr>Link<wbr>Hash<wbr>Valid<wbr>Time</span></code>
+                <a class="headerlink" href="#confval-felogin-felogin-forgotlinkhashvalidtime" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-forgotlinkhashvalidtime" data-rstCode=":confval:`felogin.forgotLinkHashValidTime &lt;somemanual:felogin-felogin-forgotlinkhashvalidtime&gt;`"  title="Reference this configuration value">¶</a>
+        </div>
+        <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
+    </dt>
+    <dd>
+                <dl class="field-list simple">
+                            <dt class="field-even">Type</dt>
+                <dd class="field-even"><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">int</code>
+                </dd>
+                        <dt class="field-odd">Default</dt>
+            <dd class="field-odd"><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">12</code>
+            </dd>
+            <dt class="field-even">Label</dt>
+                <dd class="field-even">Time in hours how long the link for forgot password is valid
+                </dd>
+            </dl>
+                <div class="confval-description">
+
+    <p>How many hours the link for forgot password is valid</p>
+
+        </div>
+    </dd>
+</dl>
+                <dl class="confval">
+    <dt id="confval-felogin-felogin-domains" class="d-flex justify-content-between">
+        <div class="confval-header">
+        <code class="sig-name descname"><span class="pre">felogin.<wbr>domains</span></code>
+                <a class="headerlink" href="#confval-felogin-felogin-domains" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-domains" data-rstCode=":confval:`felogin.domains &lt;somemanual:felogin-felogin-domains&gt;`"  title="Reference this configuration value">¶</a>
+        </div>
+        <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
+    </dt>
+    <dd>
+                <dl class="field-list simple">
+                            <dt class="field-even">Type</dt>
+                <dd class="field-even"><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">string</code>
+                </dd>
+            <dt class="field-even">Label</dt>
+                <dd class="field-even">Allowed Referrer-Redirect-Domains
+                </dd>
+            </dl>
+                <div class="confval-description">
+
+    <p>Comma separated list of domains which are allowed for the referrer redirect mode</p>
+
+        </div>
+    </dd>
+</dl>
+                <dl class="confval">
+    <dt id="confval-felogin-felogin-exposenonexistentuserinforgotpassworddialog" class="d-flex justify-content-between">
+        <div class="confval-header">
+        <code class="sig-name descname"><span class="pre">felogin.<wbr>expose<wbr>Nonexistent<wbr>User<wbr>In<wbr>Forgot<wbr>Password<wbr>Dialog</span></code>
+                <a class="headerlink" href="#confval-felogin-felogin-exposenonexistentuserinforgotpassworddialog" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-exposenonexistentuserinforgotpassworddialog" data-rstCode=":confval:`felogin.exposeNonexistentUserInForgotPasswordDialog &lt;somemanual:felogin-felogin-exposenonexistentuserinforgotpassworddialog&gt;`"  title="Reference this configuration value">¶</a>
+        </div>
+        <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
+    </dt>
+    <dd>
+                <dl class="field-list simple">
+                            <dt class="field-even">Type</dt>
+                <dd class="field-even"><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">bool</code>
+                </dd>
+                        <dt class="field-odd">Default</dt>
+            <dd class="field-odd"><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">false</code>
+            </dd>
+            <dt class="field-even">Label</dt>
+                <dd class="field-even">Expose existing users
+                </dd>
+            </dl>
+                <div class="confval-description">
+
+    <p>Expose the information on whether or not the account for which a new password was requested exists. By default, that information is not disclosed for privacy reasons.</p>
+
+        </div>
+    </dd>
+</dl>
+                <dl class="confval">
+    <dt id="confval-felogin-felogin-view-templaterootpath" class="d-flex justify-content-between">
+        <div class="confval-header">
+        <code class="sig-name descname"><span class="pre">felogin.<wbr>view.<wbr>template<wbr>Root<wbr>Path</span></code>
+                <a class="headerlink" href="#confval-felogin-felogin-view-templaterootpath" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-view-templaterootpath" data-rstCode=":confval:`felogin.view.templateRootPath &lt;somemanual:felogin-felogin-view-templaterootpath&gt;`"  title="Reference this configuration value">¶</a>
+        </div>
+        <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
+    </dt>
+    <dd>
+                <dl class="field-list simple">
+                            <dt class="field-even">Type</dt>
+                <dd class="field-even"><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">string</code>
+                </dd>
+            <dt class="field-even">Label</dt>
+                <dd class="field-even">Path to template root (frontend)
+                </dd>
+            </dl>
+                <div class="confval-description">
+
+    <p>Path to template directory used for the plugin in the frontend. Extends the default template location.</p>
+
+        </div>
+    </dd>
+</dl>
+                <dl class="confval">
+    <dt id="confval-felogin-felogin-view-partialrootpath" class="d-flex justify-content-between">
+        <div class="confval-header">
+        <code class="sig-name descname"><span class="pre">felogin.<wbr>view.<wbr>partial<wbr>Root<wbr>Path</span></code>
+                <a class="headerlink" href="#confval-felogin-felogin-view-partialrootpath" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-view-partialrootpath" data-rstCode=":confval:`felogin.view.partialRootPath &lt;somemanual:felogin-felogin-view-partialrootpath&gt;`"  title="Reference this configuration value">¶</a>
+        </div>
+        <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
+    </dt>
+    <dd>
+                <dl class="field-list simple">
+                            <dt class="field-even">Type</dt>
+                <dd class="field-even"><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">string</code>
+                </dd>
+            <dt class="field-even">Label</dt>
+                <dd class="field-even">Path to template partials (frontend)
+                </dd>
+            </dl>
+                <div class="confval-description">
+
+    <p>Path to partial directory for the plugin in the frontend. Extends the default partial location.</p>
+
+        </div>
+    </dd>
+</dl>
+                <dl class="confval">
+    <dt id="confval-felogin-felogin-view-layoutrootpath" class="d-flex justify-content-between">
+        <div class="confval-header">
+        <code class="sig-name descname"><span class="pre">felogin.<wbr>view.<wbr>layout<wbr>Root<wbr>Path</span></code>
+                <a class="headerlink" href="#confval-felogin-felogin-view-layoutrootpath" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-view-layoutrootpath" data-rstCode=":confval:`felogin.view.layoutRootPath &lt;somemanual:felogin-felogin-view-layoutrootpath&gt;`"  title="Reference this configuration value">¶</a>
+        </div>
+        <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
+    </dt>
+    <dd>
+                <dl class="field-list simple">
+                            <dt class="field-even">Type</dt>
+                <dd class="field-even"><code class="code-inline"
+          translate="no"
+          aria-description=""
+          aria-details=""
+          data-bs-html="true">string</code>
+                </dd>
+            <dt class="field-even">Label</dt>
+                <dd class="field-even">Path to template layouts (frontend)
+                </dd>
+            </dl>
+                <div class="confval-description">
+
+    <p>Path to layout directory used for the plugin in the frontend. Can be used to introduce a custom layout.</p>
+
+        </div>
+    </dd>
+</dl>
+
+    </section>
+        <!-- content end -->

--- a/tests/Integration/tests/site-set-labels-autoload/input/_includes/Configuration/Sets/Felogin/config.yaml
+++ b/tests/Integration/tests/site-set-labels-autoload/input/_includes/Configuration/Sets/Felogin/config.yaml
@@ -1,0 +1,1 @@
+name: typo3/felogin

--- a/tests/Integration/tests/site-set-labels-autoload/input/_includes/Configuration/Sets/Felogin/labels.xlf
+++ b/tests/Integration/tests/site-set-labels-autoload/input/_includes/Configuration/Sets/Felogin/labels.xlf
@@ -1,0 +1,161 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" datatype="plaintext" original="EXT:felogin/Resources/Private/Language/locallang_set.xlf" date="2024-09-05T08:00:00Z" product-name="felogin">
+        <header/>
+        <body>
+            <trans-unit id="label" resname="label">
+                <source>Frontend Login</source>
+            </trans-unit>
+            <trans-unit id="settings.felogin.pid" resname="settings.felogin.pid">
+                <source>User Storage Page</source>
+            </trans-unit>
+            <trans-unit id="settings.description.felogin.pid" resname="settings.description.felogin.pid">
+                <source>Define the Storage Folder with the Website User Records, using a comma separated list or single value</source>
+            </trans-unit>
+            <trans-unit id="settings.felogin.recursive" resname="settings.felogin.recursive">
+                <source>Recursive</source>
+            </trans-unit>
+            <trans-unit id="settings.description.felogin.recursive" resname="settings.description.felogin.recursive">
+                <source>If set, also subfolder at configured recursive levels of the User Storage Page will be used</source>
+            </trans-unit>
+            <trans-unit id="settings.felogin.showForgotPassword" resname="settings.felogin.showForgotPassword">
+                <source>Display Password Recovery Link</source>
+            </trans-unit>
+            <trans-unit id="settings.description.felogin.showForgotPassword" resname="settings.description.felogin.showForgotPassword">
+                <source>If set, the section in the template to display the link to the forgot password dialogue is visible.</source>
+            </trans-unit>
+            <trans-unit id="settings.felogin.showPermaLogin" resname="settings.felogin.showPermaLogin">
+                <source>Display Remember Login Option</source>
+            </trans-unit>
+            <trans-unit id="settings.description.felogin.showPermaLogin" resname="settings.description.felogin.showPermaLogin">
+                <source>If set, the section in the template to display the option to remember the login (with a cookie) is visible.</source>
+            </trans-unit>
+            <trans-unit id="settings.felogin.showLogoutFormAfterLogin" resname="settings.felogin.showLogoutFormAfterLogin">
+                <source>Disable redirect after successful login, but display logout-form</source>
+            </trans-unit>
+            <trans-unit id="settings.description.felogin.showLogoutFormAfterLogin" resname="settings.description.felogin.showLogoutFormAfterLogin">
+                <source>If set, the logout form will be displayed immediately after successful login.</source>
+            </trans-unit>
+            <trans-unit id="settings.felogin.emailFrom" resname="settings.felogin.emailFrom">
+                <source>Email Sender Address</source>
+            </trans-unit>
+            <trans-unit id="settings.description.felogin.emailFrom" resname="settings.description.felogin.emailFrom">
+                <source>email address used as sender of the change password emails</source>
+            </trans-unit>
+            <trans-unit id="settings.felogin.emailFromName" resname="settings.felogin.emailFromName">
+                <source>Email Sender Name</source>
+            </trans-unit>
+            <trans-unit id="settings.description.felogin.emailFromName" resname="settings.description.felogin.emailFromName">
+                <source>Name used as sender of the change password emails</source>
+            </trans-unit>
+            <trans-unit id="settings.felogin.replyToEmail" resname="settings.felogin.replyToEmail">
+                <source>Reply-to email Address</source>
+            </trans-unit>
+            <trans-unit id="settings.description.felogin.replyToEmail" resname="settings.description.felogin.replyToEmail">
+                <source>Reply-to address used in the change password emails</source>
+            </trans-unit>
+            <trans-unit id="settings.felogin.dateFormat" resname="settings.felogin.dateFormat">
+                <source>Date format</source>
+            </trans-unit>
+            <trans-unit id="settings.description.felogin.dateFormat" resname="settings.description.felogin.dateFormat">
+                <source>Format for the link is valid until message (forgot password email)</source>
+            </trans-unit>
+            <trans-unit id="settings.felogin.email.layoutRootPath" resname="settings.felogin.email.layoutRootPath">
+                <source>Layout root path</source>
+            </trans-unit>
+            <trans-unit id="settings.description.felogin.email.layoutRootPath" resname="settings.description.felogin.email.layoutRootPath">
+                <source>Path to layout directory used for emails</source>
+            </trans-unit>
+            <trans-unit id="settings.felogin.email.templateRootPath" resname="settings.felogin.email.templateRootPath">
+                <source>Template root path</source>
+            </trans-unit>
+            <trans-unit id="settings.description.felogin.email.templateRootPath" resname="settings.description.felogin.email.templateRootPath">
+                <source>Path to template directory used for emails</source>
+            </trans-unit>
+            <trans-unit id="settings.felogin.email.partialRootPath" resname="settings.felogin.email.partialRootPath">
+                <source>Partial root path</source>
+            </trans-unit>
+            <trans-unit id="settings.description.felogin.email.partialRootPath" resname="settings.description.felogin.email.partialRootPath">
+                <source>Path to partial directory used for emails</source>
+            </trans-unit>
+            <trans-unit id="settings.felogin.email.templateName" resname="settings.felogin.email.templateName">
+                <source>Template name for emails.</source>
+            </trans-unit>
+            <trans-unit id="settings.description.felogin.email.templateName" resname="settings.description.felogin.email.templateName">
+                <source>HTML emails get the .html file extension, plaintext emails get the .txt file extension.</source>
+            </trans-unit>
+            <trans-unit id="settings.felogin.redirectMode" resname="settings.felogin.redirectMode">
+                <source>Redirect Mode</source>
+            </trans-unit>
+            <trans-unit id="settings.description.felogin.redirectMode" resname="settings.description.felogin.redirectMode">
+                <source>Comma separated list of redirect modes. Possible values: groupLogin, userLogin, login, getpost, referer, refererDomains, loginError, logout. Warning: redirects only work if neither the plugin nor the page it is displayed on are set to `hide at login`.</source>
+            </trans-unit>
+            <trans-unit id="settings.felogin.redirectFirstMethod" resname="settings.felogin.redirectFirstMethod">
+                <source>Use First Supported Mode from Selection</source>
+            </trans-unit>
+            <trans-unit id="settings.description.felogin.redirectFirstMethod" resname="settings.description.felogin.redirectFirstMethod">
+                <source>If set the first method from redirectMode which is possible will be used</source>
+            </trans-unit>
+            <trans-unit id="settings.felogin.redirectPageLogin" resname="settings.felogin.redirectPageLogin">
+                <source>After Successful Login Redirect to Page</source>
+            </trans-unit>
+            <trans-unit id="settings.description.felogin.redirectPageLogin" resname="settings.description.felogin.redirectPageLogin">
+                <source>Page id to redirect to after Login</source>
+            </trans-unit>
+            <trans-unit id="settings.felogin.redirectPageLoginError" resname="settings.felogin.redirectPageLoginError">
+                <source>After Failed Login Redirect to Page</source>
+            </trans-unit>
+            <trans-unit id="settings.description.felogin.redirectPageLoginError" resname="settings.description.felogin.redirectPageLoginError">
+                <source>Page id to redirect to after Login Error</source>
+            </trans-unit>
+            <trans-unit id="settings.felogin.redirectPageLogout" resname="settings.felogin.redirectPageLogout">
+                <source>After Logout Redirect to Page</source>
+            </trans-unit>
+            <trans-unit id="settings.description.felogin.redirectPageLogout" resname="settings.description.felogin.redirectPageLogout">
+                <source>Page id to redirect to after Logout</source>
+            </trans-unit>
+            <trans-unit id="settings.felogin.redirectDisable" resname="settings.felogin.redirectDisable">
+                <source>Disable Redirect</source>
+            </trans-unit>
+            <trans-unit id="settings.description.felogin.redirectDisable" resname="settings.description.felogin.redirectDisable">
+                <source>If set redirecting is disabled</source>
+            </trans-unit>
+            <trans-unit id="settings.felogin.forgotLinkHashValidTime" resname="settings.felogin.forgotLinkHashValidTime">
+                <source>Time in hours how long the link for forgot password is valid</source>
+            </trans-unit>
+            <trans-unit id="settings.description.felogin.forgotLinkHashValidTime" resname="settings.description.felogin.forgotLinkHashValidTime">
+                <source>How many hours the link for forgot password is valid</source>
+            </trans-unit>
+            <trans-unit id="settings.felogin.domains" resname="settings.felogin.domains">
+                <source>Allowed Referrer-Redirect-Domains</source>
+            </trans-unit>
+            <trans-unit id="settings.description.felogin.domains" resname="settings.description.felogin.domains">
+                <source>Comma separated list of domains which are allowed for the referrer redirect mode</source>
+            </trans-unit>
+            <trans-unit id="settings.felogin.exposeNonexistentUserInForgotPasswordDialog" resname="settings.felogin.exposeNonexistentUserInForgotPasswordDialog">
+                <source>Expose existing users</source>
+            </trans-unit>
+            <trans-unit id="settings.description.felogin.exposeNonexistentUserInForgotPasswordDialog" resname="settings.description.felogin.exposeNonexistentUserInForgotPasswordDialog">
+                <source>Expose the information on whether or not the account for which a new password was requested exists. By default, that information is not disclosed for privacy reasons.</source>
+            </trans-unit>
+            <trans-unit id="settings.felogin.view.templateRootPath" resname="settings.felogin.view.templateRootPath">
+                <source>Path to template root (frontend)</source>
+            </trans-unit>
+            <trans-unit id="settings.description.felogin.view.templateRootPath" resname="settings.description.felogin.view.templateRootPath">
+                <source>Path to template directory used for the plugin in the frontend. Extends the default template location.</source>
+            </trans-unit>
+            <trans-unit id="settings.felogin.view.partialRootPath" resname="settings.felogin.view.partialRootPath">
+                <source>Path to template partials (frontend)</source>
+            </trans-unit>
+            <trans-unit id="settings.description.felogin.view.partialRootPath" resname="settings.description.felogin.view.partialRootPath">
+                <source>Path to partial directory for the plugin in the frontend. Extends the default partial location.</source>
+            </trans-unit>
+            <trans-unit id="settings.felogin.view.layoutRootPath" resname="settings.felogin.view.layoutRootPath">
+                <source>Path to template layouts (frontend)</source>
+            </trans-unit>
+            <trans-unit id="settings.description.felogin.view.layoutRootPath" resname="settings.description.felogin.view.layoutRootPath">
+                <source>Path to layout directory used for the plugin in the frontend. Can be used to introduce a custom layout.</source>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/tests/Integration/tests/site-set-labels-autoload/input/_includes/Configuration/Sets/Felogin/settings.definitions.yaml
+++ b/tests/Integration/tests/site-set-labels-autoload/input/_includes/Configuration/Sets/Felogin/settings.definitions.yaml
@@ -1,0 +1,83 @@
+settings:
+  felogin.pid:
+    default: '0'
+    type: string
+  felogin.recursive:
+    default: '0'
+    type: string
+    enum:
+      '0': '0'
+      '1': '1'
+      '2': '2'
+      '3': '3'
+      '4': '4'
+      '255': '255'
+  felogin.showForgotPassword:
+    default: false
+    type: bool
+  felogin.showPermaLogin:
+    default: false
+    type: bool
+  felogin.showLogoutFormAfterLogin:
+    default: false
+    type: bool
+  felogin.emailFrom:
+    default: ''
+    type: string
+  felogin.emailFromName:
+    default: ''
+    type: string
+  felogin.replyToEmail:
+    default: ''
+    type: string
+  felogin.dateFormat:
+    default: 'Y-m-d H:i'
+    type: string
+  felogin.email.layoutRootPath:
+    default: ''
+    type: string
+  felogin.email.templateRootPath:
+    default: 'EXT:felogin/Resources/Private/Email/Templates/'
+    type: string
+  felogin.email.partialRootPath:
+    default: ''
+    type: string
+  felogin.email.templateName:
+    default: PasswordRecovery
+    type: string
+  felogin.redirectMode:
+    default: ''
+    type: string
+  felogin.redirectFirstMethod:
+    default: false
+    type: bool
+  felogin.redirectPageLogin:
+    default: 0
+    type: int
+  felogin.redirectPageLoginError:
+    default: 0
+    type: int
+  felogin.redirectPageLogout:
+    default: 0
+    type: int
+  felogin.redirectDisable:
+    default: false
+    type: bool
+  felogin.forgotLinkHashValidTime:
+    default: 12
+    type: int
+  felogin.domains:
+    default: ''
+    type: string
+  felogin.exposeNonexistentUserInForgotPasswordDialog:
+    default: false
+    type: bool
+  felogin.view.templateRootPath:
+    default: ''
+    type: string
+  felogin.view.partialRootPath:
+    default: ''
+    type: string
+  felogin.view.layoutRootPath:
+    default: ''
+    type: string

--- a/tests/Integration/tests/site-set-labels-autoload/input/index.rst
+++ b/tests/Integration/tests/site-set-labels-autoload/input/index.rst
@@ -1,0 +1,8 @@
+======================
+Site Set Configuration
+======================
+
+..  typo3:site-set-settings:: _includes/Configuration/Sets/Felogin/settings.definitions.yaml
+    :name: felogin
+    :type:
+    :Label:


### PR DESCRIPTION
The set language files introduced in https://forge.typo3.org/issues/104831 are now auto-loaded from labels.xlf within the sets folder, if the file is provided and the set configuration does not reference an explicit labels xlf file.