### PR TITLE
[BUGFIX] Replace pilcrows by fontawesome icons

### DIFF
--- a/packages/typo3-docs-theme/resources/template/body/directive/confval.html.twig
+++ b/packages/typo3-docs-theme/resources/template/body/directive/confval.html.twig
@@ -4,7 +4,7 @@
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">{{ replaceLineBreakOpportunityTags(node.plainContent) }}</span></code>
         {% if not node.noindex %}
-        <a class="headerlink" href="#{{ node.anchor }}" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="{{ node.anchor }}" data-rstCode="{{ getRstCodeForLink(node) }}"  title="Reference this configuration value">¶</a>
+        <a class="headerlink" href="#{{ node.anchor }}" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="{{ node.anchor }}" data-rstCode="{{ getRstCodeForLink(node) }}"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         {% else %}
             <span class="headerNoindex" title="This configuration value cannot be linked directly. Consider to link to the section above."><i class="fa-solid fa-link-slash"></i></span>
         {% endif -%}

--- a/packages/typo3-docs-theme/resources/template/body/directive/php/partials/linkToSnippet.html.twig
+++ b/packages/typo3-docs-theme/resources/template/body/directive/php/partials/linkToSnippet.html.twig
@@ -1,4 +1,4 @@
-{%- if not node.noindex %}<a class="headerlink" href="#{{ node.id }}" data-id="{{ node.id }}" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-rstCode="{{ getRstCodeForLink(node) }}"  title="Reference this definition">¶</a>
+{%- if not node.noindex %}<a class="headerlink" href="#{{ node.id }}" data-id="{{ node.id }}" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-rstCode="{{ getRstCodeForLink(node) }}"  title="Reference this definition"><i class="fa-solid fa-paragraph"></i></a>
 {% else -%}
     <span class="headerNoindex" title="This PHP item cannot be linked directly. Consider to link to the section above."><i class="fa-solid fa-link-slash"></i></span>
 {% endif -%}

--- a/packages/typo3-docs-theme/resources/template/body/directive/viewhelper/viewhelper-argument.html.twig
+++ b/packages/typo3-docs-theme/resources/template/body/directive/viewhelper/viewhelper-argument.html.twig
@@ -3,7 +3,7 @@
         <div class="confval-header">
             <code class="sig-name descname"><span class="pre">{{ argument.plainContent }}</span></code>
             {% if not argument.noindex %}
-                <a class="headerlink" href="#{{ argument.anchor }}" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="{{ argument.anchor }}" data-rstCode="{{ getRstCodeForLink(argument) }}"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#{{ argument.anchor }}" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="{{ argument.anchor }}" data-rstCode="{{ getRstCodeForLink(argument) }}"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
             {% else %}
                 <span class="headerNoindex" title="This configuration value cannot be linked directly. Consider to link to the section above."><i class="fa-solid fa-link-slash"></i></span>
             {% endif -%}

--- a/packages/typo3-docs-theme/resources/template/structure/header-title.html.twig
+++ b/packages/typo3-docs-theme/resources/template/structure/header-title.html.twig
@@ -1,1 +1,1 @@
-<h{{ node.level }}>{{ renderNode(node.value) }}<a class="headerlink" href="#{{ node.id }}" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h{{ node.level }}>
+<h{{ node.level }}>{{ renderNode(node.value) }}<a class="headerlink" href="#{{ node.id }}" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h{{ node.level }}>

--- a/tests/Integration/tests-full/breadcrumb/expected/index.html
+++ b/tests/Integration/tests-full/breadcrumb/expected/index.html
@@ -123,7 +123,7 @@
         <!-- content start -->
                 <section class="section" id="typo3-extension-oauth2-mfc-oauth2" data-rst-anchor="start">
             <a id="start"></a>
-            <h1>TYPO3 Extension <code>oauth2</code> (<code>mfc/oauth2</code>)<a class="headerlink" href="#typo3-extension-oauth2-mfc-oauth2" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>TYPO3 Extension <code>oauth2</code> (<code>mfc/oauth2</code>)<a class="headerlink" href="#typo3-extension-oauth2-mfc-oauth2" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
             
     <p>Lorem Ipsum Dolor.</p>
 

--- a/tests/Integration/tests-full/breadcrumb/expected/page.html
+++ b/tests/Integration/tests-full/breadcrumb/expected/page.html
@@ -124,7 +124,7 @@
     <div itemprop="articleBody">
         <!-- content start -->
                 <section class="section" id="page-ref-start">
-            <h1>Page <a href="index.html#start">TYPO3 Extension oauth2 (mfc/oauth2)</a><a class="headerlink" href="#page-ref-start" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Page <a href="index.html#start">TYPO3 Extension oauth2 (mfc/oauth2)</a><a class="headerlink" href="#page-ref-start" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
             
     <p>Lorem Ipsum Dolor.</p>
 

--- a/tests/Integration/tests-full/breadcrumb/expected/yetAnotherPage.html
+++ b/tests/Integration/tests-full/breadcrumb/expected/yetAnotherPage.html
@@ -123,7 +123,7 @@
     <div itemprop="articleBody">
         <!-- content start -->
                 <section class="section" id="another-page">
-            <h1>Another <code class="code-inline" translate="no">Page</code><a class="headerlink" href="#another-page" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Another <code class="code-inline" translate="no">Page</code><a class="headerlink" href="#another-page" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
             
     <p>Lorem Ipsum Dolor.</p>
 

--- a/tests/Integration/tests-full/changelog/expected/Changelog/12.0/Breaking-87616-RemovedHookForAlteringPageLinks.html
+++ b/tests/Integration/tests-full/changelog/expected/Changelog/12.0/Breaking-87616-RemovedHookForAlteringPageLinks.html
@@ -158,12 +158,12 @@
                 
 <section class="section" id="breaking-87616-removed-hook-for-altering-page-links" data-rst-anchor="breaking-87616">
             <a id="breaking-87616"></a>
-            <h1>Breaking: #87616 - Removed hook for altering page links<a class="headerlink" href="#breaking-87616-removed-hook-for-altering-page-links" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Breaking: #87616 - Removed hook for altering page links<a class="headerlink" href="#breaking-87616-removed-hook-for-altering-page-links" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
             
     <p>See <a href="https://forge.typo3.org/issues/87616">forge#87616</a></p>
 
             <section class="section" id="description">
-            <h2>Description<a class="headerlink" href="#description" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h2>
+            <h2>Description<a class="headerlink" href="#description" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h2>
             
     <p>The hook <code class="code-inline code-inline-long"
           translate="no"
@@ -190,20 +190,20 @@ properties, if needed.</p>
 
     </section>
             <section class="section" id="impact">
-            <h2>Impact<a class="headerlink" href="#impact" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h2>
+            <h2>Impact<a class="headerlink" href="#impact" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h2>
             
     <p>Any hook implementation registered is not executed anymore
 in TYPO3 v12.0+.</p>
 
     </section>
             <section class="section" id="affected-installations">
-            <h2>Affected Installations<a class="headerlink" href="#affected-installations" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h2>
+            <h2>Affected Installations<a class="headerlink" href="#affected-installations" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h2>
             
     <p>TYPO3 installations with custom extensions using this hook.</p>
 
     </section>
             <section class="section" id="migration">
-            <h2>Migration<a class="headerlink" href="#migration" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h2>
+            <h2>Migration<a class="headerlink" href="#migration" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h2>
             
     <p>The hook is removed without deprecation in order to allow extensions
 to work with TYPO3 v11 (using the hook) and v12+ (using the new event).</p>

--- a/tests/Integration/tests-full/changelog/expected/Changelog/12.0/Index.html
+++ b/tests/Integration/tests-full/changelog/expected/Changelog/12.0/Index.html
@@ -156,7 +156,7 @@
     <div itemprop="articleBody">
         <!-- content start -->
                 <section class="section" id="12-0-changes">
-            <h1>12.0 Changes<a class="headerlink" href="#12-0-changes" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>12.0 Changes<a class="headerlink" href="#12-0-changes" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
             
     <p><strong>Table of contents</strong></p>
 
@@ -185,7 +185,7 @@
     </ul>
 </div>
             <section class="section" id="breaking-changes">
-            <h2>Breaking Changes<a class="headerlink" href="#breaking-changes" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h2>
+            <h2>Breaking Changes<a class="headerlink" href="#breaking-changes" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h2>
             <div class="toctree-wrapper compound">
         <ul class="menu-level">
     <li class="toc-item">
@@ -202,7 +202,7 @@
 </div>
     </section>
             <section class="section" id="features">
-            <h2>Features<a class="headerlink" href="#features" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h2>
+            <h2>Features<a class="headerlink" href="#features" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h2>
             <div class="toctree-wrapper compound">
         <ul class="menu-level">
     <li class="toc-item">
@@ -224,7 +224,7 @@
 </div>
     </section>
             <section class="section" id="deprecation">
-            <h2>Deprecation<a class="headerlink" href="#deprecation" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h2>
+            <h2>Deprecation<a class="headerlink" href="#deprecation" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h2>
             <div class="toctree-wrapper compound">
         <ul class="menu-level">
     <li class="toc-item">
@@ -241,7 +241,7 @@
 </div>
     </section>
             <section class="section" id="important">
-            <h2>Important<a class="headerlink" href="#important" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h2>
+            <h2>Important<a class="headerlink" href="#important" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h2>
             <div class="toctree-wrapper compound">
         <ul class="menu-level">
     <li class="toc-item">

--- a/tests/Integration/tests-full/changelog/expected/Index.html
+++ b/tests/Integration/tests-full/changelog/expected/Index.html
@@ -153,7 +153,7 @@
         <!-- content start -->
                 
 <section class="section" id="typo3-core">
-            <h1>TYPO3 Core<a class="headerlink" href="#typo3-core" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>TYPO3 Core<a class="headerlink" href="#typo3-core" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
             <dl class="field-list simple ">
             <dt class="field-odd">Extension key</dt>
 

--- a/tests/Integration/tests-full/changelog/expected/Sitemap.html
+++ b/tests/Integration/tests-full/changelog/expected/Sitemap.html
@@ -156,7 +156,7 @@
                     
 
 <section class="section" id="sitemap">
-            <h1>Sitemap<a class="headerlink" href="#sitemap" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Sitemap<a class="headerlink" href="#sitemap" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
     </section>
 <div class="section">
     

--- a/tests/Integration/tests-full/edit-on-github/edit-on-github-per-page/expected/index.html
+++ b/tests/Integration/tests-full/edit-on-github/edit-on-github-per-page/expected/index.html
@@ -126,7 +126,7 @@
     <div itemprop="articleBody">
         <!-- content start -->
                 <section class="section" id="document-title">
-            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
             
     <p>Lorem Ipsum Dolor.</p>
 

--- a/tests/Integration/tests-full/edit-on-github/edit-on-github-per-page/expected/page1.html
+++ b/tests/Integration/tests-full/edit-on-github/edit-on-github-per-page/expected/page1.html
@@ -128,7 +128,7 @@
         <!-- content start -->
                 <section class="section" id="avatar-viewhelper-be-avatar" data-rst-anchor="typo3-backend-avatar">
             <a id="typo3-backend-avatar"></a>
-            <h1>Avatar ViewHelper <code class="code-inline" translate="no">&lt;be:<wbr>avatar&gt;</code><a class="headerlink" href="#avatar-viewhelper-be-avatar" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Avatar ViewHelper <code class="code-inline" translate="no">&lt;be:<wbr>avatar&gt;</code><a class="headerlink" href="#avatar-viewhelper-be-avatar" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
             
     <p>Render the avatar markup, including the <code class="code-inline"
           translate="no"

--- a/tests/Integration/tests-full/index/expected/index.html
+++ b/tests/Integration/tests-full/index/expected/index.html
@@ -134,7 +134,7 @@
     <div itemprop="articleBody">
         <!-- content start -->
                 <section class="section" id="document-title">
-            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
             
     <p>Lorem Ipsum Dolor.</p>
 

--- a/tests/Integration/tests-full/link-wizard/expected/index.html
+++ b/tests/Integration/tests-full/link-wizard/expected/index.html
@@ -114,16 +114,16 @@
         <!-- content start -->
                 <section class="section" id="document-title" data-rst-anchor="my_document">
             <a id="my_document"></a>
-            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
             
     <p>Lorem Ipsum Dolor.</p>
 
             <section class="section" id="section-1" data-rst-anchor="my_section">
             <a id="my_section"></a>
-            <h2>Section 1<a class="headerlink" href="#section-1" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h2>
+            <h2>Section 1<a class="headerlink" href="#section-1" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h2>
     </section>
             <section class="section" id="section">
-            <h2>Section<a class="headerlink" href="#section" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h2>
+            <h2>Section<a class="headerlink" href="#section" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h2>
     </section>
     </section>
         <!-- content end -->

--- a/tests/Integration/tests-full/menu-subpages-max-1/expected/index.html
+++ b/tests/Integration/tests-full/menu-subpages-max-1/expected/index.html
@@ -134,7 +134,7 @@
         <!-- content start -->
                 
 <section class="section" id="document-title">
-            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
             
     <p>Lorem Ipsum Dolor.</p>
 

--- a/tests/Integration/tests-full/menu-subpages-no-titlesonly-maxdepth-1/expected/index.html
+++ b/tests/Integration/tests-full/menu-subpages-no-titlesonly-maxdepth-1/expected/index.html
@@ -143,7 +143,7 @@
         <!-- content start -->
                 
 <section class="section" id="document-title">
-            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
             
     <p>Lorem Ipsum Dolor.</p>
 

--- a/tests/Integration/tests-full/menu-subpages-no-titlesonly-maxdepth-2/expected/index.html
+++ b/tests/Integration/tests-full/menu-subpages-no-titlesonly-maxdepth-2/expected/index.html
@@ -143,7 +143,7 @@
         <!-- content start -->
                 
 <section class="section" id="document-title">
-            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
             
     <p>Lorem Ipsum Dolor.</p>
 

--- a/tests/Integration/tests-full/menu-subpages/expected/index.html
+++ b/tests/Integration/tests-full/menu-subpages/expected/index.html
@@ -143,7 +143,7 @@
         <!-- content start -->
                 
 <section class="section" id="document-title">
-            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
             
     <p>Lorem Ipsum Dolor.</p>
 

--- a/tests/Integration/tests-full/meta-data/expected/index.html
+++ b/tests/Integration/tests-full/meta-data/expected/index.html
@@ -134,7 +134,7 @@
     <div itemprop="articleBody">
         <!-- content start -->
                 <section class="section" id="document-title">
-            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
             
     <p>Lorem Ipsum Dolor.</p>
 

--- a/tests/Integration/tests-full/navigation-title/expected/anotherPage.html
+++ b/tests/Integration/tests-full/navigation-title/expected/anotherPage.html
@@ -149,7 +149,7 @@
         <!-- content start -->
                 
 <section class="section" id="another-page">
-            <h1>Another Page<a class="headerlink" href="#another-page" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Another Page<a class="headerlink" href="#another-page" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
             
     <p>Lorem Ipsum Dolor.</p>
 

--- a/tests/Integration/tests-full/navigation-title/expected/index.html
+++ b/tests/Integration/tests-full/navigation-title/expected/index.html
@@ -147,7 +147,7 @@
         <!-- content start -->
                 
 <section class="section" id="document-title">
-            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
             
     <p>Lorem Ipsum Dolor.</p>
 

--- a/tests/Integration/tests-full/navigation-title/expected/yetAnotherPage.html
+++ b/tests/Integration/tests-full/navigation-title/expected/yetAnotherPage.html
@@ -149,7 +149,7 @@
                 
 <section class="section" id="yet-another-page-1" data-rst-anchor="yet-another-page">
             <a id="yet-another-page"></a>
-            <h1>Yet Another Page<a class="headerlink" href="#yet-another-page-1" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Yet Another Page<a class="headerlink" href="#yet-another-page-1" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
             
     <p>Lorem Ipsum Dolor.</p>
 

--- a/tests/Integration/tests-full/next-prev-by-toctree/expected/four.html
+++ b/tests/Integration/tests-full/next-prev-by-toctree/expected/four.html
@@ -136,7 +136,7 @@
     <div itemprop="articleBody">
         <!-- content start -->
                 <section class="section" id="four">
-            <h1>Four<a class="headerlink" href="#four" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Four<a class="headerlink" href="#four" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
             
     <p>Lorem Ipsum Dolor. <a href="https://typ03.org">index</a></p>
 

--- a/tests/Integration/tests-full/next-prev-by-toctree/expected/i.html
+++ b/tests/Integration/tests-full/next-prev-by-toctree/expected/i.html
@@ -137,7 +137,7 @@
     <div itemprop="articleBody">
         <!-- content start -->
                 <section class="section" id="i-sqrt-1">
-            <h1>i (sqrt(-1))<a class="headerlink" href="#i-sqrt-1" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>i (sqrt(-1))<a class="headerlink" href="#i-sqrt-1" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
             
     <p>Irreal: orphan</p>
 

--- a/tests/Integration/tests-full/next-prev-by-toctree/expected/index.html
+++ b/tests/Integration/tests-full/next-prev-by-toctree/expected/index.html
@@ -134,7 +134,7 @@
     <div itemprop="articleBody">
         <!-- content start -->
                 <section class="section" id="root-index">
-            <h1>Root index<a class="headerlink" href="#root-index" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Root index<a class="headerlink" href="#root-index" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
             
     <p>Lorem Ipsum Dolor.</p>
 

--- a/tests/Integration/tests-full/next-prev-by-toctree/expected/one.html
+++ b/tests/Integration/tests-full/next-prev-by-toctree/expected/one.html
@@ -136,7 +136,7 @@
     <div itemprop="articleBody">
         <!-- content start -->
                 <section class="section" id="one">
-            <h1>One<a class="headerlink" href="#one" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>One<a class="headerlink" href="#one" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
             
     <p>Lorem Ipsum Dolor 1</p>
 

--- a/tests/Integration/tests-full/next-prev-by-toctree/expected/three/index.html
+++ b/tests/Integration/tests-full/next-prev-by-toctree/expected/three/index.html
@@ -136,7 +136,7 @@
     <div itemprop="articleBody">
         <!-- content start -->
                 <section class="section" id="three-point-something">
-            <h1>Three point something<a class="headerlink" href="#three-point-something" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Three point something<a class="headerlink" href="#three-point-something" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
             
     <p>Lorem Ipsum Dolor.</p>
 

--- a/tests/Integration/tests-full/next-prev-by-toctree/expected/three/pi.html
+++ b/tests/Integration/tests-full/next-prev-by-toctree/expected/three/pi.html
@@ -136,7 +136,7 @@
     <div itemprop="articleBody">
         <!-- content start -->
                 <section class="section" id="pi">
-            <h1>Pi<a class="headerlink" href="#pi" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Pi<a class="headerlink" href="#pi" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
             
     <p>Irrational: Orphan</p>
 

--- a/tests/Integration/tests-full/next-prev-by-toctree/expected/three/three.html
+++ b/tests/Integration/tests-full/next-prev-by-toctree/expected/three/three.html
@@ -137,7 +137,7 @@
     <div itemprop="articleBody">
         <!-- content start -->
                 <section class="section" id="three">
-            <h1>Three<a class="headerlink" href="#three" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Three<a class="headerlink" href="#three" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
             
     <p>Lorem Ipsum Dolor. 3.</p>
 

--- a/tests/Integration/tests-full/next-prev-by-toctree/expected/three/threepointfive.html
+++ b/tests/Integration/tests-full/next-prev-by-toctree/expected/three/threepointfive.html
@@ -137,7 +137,7 @@
     <div itemprop="articleBody">
         <!-- content start -->
                 <section class="section" id="3-5">
-            <h1>3.5<a class="headerlink" href="#3-5" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>3.5<a class="headerlink" href="#3-5" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
             
     <p>Lorem Ipsum Dolor.</p>
 

--- a/tests/Integration/tests-full/next-prev-by-toctree/expected/two.html
+++ b/tests/Integration/tests-full/next-prev-by-toctree/expected/two.html
@@ -136,7 +136,7 @@
     <div itemprop="articleBody">
         <!-- content start -->
                 <section class="section" id="two">
-            <h1>Two<a class="headerlink" href="#two" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Two<a class="headerlink" href="#two" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
             
     <p>Lorem Ipsum Dolor. 2</p>
 

--- a/tests/Integration/tests-full/next-prev/expected/index.html
+++ b/tests/Integration/tests-full/next-prev/expected/index.html
@@ -122,7 +122,7 @@
     <div itemprop="articleBody">
         <!-- content start -->
                 <section class="section" id="document-title">
-            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
             
     <p>Lorem Ipsum Dolor.</p>
 

--- a/tests/Integration/tests-full/next-prev/expected/page.html
+++ b/tests/Integration/tests-full/next-prev/expected/page.html
@@ -124,7 +124,7 @@
     <div itemprop="articleBody">
         <!-- content start -->
                 <section class="section" id="page">
-            <h1>Page<a class="headerlink" href="#page" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Page<a class="headerlink" href="#page" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
             
     <p>Lorem Ipsum Dolor.</p>
 

--- a/tests/Integration/tests-full/next-prev/expected/yetAnotherPage.html
+++ b/tests/Integration/tests-full/next-prev/expected/yetAnotherPage.html
@@ -123,7 +123,7 @@
     <div itemprop="articleBody">
         <!-- content start -->
                 <section class="section" id="another-page">
-            <h1>Another Page<a class="headerlink" href="#another-page" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Another Page<a class="headerlink" href="#another-page" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
             
     <p>Lorem Ipsum Dolor.</p>
 

--- a/tests/Integration/tests-full/page-with-subpages/expected/index.html
+++ b/tests/Integration/tests-full/page-with-subpages/expected/index.html
@@ -119,7 +119,7 @@
     <div itemprop="articleBody">
         <!-- content start -->
                 <section class="section" id="root-index">
-            <h1>Root index<a class="headerlink" href="#root-index" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Root index<a class="headerlink" href="#root-index" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
             
     <p>Lorem Ipsum Dolor. See <a href="sub/index.html#sub-index">Sub index</a>.</p>
 

--- a/tests/Integration/tests-full/page-with-subpages/expected/singlehtml/Index.html
+++ b/tests/Integration/tests-full/page-with-subpages/expected/singlehtml/Index.html
@@ -82,7 +82,7 @@
                 <div class="rst-content">                                                                <!-- content start -->
     <article>
             <section class="section" id="root-index">
-            <h1>Root index<a class="headerlink" href="#root-index" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Root index<a class="headerlink" href="#root-index" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
             
     <p>Lorem Ipsum Dolor. See <a href="#sub-index">Sub index</a>.</p>
 
@@ -100,7 +100,7 @@
         </article>
 <article>
             <section class="section" id="root-index">
-            <h1>Root index<a class="headerlink" href="#root-index" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Root index<a class="headerlink" href="#root-index" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
             
     <p>Lorem Ipsum Dolor. See <a href="#sub-index">Sub index</a>.</p>
 
@@ -118,7 +118,7 @@
         </article>
 <article>
             <section class="section" id="sub-index">
-            <h1>Sub index<a class="headerlink" href="#sub-index" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Sub index<a class="headerlink" href="#sub-index" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
             
     <p>Lorem Ipsum Dolor.  See <a href="#root-index">Root index</a>.</p>
 

--- a/tests/Integration/tests-full/page-with-subpages/expected/sub/index.html
+++ b/tests/Integration/tests-full/page-with-subpages/expected/sub/index.html
@@ -120,7 +120,7 @@
     <div itemprop="articleBody">
         <!-- content start -->
                 <section class="section" id="sub-index">
-            <h1>Sub index<a class="headerlink" href="#sub-index" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Sub index<a class="headerlink" href="#sub-index" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
             
     <p>Lorem Ipsum Dolor.  See <a href="../index.html#root-index">Root index</a>.</p>
 

--- a/tests/Integration/tests-full/report-issue/project-issue-github/expected/index.html
+++ b/tests/Integration/tests-full/report-issue/project-issue-github/expected/index.html
@@ -123,7 +123,7 @@
     <div itemprop="articleBody">
         <!-- content start -->
                 <section class="section" id="document-title">
-            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
             
     <p>Lorem Ipsum Dolor.</p>
 

--- a/tests/Integration/tests-full/report-issue/report-issue-forge/expected/index.html
+++ b/tests/Integration/tests-full/report-issue/report-issue-forge/expected/index.html
@@ -123,7 +123,7 @@
     <div itemprop="articleBody">
         <!-- content start -->
                 <section class="section" id="document-title">
-            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
             
     <p>Lorem Ipsum Dolor.</p>
 

--- a/tests/Integration/tests-full/report-issue/report-issue-github/expected/index.html
+++ b/tests/Integration/tests-full/report-issue/report-issue-github/expected/index.html
@@ -123,7 +123,7 @@
     <div itemprop="articleBody">
         <!-- content start -->
                 <section class="section" id="document-title">
-            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
             
     <p>Lorem Ipsum Dolor.</p>
 

--- a/tests/Integration/tests-full/report-issue/report-issue-internal/expected/index.html
+++ b/tests/Integration/tests-full/report-issue/report-issue-internal/expected/index.html
@@ -123,7 +123,7 @@
     <div itemprop="articleBody">
         <!-- content start -->
                 <section class="section" id="document-title">
-            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
             
     <p>Lorem Ipsum Dolor.</p>
 

--- a/tests/Integration/tests-full/sitemap/expected/Sitemap.html
+++ b/tests/Integration/tests-full/sitemap/expected/Sitemap.html
@@ -135,7 +135,7 @@
         <!-- content start -->
                     
 <section class="section" id="sitemap">
-            <h1>Sitemap<a class="headerlink" href="#sitemap" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Sitemap<a class="headerlink" href="#sitemap" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
     </section>
 <div class="section">
     

--- a/tests/Integration/tests-full/sitemap/expected/index.html
+++ b/tests/Integration/tests-full/sitemap/expected/index.html
@@ -131,7 +131,7 @@
     <div itemprop="articleBody">
         <!-- content start -->
                 <section class="section" id="document-title">
-            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
             
     <p>Lorem Ipsum Dolor.</p>
 

--- a/tests/Integration/tests-full/sitemap/expected/subpages/subpage1.html
+++ b/tests/Integration/tests-full/sitemap/expected/subpages/subpage1.html
@@ -135,7 +135,7 @@
     <div itemprop="articleBody">
         <!-- content start -->
                 <section class="section" id="subpage-1-not-searched">
-            <h1>Subpage 1 - Not searched<a class="headerlink" href="#subpage-1-not-searched" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Subpage 1 - Not searched<a class="headerlink" href="#subpage-1-not-searched" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
             
     <p>Lorem Ipsum Dolor.</p>
 

--- a/tests/Integration/tests-full/two-toctrees/expected/index.html
+++ b/tests/Integration/tests-full/two-toctrees/expected/index.html
@@ -148,7 +148,7 @@
     <div itemprop="articleBody">
         <!-- content start -->
                 <section class="section" id="document-title">
-            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
             
     <p>Lorem Ipsum Dolor.</p>
 

--- a/tests/Integration/tests/admonitions/expected/index.html
+++ b/tests/Integration/tests/admonitions/expected/index.html
@@ -1,6 +1,6 @@
 <!-- content start -->
                 <section class="section" id="admonitions-tip-note-warning-see-also-etc">
-            <h1>Admonitions: Tip, Note, Warning, See also,  etc<a class="headerlink" href="#admonitions-tip-note-warning-see-also-etc" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Admonitions: Tip, Note, Warning, See also,  etc<a class="headerlink" href="#admonitions-tip-note-warning-see-also-etc" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
 
 <div class="admonition custom-admonition" role="alert">
     <p class="admonition-title">Custom admonition</p>
@@ -9,7 +9,7 @@
 
 </div>
             <section class="section" id="see-also">
-            <h2>See also<a class="headerlink" href="#see-also" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h2>
+            <h2>See also<a class="headerlink" href="#see-also" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h2>
 
 <div class="admonition seealso" role="alert">
     <p class="admonition-title">See also</p>
@@ -19,7 +19,7 @@
 </div>
     </section>
             <section class="section" id="note">
-            <h2>Note<a class="headerlink" href="#note" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h2>
+            <h2>Note<a class="headerlink" href="#note" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h2>
 
 <div class="admonition note" role="alert">
     <p class="admonition-title">Note</p>
@@ -29,7 +29,7 @@
 </div>
     </section>
             <section class="section" id="tip">
-            <h2>Tip<a class="headerlink" href="#tip" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h2>
+            <h2>Tip<a class="headerlink" href="#tip" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h2>
 
 <div class="admonition tip" role="alert">
     <p class="admonition-title">Tip</p>
@@ -52,7 +52,7 @@
 </div>
     </section>
             <section class="section" id="warning">
-            <h2>Warning<a class="headerlink" href="#warning" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h2>
+            <h2>Warning<a class="headerlink" href="#warning" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h2>
 
 <div class="admonition warning" role="alert">
     <p class="admonition-title">Warning</p>
@@ -83,7 +83,7 @@
 </div>
     </section>
             <section class="section" id="attention">
-            <h2>Attention<a class="headerlink" href="#attention" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h2>
+            <h2>Attention<a class="headerlink" href="#attention" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h2>
 
 <div class="admonition attention" role="alert">
     <p class="admonition-title">Attention</p>

--- a/tests/Integration/tests/bignum/bignum-lists/expected/index.html
+++ b/tests/Integration/tests/bignum/bignum-lists/expected/index.html
@@ -1,11 +1,11 @@
 <!-- content start -->
                 <section class="section" id="styled-numbered-sections-bignums">
-            <h1>Styled numbered sections (bignums)<a class="headerlink" href="#styled-numbered-sections-bignums" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Styled numbered sections (bignums)<a class="headerlink" href="#styled-numbered-sections-bignums" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
 
     <p>Lorem Ipsum Dolor.</p>
 
             <section class="section" id="with-xxl-big-numbers">
-            <h2>With XXL Big Numbers<a class="headerlink" href="#with-xxl-big-numbers" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h2>
+            <h2>With XXL Big Numbers<a class="headerlink" href="#with-xxl-big-numbers" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h2>
 
 
 <ol class="bignums-xxl" start="1">
@@ -33,7 +33,7 @@
 
     </section>
             <section class="section" id="with-big-numbers-tip">
-            <h2>With Big Numbers - Tip<a class="headerlink" href="#with-big-numbers-tip" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h2>
+            <h2>With Big Numbers - Tip<a class="headerlink" href="#with-big-numbers-tip" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h2>
 
 
 <ol class="bignums-tip" start="1">

--- a/tests/Integration/tests/bignum/bignum-nested/expected/index.html
+++ b/tests/Integration/tests/bignum/bignum-nested/expected/index.html
@@ -1,6 +1,6 @@
 <!-- content start -->
                 <section class="section" id="nested-bignums-xxl-bignums-normally-styled">
-            <h1>Nested bignums-xxl &gt; bignums &gt; Normally Styled<a class="headerlink" href="#nested-bignums-xxl-bignums-normally-styled" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Nested bignums-xxl &gt; bignums &gt; Normally Styled<a class="headerlink" href="#nested-bignums-xxl-bignums-normally-styled" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
 
 
 <ol class="bignums-xxl" start="1">

--- a/tests/Integration/tests/bootstrap-cards/expected/index.html
+++ b/tests/Integration/tests/bootstrap-cards/expected/index.html
@@ -1,6 +1,6 @@
 <!-- content start -->
                 <section class="section" id="simple-cards">
-            <h1>Simple cards<a class="headerlink" href="#simple-cards" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Simple cards<a class="headerlink" href="#simple-cards" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
             <div class="row m-0 p-0">
     <div class="col-md-6 pl-0 pr-3 py-3 m-0">
     <div class="card px-0 h-100">
@@ -32,7 +32,7 @@ prior to installation.</p>
 </div>
 
             <section class="section" id="cards-with-buttons-in-the-footer">
-            <h2>Cards with buttons in the footer<a class="headerlink" href="#cards-with-buttons-in-the-footer" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h2>
+            <h2>Cards with buttons in the footer<a class="headerlink" href="#cards-with-buttons-in-the-footer" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h2>
             <div class="row m-0 p-0">
     <div class="col-md-6 pl-0 pr-3 py-3 m-0">
     <div class="card px-0 h-100">

--- a/tests/Integration/tests/code-block/directive-only/expected/index.html
+++ b/tests/Integration/tests/code-block/directive-only/expected/index.html
@@ -1,6 +1,6 @@
 <!-- content start -->
                 <section class="section" id="just-a-code-block">
-            <h1>Just a code block<a class="headerlink" href="#just-a-code-block" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Just a code block<a class="headerlink" href="#just-a-code-block" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
             <div class="code-block-wrapper" translate="no">
 
     <pre class="code-block"><code>echo &#039;Hello, TYPO3&#039;;</code></pre>

--- a/tests/Integration/tests/code-block/literalinclude/expected/Index.html
+++ b/tests/Integration/tests/code-block/literalinclude/expected/Index.html
@@ -1,6 +1,6 @@
 <!-- content start -->
                 <section class="section" id="document-title">
-            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
 
     <p>This is a paragraph above.</p>
 

--- a/tests/Integration/tests/code-block/with-caption/expected/index.html
+++ b/tests/Integration/tests/code-block/with-caption/expected/index.html
@@ -1,6 +1,6 @@
 <!-- content start -->
                 <section class="section" id="with-caption">
-            <h1>With caption<a class="headerlink" href="#with-caption" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>With caption<a class="headerlink" href="#with-caption" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
                 <div class="code-block-caption">
         <span class="caption-text">src/hello.php</span>
     </div><div class="code-block-wrapper" translate="no">

--- a/tests/Integration/tests/code-block/with-classes/expected/index.html
+++ b/tests/Integration/tests/code-block/with-classes/expected/index.html
@@ -1,6 +1,6 @@
 <!-- content start -->
                 <section class="section" id="with-classes">
-            <h1>With classes<a class="headerlink" href="#with-classes" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>With classes<a class="headerlink" href="#with-classes" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
             <div class="code-block-wrapper" translate="no">
 
     <pre class="code-block some-class another-class"><code class="hljs python"><span class="hljs-function"><span class="hljs-keyword">def</span> <span class="hljs-title">some_function</span><span class="hljs-params">()</span>:</span>

--- a/tests/Integration/tests/code-block/with-emphasize-lines/expected/index.html
+++ b/tests/Integration/tests/code-block/with-emphasize-lines/expected/index.html
@@ -1,6 +1,6 @@
 <!-- content start -->
                 <section class="section" id="with-emphasize-lines">
-            <h1>With emphasize lines<a class="headerlink" href="#with-emphasize-lines" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>With emphasize lines<a class="headerlink" href="#with-emphasize-lines" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
             <div class="code-block-wrapper" translate="no">
 
     <pre class="code-block"><code class="hljs python"><span class="hljs-function"><span class="hljs-keyword">def</span> <span class="hljs-title">some_function</span><span class="hljs-params">()</span>:</span>

--- a/tests/Integration/tests/code-block/with-language-aliases/expected/index.html
+++ b/tests/Integration/tests/code-block/with-language-aliases/expected/index.html
@@ -1,6 +1,6 @@
 <!-- content start -->
                 <section class="section" id="with-language-aliases">
-            <h1>With language aliases<a class="headerlink" href="#with-language-aliases" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>With language aliases<a class="headerlink" href="#with-language-aliases" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
             <div class="code-block-wrapper" translate="no">
 
     <pre class="code-block"><code class="hljs plaintext">something we don't know of</code></pre>

--- a/tests/Integration/tests/code-block/with-language-rst/expected/index.html
+++ b/tests/Integration/tests/code-block/with-language-rst/expected/index.html
@@ -1,6 +1,6 @@
 <!-- content start -->
                 <section class="section" id="with-language-rst">
-            <h1>With language rst<a class="headerlink" href="#with-language-rst" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>With language rst<a class="headerlink" href="#with-language-rst" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
             <div class="code-block-wrapper" translate="no">
 
     <pre class="code-block"><code class="hljs rst"><span class="hljs-meta">..  note::</span> this is a note

--- a/tests/Integration/tests/code-block/with-language-typoscript/expected/index.html
+++ b/tests/Integration/tests/code-block/with-language-typoscript/expected/index.html
@@ -1,8 +1,8 @@
 <!-- content start -->
                 <section class="section" id="with-language-typoscript">
-            <h1>With language &quot;typoscript&quot;<a class="headerlink" href="#with-language-typoscript" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>With language &quot;typoscript&quot;<a class="headerlink" href="#with-language-typoscript" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
             <section class="section" id="imports">
-            <h2>Imports<a class="headerlink" href="#imports" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h2>
+            <h2>Imports<a class="headerlink" href="#imports" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h2>
             <div class="code-block-wrapper" translate="no">
 
     <pre class="code-block"><code class="hljs typoscript"><span class="hljs-name">@import '<span class="hljs-bullet">EXT:myproject/Configuration/TypoScript/*.typoscript</span>'</span>
@@ -21,7 +21,7 @@
 </div>
     </section>
             <section class="section" id="conditions">
-            <h2>Conditions<a class="headerlink" href="#conditions" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h2>
+            <h2>Conditions<a class="headerlink" href="#conditions" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h2>
             <div class="code-block-wrapper" translate="no">
 
     <pre class="code-block"><code class="hljs typoscript"><span class="hljs-meta">[date("j") == 9]</span>
@@ -42,7 +42,7 @@
 </div>
     </section>
             <section class="section" id="quoting-of-sql-identifiers">
-            <h2>Quoting of SQL identifiers<a class="headerlink" href="#quoting-of-sql-identifiers" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h2>
+            <h2>Quoting of SQL identifiers<a class="headerlink" href="#quoting-of-sql-identifiers" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h2>
             <div class="code-block-wrapper" translate="no">
 
     <pre class="code-block"><code class="hljs typoscript">select.where = (<span class="hljs-name">{#title}</span> LIKE <span class="hljs-name">{#%SOMETHING%}</span> AND NOT <span class="hljs-name">{#doktype}</span>)</code></pre>
@@ -55,7 +55,7 @@
 </div>
     </section>
             <section class="section" id="variables">
-            <h2>Variables<a class="headerlink" href="#variables" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h2>
+            <h2>Variables<a class="headerlink" href="#variables" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h2>
             <div class="code-block-wrapper" translate="no">
 
     <pre class="code-block"><code class="hljs typoscript">something = <span class="hljs-name">{$foo.bar}</span></code></pre>
@@ -68,7 +68,7 @@
 </div>
     </section>
             <section class="section" id="comments">
-            <h2>Comments<a class="headerlink" href="#comments" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h2>
+            <h2>Comments<a class="headerlink" href="#comments" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h2>
             <div class="code-block-wrapper" translate="no">
 
     <pre class="code-block"><code class="hljs typoscript"><span class="hljs-comment"># Some comment</span>
@@ -95,7 +95,7 @@ comment */</span> and more</code></pre>
 </div>
     </section>
             <section class="section" id="register">
-            <h2>Register<a class="headerlink" href="#register" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h2>
+            <h2>Register<a class="headerlink" href="#register" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h2>
             <div class="code-block-wrapper" translate="no">
 
     <pre class="code-block"><code class="hljs typoscript">dataWrap = &lt;ul class="<span class="hljs-name">{register:ulClass}</span>"&gt;|&lt;/ul&gt;</code></pre>
@@ -108,7 +108,7 @@ comment */</span> and more</code></pre>
 </div>
     </section>
             <section class="section" id="colors">
-            <h2>Colors<a class="headerlink" href="#colors" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h2>
+            <h2>Colors<a class="headerlink" href="#colors" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h2>
             <div class="code-block-wrapper" translate="no">
 
     <pre class="code-block"><code class="hljs typoscript">something = <span class="hljs-number">#123</span>
@@ -125,7 +125,7 @@ something = 1234 <span class="hljs-comment"># not recognized as color</span></co
 </div>
     </section>
             <section class="section" id="array-numbers">
-            <h2>Array numbers<a class="headerlink" href="#array-numbers" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h2>
+            <h2>Array numbers<a class="headerlink" href="#array-numbers" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h2>
             <div class="code-block-wrapper" translate="no">
 
     <pre class="code-block"><code class="hljs typoscript"><span class="hljs-title">10</span> = <span class="hljs-keyword">TEXT</span>
@@ -144,7 +144,7 @@ something = 1234 <span class="hljs-comment"># not recognized as color</span></co
 </div>
     </section>
             <section class="section" id="keywords">
-            <h2>Keywords<a class="headerlink" href="#keywords" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h2>
+            <h2>Keywords<a class="headerlink" href="#keywords" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h2>
             <div class="code-block-wrapper" translate="no">
 
     <pre class="code-block"><code class="hljs typoscript"><span class="hljs-title">10</span> = <span class="hljs-keyword">TEXT</span>

--- a/tests/Integration/tests/code-block/with-language/expected/index.html
+++ b/tests/Integration/tests/code-block/with-language/expected/index.html
@@ -1,6 +1,6 @@
 <!-- content start -->
                 <section class="section" id="with-language">
-            <h1>With language<a class="headerlink" href="#with-language" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>With language<a class="headerlink" href="#with-language" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
             <div class="code-block-wrapper" translate="no">
 
     <pre class="code-block"><code class="hljs php"><span class="hljs-keyword">echo</span> <span class="hljs-string">'Hello, TYPO3'</span>;</code></pre>

--- a/tests/Integration/tests/code-block/with-line-number-start/expected/index.html
+++ b/tests/Integration/tests/code-block/with-line-number-start/expected/index.html
@@ -1,6 +1,6 @@
 <!-- content start -->
                 <section class="section" id="with-line-numbers">
-            <h1>With line numbers<a class="headerlink" href="#with-line-numbers" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>With line numbers<a class="headerlink" href="#with-line-numbers" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
             <div class="code-block-wrapper" translate="no">
 
     <pre class="code-block"><code class="hljs ruby"><span data-line-number="10">Some more Ruby code.</span></code></pre>

--- a/tests/Integration/tests/code-block/with-line-numbers/expected/index.html
+++ b/tests/Integration/tests/code-block/with-line-numbers/expected/index.html
@@ -1,6 +1,6 @@
 <!-- content start -->
                 <section class="section" id="with-line-number-start">
-            <h1>With line number start<a class="headerlink" href="#with-line-number-start" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>With line number start<a class="headerlink" href="#with-line-number-start" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
             <div class="code-block-wrapper" translate="no">
 
     <pre class="code-block"><code class="hljs ruby"><span data-line-number="1">Some more Ruby code, with line numbering starting at <span class="hljs-number">10</span>.</span></code></pre>

--- a/tests/Integration/tests/code-inline/expected/index.html
+++ b/tests/Integration/tests/code-inline/expected/index.html
@@ -1,6 +1,6 @@
 <!-- content start -->
                 <section class="section" id="inline-code">
-            <h1>Inline code<a class="headerlink" href="#inline-code" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Inline code<a class="headerlink" href="#inline-code" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
 
     <p><code class="code-inline code-inline-long"
           translate="no"

--- a/tests/Integration/tests/code/code-generic/expected/index.html
+++ b/tests/Integration/tests/code/code-generic/expected/index.html
@@ -1,6 +1,6 @@
 <!-- content start -->
                 <section class="section" id="code">
-            <h1>Code<a class="headerlink" href="#code" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Code<a class="headerlink" href="#code" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
 
     <p><code class="code-inline" translate="no">some code</code></p>
 

--- a/tests/Integration/tests/code/code-php/expected/index.html
+++ b/tests/Integration/tests/code/code-php/expected/index.html
@@ -1,6 +1,6 @@
 <!-- content start -->
                 <section class="section" id="php-code">
-            <h1>PHP Code<a class="headerlink" href="#php-code" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>PHP Code<a class="headerlink" href="#php-code" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
 
     <p><code class="code-inline code-inline-long"
           translate="no"

--- a/tests/Integration/tests/codehighlight-languages/expected/index.html
+++ b/tests/Integration/tests/codehighlight-languages/expected/index.html
@@ -1,6 +1,6 @@
 <!-- content start -->
                 <section class="section" id="registered-code-block-languages">
-            <h1>Registered code-block languages<a class="headerlink" href="#registered-code-block-languages" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Registered code-block languages<a class="headerlink" href="#registered-code-block-languages" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
 
     <p>All registered languages for code blocks:</p>
 

--- a/tests/Integration/tests/command-list/expected/index.html
+++ b/tests/Integration/tests/command-list/expected/index.html
@@ -1,6 +1,6 @@
 <!-- content start -->
                 <section class="section" id="document-title">
-            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
             <div class="contents-wrapper">
         <ul class="menu-level">
     <li class="toc-item">
@@ -21,7 +21,7 @@
     </ul>
 </div>
             <section class="section" id="cache-commands">
-            <h2>Cache commands<a class="headerlink" href="#cache-commands" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h2>
+            <h2>Cache commands<a class="headerlink" href="#cache-commands" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h2>
             <dl class="command">
     <dt>
         <code class="sig-name descname"><span class="pre">vendor/bin/typo3 cache:flush</span></code>
@@ -127,7 +127,7 @@
 </dl>
     </section>
             <section class="section" id="global-commands">
-            <h2>Global commands<a class="headerlink" href="#global-commands" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h2>
+            <h2>Global commands<a class="headerlink" href="#global-commands" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h2>
             <dl class="command">
     <dt>
         <code class="sig-name descname"><span class="pre">bin/typo3 list</span></code>
@@ -595,7 +595,7 @@ when using <code class="code-inline" translate="no">bash</code> or <code class="
 </dl>
     </section>
             <section class="section" id="all-commands">
-            <h2>All commands<a class="headerlink" href="#all-commands" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h2>
+            <h2>All commands<a class="headerlink" href="#all-commands" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h2>
             <dl class="command">
     <dt id="console-command-complete">
         <code class="sig-name descname"><span class="pre">_complete</span></code>

--- a/tests/Integration/tests/commands/expected/index.html
+++ b/tests/Integration/tests/commands/expected/index.html
@@ -1,6 +1,6 @@
 <!-- content start -->
                 <section class="section" id="document-title">
-            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
             <dl class="command">
     <dt id="console-command-cache-flush">
         <code class="sig-name descname"><span class="pre">vendor/bin/typo3 cache:flush</span></code>

--- a/tests/Integration/tests/configuration/expected/index.html
+++ b/tests/Integration/tests/configuration/expected/index.html
@@ -1,6 +1,6 @@
 <!-- content start -->
                 <section class="section" id="document-title">
-            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
 
     <p>Learn more about how to <a href="https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/Index.html#start">write documentation</a> or have
 a look at <a href="https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/Index.html#start">TYPO3 Explained</a>.</p>

--- a/tests/Integration/tests/confval/confval-basic/expected/index.html
+++ b/tests/Integration/tests/confval/confval-basic/expected/index.html
@@ -1,12 +1,12 @@
 <!-- content start -->
                 <section class="section" id="confval">
-            <h1>Confval<a class="headerlink" href="#confval" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Confval<a class="headerlink" href="#confval" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
             <section data-search-title="demo" data-search-id="confval-demo" data-search-facet="Option">
 <dl class="confval">
     <dt id="confval-demo" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">demo</span></code>
-                <a class="headerlink" href="#confval-demo" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-demo" data-rstCode=":confval:`demo &lt;somemanual:demo&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-demo" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-demo" data-rstCode=":confval:`demo &lt;somemanual:demo&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>

--- a/tests/Integration/tests/confval/confval-duplicate-with-name/expected/anotherDomain.html
+++ b/tests/Integration/tests/confval/confval-duplicate-with-name/expected/anotherDomain.html
@@ -1,12 +1,12 @@
 <!-- content start -->
                 <section class="section" id="confval-in-another-domain">
-            <h1>Confval in another domain<a class="headerlink" href="#confval-in-another-domain" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Confval in another domain<a class="headerlink" href="#confval-in-another-domain" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
             <section data-search-title="demo" data-search-id="confval-another-demo" data-search-facet="Option">
 <dl class="confval">
     <dt id="confval-another-demo" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">demo</span></code>
-                <a class="headerlink" href="#confval-another-demo" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-another-demo" data-rstCode=":confval:`demo &lt;somemanual:another-demo&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-another-demo" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-another-demo" data-rstCode=":confval:`demo &lt;somemanual:another-demo&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>

--- a/tests/Integration/tests/confval/confval-duplicate-with-name/expected/index.html
+++ b/tests/Integration/tests/confval/confval-duplicate-with-name/expected/index.html
@@ -1,12 +1,12 @@
 <!-- content start -->
                 <section class="section" id="confval">
-            <h1>Confval<a class="headerlink" href="#confval" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Confval<a class="headerlink" href="#confval" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
             <section data-search-title="demo" data-search-id="confval-demo" data-search-facet="Option">
 <dl class="confval">
     <dt id="confval-demo" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">demo</span></code>
-                <a class="headerlink" href="#confval-demo" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-demo" data-rstCode=":confval:`demo &lt;somemanual:demo&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-demo" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-demo" data-rstCode=":confval:`demo &lt;somemanual:demo&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>

--- a/tests/Integration/tests/confval/confval-duplicate/expected/anotherDomain.html
+++ b/tests/Integration/tests/confval/confval-duplicate/expected/anotherDomain.html
@@ -1,12 +1,12 @@
 <!-- content start -->
                 <section class="section" id="confval-in-another-domain">
-            <h1>Confval in another domain<a class="headerlink" href="#confval-in-another-domain" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Confval in another domain<a class="headerlink" href="#confval-in-another-domain" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
             <section data-search-title="demo" data-search-id="confval-demo" data-search-facet="Option">
 <dl class="confval">
     <dt id="confval-demo" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">demo</span></code>
-                <a class="headerlink" href="#confval-demo" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-demo" data-rstCode=":confval:`demo &lt;somemanual:demo&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-demo" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-demo" data-rstCode=":confval:`demo &lt;somemanual:demo&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>

--- a/tests/Integration/tests/confval/confval-duplicate/expected/index.html
+++ b/tests/Integration/tests/confval/confval-duplicate/expected/index.html
@@ -1,12 +1,12 @@
 <!-- content start -->
                 <section class="section" id="confval">
-            <h1>Confval<a class="headerlink" href="#confval" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Confval<a class="headerlink" href="#confval" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
             <section data-search-title="demo" data-search-id="confval-demo" data-search-facet="Option">
 <dl class="confval">
     <dt id="confval-demo" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">demo</span></code>
-                <a class="headerlink" href="#confval-demo" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-demo" data-rstCode=":confval:`demo &lt;somemanual:demo&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-demo" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-demo" data-rstCode=":confval:`demo &lt;somemanual:demo&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>

--- a/tests/Integration/tests/confval/confval-menu-tree-anchor/expected/index.html
+++ b/tests/Integration/tests/confval/confval-menu-tree-anchor/expected/index.html
@@ -1,6 +1,6 @@
 <!-- content start -->
                 <section class="section" id="confval">
-            <h1>Confval<a class="headerlink" href="#confval" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Confval<a class="headerlink" href="#confval" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
 
 
 
@@ -50,7 +50,7 @@
     <dt id="confval-case-array" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">array of c<wbr>Objects</span></code>
-                <a class="headerlink" href="#confval-case-array" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-case-array" data-rstCode=":confval:`array of cObjects &lt;somemanual:case-array&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-case-array" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-case-array" data-rstCode=":confval:`array of cObjects &lt;somemanual:case-array&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -77,7 +77,7 @@ the names of the other properties of the cObject CASE.</p>
     <dt id="confval-case-cache" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">cache</span></code>
-                <a class="headerlink" href="#confval-case-cache" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-case-cache" data-rstCode=":confval:`cache &lt;somemanual:case-cache&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-case-cache" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-case-cache" data-rstCode=":confval:`cache &lt;somemanual:case-cache&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -101,7 +101,7 @@ the names of the other properties of the cObject CASE.</p>
     <dt id="confval-case-default" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">default</span></code>
-                <a class="headerlink" href="#confval-case-default" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-case-default" data-rstCode=":confval:`default &lt;somemanual:case-default&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-case-default" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-case-default" data-rstCode=":confval:`default &lt;somemanual:case-default&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -129,7 +129,7 @@ the default case.</p>
     <dt id="confval-case-if" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">if</span></code>
-                <a class="headerlink" href="#confval-case-if" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-case-if" data-rstCode=":confval:`if &lt;somemanual:case-if&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-case-if" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-case-if" data-rstCode=":confval:`if &lt;somemanual:case-if&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>

--- a/tests/Integration/tests/confval/confval-menu-tree-multiple/expected/index.html
+++ b/tests/Integration/tests/confval/confval-menu-tree-multiple/expected/index.html
@@ -1,11 +1,11 @@
 <!-- content start -->
                 <section class="section" id="confval">
-            <h1>Confval<a class="headerlink" href="#confval" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Confval<a class="headerlink" href="#confval" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
     </section>
 <section class="section" id="confvals-with-subtrees">
-            <h1>Confvals with subtrees<a class="headerlink" href="#confvals-with-subtrees" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Confvals with subtrees<a class="headerlink" href="#confvals-with-subtrees" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
             <section class="section" id="properties-of-case">
-            <h2>Properties of CASE<a class="headerlink" href="#properties-of-case" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h2>
+            <h2>Properties of CASE<a class="headerlink" href="#properties-of-case" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h2>
 
 
 
@@ -54,7 +54,7 @@
     <dt id="confval-case-array" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">array of c<wbr>Objects</span></code>
-                <a class="headerlink" href="#confval-case-array" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-case-array" data-rstCode=":confval:`array of cObjects &lt;somemanual:case-array&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-case-array" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-case-array" data-rstCode=":confval:`array of cObjects &lt;somemanual:case-array&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -80,7 +80,7 @@ the names of the other properties of the cObject CASE.</p>
     <dt id="confval-case-cache" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">cache</span></code>
-                <a class="headerlink" href="#confval-case-cache" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-case-cache" data-rstCode=":confval:`cache &lt;somemanual:case-cache&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-case-cache" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-case-cache" data-rstCode=":confval:`cache &lt;somemanual:case-cache&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -103,7 +103,7 @@ the names of the other properties of the cObject CASE.</p>
     <dt id="confval-case-default" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">default</span></code>
-                <a class="headerlink" href="#confval-case-default" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-case-default" data-rstCode=":confval:`default &lt;somemanual:case-default&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-case-default" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-case-default" data-rstCode=":confval:`default &lt;somemanual:case-default&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -129,7 +129,7 @@ the default case.</p>
     <dt id="confval-case-if" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">if</span></code>
-                <a class="headerlink" href="#confval-case-if" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-case-if" data-rstCode=":confval:`if &lt;somemanual:case-if&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-case-if" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-case-if" data-rstCode=":confval:`if &lt;somemanual:case-if&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -150,7 +150,7 @@ the default case.</p>
 
     </section>
             <section class="section" id="properties-of-coa">
-            <h2>Properties of COA<a class="headerlink" href="#properties-of-coa" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h2>
+            <h2>Properties of COA<a class="headerlink" href="#properties-of-coa" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h2>
 
 
 
@@ -192,7 +192,7 @@ the default case.</p>
     <dt id="confval-coa-array" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">1,2,3,4...</span></code>
-                <a class="headerlink" href="#confval-coa-array" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-coa-array" data-rstCode=":confval:`1,2,3,4... &lt;somemanual:coa-array&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-coa-array" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-coa-array" data-rstCode=":confval:`1,2,3,4... &lt;somemanual:coa-array&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -216,7 +216,7 @@ rendered.</p>
     <dt id="confval-coa-cache" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">cache</span></code>
-                <a class="headerlink" href="#confval-coa-cache" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-coa-cache" data-rstCode=":confval:`cache &lt;somemanual:coa-cache&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-coa-cache" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-coa-cache" data-rstCode=":confval:`cache &lt;somemanual:coa-cache&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -239,7 +239,7 @@ rendered.</p>
     <dt id="confval-coa-if" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">if</span></code>
-                <a class="headerlink" href="#confval-coa-if" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-coa-if" data-rstCode=":confval:`if &lt;somemanual:coa-if&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-coa-if" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-coa-if" data-rstCode=":confval:`if &lt;somemanual:coa-if&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>

--- a/tests/Integration/tests/confval/confval-menu-tree/expected/index.html
+++ b/tests/Integration/tests/confval/confval-menu-tree/expected/index.html
@@ -1,8 +1,8 @@
 <!-- content start -->
                 <section class="section" id="confval">
-            <h1>Confval<a class="headerlink" href="#confval" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Confval<a class="headerlink" href="#confval" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
             <section class="section" id="confval-menu-as-list">
-            <h2>Confval menu as list<a class="headerlink" href="#confval-menu-as-list" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h2>
+            <h2>Confval menu as list<a class="headerlink" href="#confval-menu-as-list" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h2>
 
 
 
@@ -112,7 +112,7 @@
 
     </section>
             <section class="section" id="confval-menu-as-list-with-more-info">
-            <h2>Confval menu as list with more info<a class="headerlink" href="#confval-menu-as-list-with-more-info" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h2>
+            <h2>Confval menu as list with more info<a class="headerlink" href="#confval-menu-as-list-with-more-info" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h2>
 
 
 
@@ -240,7 +240,7 @@
 
     </section>
             <section class="section" id="confval-menu-as-tree">
-            <h2>Confval menu as tree<a class="headerlink" href="#confval-menu-as-tree" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h2>
+            <h2>Confval menu as tree<a class="headerlink" href="#confval-menu-as-tree" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h2>
 
 
 
@@ -373,7 +373,7 @@
 
     </section>
             <section class="section" id="confval-menu-as-tree-with-more-info">
-            <h2>Confval menu as tree with more info<a class="headerlink" href="#confval-menu-as-tree-with-more-info" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h2>
+            <h2>Confval menu as tree with more info<a class="headerlink" href="#confval-menu-as-tree-with-more-info" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h2>
 
 
 
@@ -524,7 +524,7 @@
 
     </section>
             <section class="section" id="confval-menu-as-table">
-            <h2>Confval menu as table<a class="headerlink" href="#confval-menu-as-table" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h2>
+            <h2>Confval menu as table<a class="headerlink" href="#confval-menu-as-table" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h2>
 
 
 
@@ -651,13 +651,13 @@
 
     </section>
             <section class="section" id="confvals">
-            <h2>Confvals<a class="headerlink" href="#confvals" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h2>
+            <h2>Confvals<a class="headerlink" href="#confvals" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h2>
             <section data-search-title="demo 1" data-search-id="confval-demo-1" data-search-facet="Option">
 <dl class="confval">
     <dt id="confval-demo-1" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">demo 1</span></code>
-                <a class="headerlink" href="#confval-demo-1" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-demo-1" data-rstCode=":confval:`demo 1 &lt;somemanual:demo-1&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-demo-1" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-demo-1" data-rstCode=":confval:`demo 1 &lt;somemanual:demo-1&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -683,7 +683,7 @@
     <dt id="confval-demo-2" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">demo 2</span></code>
-                <a class="headerlink" href="#confval-demo-2" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-demo-2" data-rstCode=":confval:`demo 2 &lt;somemanual:demo-2&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-demo-2" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-demo-2" data-rstCode=":confval:`demo 2 &lt;somemanual:demo-2&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -704,7 +704,7 @@
     <dt id="confval-demo-2-1" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">demo 2.<wbr>1</span></code>
-                <a class="headerlink" href="#confval-demo-2-1" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-demo-2-1" data-rstCode=":confval:`demo 2.1 &lt;somemanual:demo-2-1&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-demo-2-1" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-demo-2-1" data-rstCode=":confval:`demo 2.1 &lt;somemanual:demo-2-1&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -725,7 +725,7 @@
     <dt id="confval-demo-2-1-1" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">demo 2.<wbr>1.<wbr>1</span></code>
-                <a class="headerlink" href="#confval-demo-2-1-1" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-demo-2-1-1" data-rstCode=":confval:`demo 2.1.1 &lt;somemanual:demo-2-1-1&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-demo-2-1-1" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-demo-2-1-1" data-rstCode=":confval:`demo 2.1.1 &lt;somemanual:demo-2-1-1&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -750,7 +750,7 @@
     <dt id="confval-demo-2-1-2" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">demo 2.<wbr>1.<wbr>2</span></code>
-                <a class="headerlink" href="#confval-demo-2-1-2" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-demo-2-1-2" data-rstCode=":confval:`demo 2.1.2 &lt;somemanual:demo-2-1-2&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-demo-2-1-2" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-demo-2-1-2" data-rstCode=":confval:`demo 2.1.2 &lt;somemanual:demo-2-1-2&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -779,7 +779,7 @@
     <dt id="confval-demo-2-2" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">demo 2.<wbr>2</span></code>
-                <a class="headerlink" href="#confval-demo-2-2" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-demo-2-2" data-rstCode=":confval:`demo 2.2 &lt;somemanual:demo-2-2&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-demo-2-2" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-demo-2-2" data-rstCode=":confval:`demo 2.2 &lt;somemanual:demo-2-2&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -809,7 +809,7 @@
     <dt id="confval-demo-3" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">demo 3</span></code>
-                <a class="headerlink" href="#confval-demo-3" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-demo-3" data-rstCode=":confval:`demo 3 &lt;somemanual:demo-3&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-demo-3" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-demo-3" data-rstCode=":confval:`demo 3 &lt;somemanual:demo-3&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -835,7 +835,7 @@
     <dt id="confval-demo-4" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">demo 4</span></code>
-                <a class="headerlink" href="#confval-demo-4" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-demo-4" data-rstCode=":confval:`demo 4 &lt;somemanual:demo-4&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-demo-4" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-demo-4" data-rstCode=":confval:`demo 4 &lt;somemanual:demo-4&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -861,7 +861,7 @@
     <dt id="confval-exclude-in-table" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">exclude in table</span></code>
-                <a class="headerlink" href="#confval-exclude-in-table" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-exclude-in-table" data-rstCode=":confval:`exclude in table &lt;somemanual:exclude-in-table&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-exclude-in-table" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-exclude-in-table" data-rstCode=":confval:`exclude in table &lt;somemanual:exclude-in-table&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>

--- a/tests/Integration/tests/confval/confval-noindex/expected/anotherDomain.html
+++ b/tests/Integration/tests/confval/confval-noindex/expected/anotherDomain.html
@@ -1,12 +1,12 @@
 <!-- content start -->
                 <section class="section" id="confval-in-another-domain">
-            <h1>Confval in another domain<a class="headerlink" href="#confval-in-another-domain" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Confval in another domain<a class="headerlink" href="#confval-in-another-domain" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
             <section data-search-title="demo" data-search-id="confval-demo" data-search-facet="Option">
 <dl class="confval">
     <dt id="confval-demo" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">demo</span></code>
-                <a class="headerlink" href="#confval-demo" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-demo" data-rstCode=":confval:`demo &lt;somemanual:demo&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-demo" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-demo" data-rstCode=":confval:`demo &lt;somemanual:demo&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>

--- a/tests/Integration/tests/confval/confval-noindex/expected/index.html
+++ b/tests/Integration/tests/confval/confval-noindex/expected/index.html
@@ -1,6 +1,6 @@
 <!-- content start -->
                 <section class="section" id="confval">
-            <h1>Confval<a class="headerlink" href="#confval" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Confval<a class="headerlink" href="#confval" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
             <section data-search-title="demo" data-search-id="confval-demo" data-search-facet="Option">
 <dl class="confval">
     <dt class="d-flex justify-content-between">

--- a/tests/Integration/tests/directive-uml/expected/index.html
+++ b/tests/Integration/tests/directive-uml/expected/index.html
@@ -1,6 +1,6 @@
 <!-- content start -->
                 <section class="section" id="uml-directive">
-            <h1>UML-directive<a class="headerlink" href="#uml-directive" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>UML-directive<a class="headerlink" href="#uml-directive" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
             <figure
         class="uml-diagram"
             >

--- a/tests/Integration/tests/directory-tree/expected/index.html
+++ b/tests/Integration/tests/directory-tree/expected/index.html
@@ -1,6 +1,6 @@
 <!-- content start -->
                 <section class="section" id="directory-tree">
-            <h1>Directory tree<a class="headerlink" href="#directory-tree" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Directory tree<a class="headerlink" href="#directory-tree" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
 
 
 <div class="directory-tree">
@@ -225,7 +225,7 @@
                     </ul>
     </div>
             <section class="section" id="directory-structure-of-a-typo3-extension">
-            <h2>Directory structure of a typo3 extension<a class="headerlink" href="#directory-structure-of-a-typo3-extension" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h2>
+            <h2>Directory structure of a typo3 extension<a class="headerlink" href="#directory-structure-of-a-typo3-extension" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h2>
 
 
 <div class="directory-tree">

--- a/tests/Integration/tests/edit-on-github/edit-on-github-include/expected/Index.html
+++ b/tests/Integration/tests/edit-on-github/edit-on-github-include/expected/Index.html
@@ -1,13 +1,13 @@
 <!-- content start -->
 
 <section class="section" id="index">
-            <h1>index<a class="headerlink" href="#index" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>index<a class="headerlink" href="#index" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
                 <div class="float-end">
         <a href="https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-CoreApi/edit/documentation-draft/Documentation/part1.rst.txt" class="btn btn-light" title="Edit following section on GitHub">
             <i class="icon fa-brands fa-github"></i>
         </a>
     </div><section class="section" id="part-1">
-            <h1>Part 1<a class="headerlink" href="#part-1" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Part 1<a class="headerlink" href="#part-1" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
 
     <p>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod
 tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.
@@ -27,7 +27,7 @@ dolor sit amet.</p>
             <i class="icon fa-brands fa-github"></i>
         </a>
     </div><section class="section" id="part-2">
-            <h1>Part 2<a class="headerlink" href="#part-2" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Part 2<a class="headerlink" href="#part-2" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
 
     <p>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod
 tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.

--- a/tests/Integration/tests/edit-on-github/edit-on-github-literalinclude/expected/Index.html
+++ b/tests/Integration/tests/edit-on-github/edit-on-github-literalinclude/expected/Index.html
@@ -1,6 +1,6 @@
 <!-- content start -->
                 <section class="section" id="document-title">
-            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
 
     <p>This is a paragraph above.</p>
 

--- a/tests/Integration/tests/file/expected/index.html
+++ b/tests/Integration/tests/file/expected/index.html
@@ -1,6 +1,6 @@
 <!-- content start -->
                 <section class="section" id="file">
-            <h1>File<a class="headerlink" href="#file" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>File<a class="headerlink" href="#file" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
 
     <p><code class="code-inline file" translate="no" title="File path">/tmp/<wbr>some.<wbr>file</code></p>
 

--- a/tests/Integration/tests/guides-inventories/expected/index.html
+++ b/tests/Integration/tests/guides-inventories/expected/index.html
@@ -1,6 +1,6 @@
 <!-- content start -->
                 <section class="section" id="title">
-            <h1>Title<a class="headerlink" href="#title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Title<a class="headerlink" href="#title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
             <ul>
             <li>api</li>
             <li>changelog</li>

--- a/tests/Integration/tests/images/Both-Folder-Image-Index/expected/Folder/index.html
+++ b/tests/Integration/tests/images/Both-Folder-Image-Index/expected/Folder/index.html
@@ -1,6 +1,6 @@
 <!-- content start -->
                 <section class="section" id="document-title">
-            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
 
     <p>Lorem Ipsum Dolor.</p>
 

--- a/tests/Integration/tests/images/Both-Folder-Image-Index/expected/index.html
+++ b/tests/Integration/tests/images/Both-Folder-Image-Index/expected/index.html
@@ -1,6 +1,6 @@
 <!-- content start -->
                 <section class="section" id="root-document">
-            <h1>root document<a class="headerlink" href="#root-document" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>root document<a class="headerlink" href="#root-document" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
 
     </section>
         <!-- content end -->

--- a/tests/Integration/tests/images/No-Folders/expected/index.html
+++ b/tests/Integration/tests/images/No-Folders/expected/index.html
@@ -1,6 +1,6 @@
 <!-- content start -->
                 <section class="section" id="document-title">
-            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
 
     <p>Lorem Ipsum Dolor.</p>
 

--- a/tests/Integration/tests/images/Only-Image-Folder/expected/index.html
+++ b/tests/Integration/tests/images/Only-Image-Folder/expected/index.html
@@ -1,6 +1,6 @@
 <!-- content start -->
                 <section class="section" id="document-title">
-            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
 
     <p>Lorem Ipsum Dolor.</p>
 

--- a/tests/Integration/tests/images/Only-Index-Folder/expected/Folder/index.html
+++ b/tests/Integration/tests/images/Only-Index-Folder/expected/Folder/index.html
@@ -1,6 +1,6 @@
 <!-- content start -->
                 <section class="section" id="document-title">
-            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
 
     <p>Lorem Ipsum Dolor.</p>
 

--- a/tests/Integration/tests/images/Only-Index-Folder/expected/index.html
+++ b/tests/Integration/tests/images/Only-Index-Folder/expected/index.html
@@ -1,6 +1,6 @@
 <!-- content start -->
                 <section class="section" id="root-document">
-            <h1>root document<a class="headerlink" href="#root-document" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>root document<a class="headerlink" href="#root-document" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
 
     </section>
         <!-- content end -->

--- a/tests/Integration/tests/include-glob/expected/index.html
+++ b/tests/Integration/tests/include-glob/expected/index.html
@@ -1,6 +1,6 @@
 <!-- content start -->
                 <section class="section" id="includes-with-glob">
-            <h1>Includes with glob<a class="headerlink" href="#includes-with-glob" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Includes with glob<a class="headerlink" href="#includes-with-glob" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
                 <div class="float-end">
         <a href="https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-CoreApi/edit/documentation-draft/Documentation/_includes/_a.rst.txt" class="btn btn-light" title="Edit following section on GitHub">
             <i class="icon fa-brands fa-github"></i>

--- a/tests/Integration/tests/index/expected/index.html
+++ b/tests/Integration/tests/index/expected/index.html
@@ -1,6 +1,6 @@
 <!-- content start -->
                 <section class="section" id="document-title">
-            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
 
     <p>Lorem Ipsum Dolor.</p>
 

--- a/tests/Integration/tests/interlink/interlink-doc/expected/index.html
+++ b/tests/Integration/tests/interlink/interlink-doc/expected/index.html
@@ -1,6 +1,6 @@
 <!-- content start -->
                 <section class="section" id="document-title">
-            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
 
     <p>See <a href="https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/Reference/ReStructuredText/Links/Index.html#how-to-document-hyperlinks">Links in ReStructured Text</a> for information about how to use cross-references.</p>
 

--- a/tests/Integration/tests/interlink/interlink-warn/expected/index.html
+++ b/tests/Integration/tests/interlink/interlink-warn/expected/index.html
@@ -1,6 +1,6 @@
 <!-- content start -->
                 <section class="section" id="document-title">
-            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
 
     <p>See <span class="invalid-link" title="This link cannot be resolved anymore">t3tsref:data-type-list</span>.</p>
 

--- a/tests/Integration/tests/interlink/typo3_core_preferred/typo3_core_preferred_11.5/expected/index.html
+++ b/tests/Integration/tests/interlink/typo3_core_preferred/typo3_core_preferred_11.5/expected/index.html
@@ -1,6 +1,6 @@
 <!-- content start -->
                 <section class="section" id="document-title">
-            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
 
     <p>See <a href="https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/Reference/ReStructuredText/Links/Index.html#how-to-document-hyperlinks">Links in ReStructured Text</a> for information about how to use cross-references.</p>
 

--- a/tests/Integration/tests/interlink/typo3_core_preferred/typo3_core_preferred_default/expected/index.html
+++ b/tests/Integration/tests/interlink/typo3_core_preferred/typo3_core_preferred_default/expected/index.html
@@ -1,6 +1,6 @@
 <!-- content start -->
                 <section class="section" id="document-title">
-            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
 
     <p>See <a href="https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/Reference/ReStructuredText/Links/Index.html#how-to-document-hyperlinks">Links in ReStructured Text</a> for information about how to use cross-references.</p>
 

--- a/tests/Integration/tests/interlink/typo3_core_preferred/typo3_core_preferred_main/expected/index.html
+++ b/tests/Integration/tests/interlink/typo3_core_preferred/typo3_core_preferred_main/expected/index.html
@@ -1,6 +1,6 @@
 <!-- content start -->
                 <section class="section" id="document-title">
-            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
 
     <p>See <a href="https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/Reference/ReStructuredText/Links/Index.html#how-to-document-hyperlinks">Links in ReStructured Text</a> for information about how to use cross-references.</p>
 

--- a/tests/Integration/tests/interlink/typo3_core_preferred/typo3_core_preferred_stable/expected/index.html
+++ b/tests/Integration/tests/interlink/typo3_core_preferred/typo3_core_preferred_stable/expected/index.html
@@ -1,6 +1,6 @@
 <!-- content start -->
                 <section class="section" id="document-title">
-            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
 
     <p>See <a href="https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/Reference/ReStructuredText/Links/Index.html#how-to-document-hyperlinks">Links in ReStructured Text</a> for information about how to use cross-references.</p>
 

--- a/tests/Integration/tests/literal/expected/index.html
+++ b/tests/Integration/tests/literal/expected/index.html
@@ -1,6 +1,6 @@
 <!-- content start -->
                 <section class="section" id="literal">
-            <h1>Literal<a class="headerlink" href="#literal" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Literal<a class="headerlink" href="#literal" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
 
     <p><code class="code-inline" translate="no">some literal</code></p>
 

--- a/tests/Integration/tests/markdown/expected/README.html
+++ b/tests/Integration/tests/markdown/expected/README.html
@@ -1,11 +1,11 @@
 <!-- content start -->
                 <section class="section" id="child-s-swing-usage-guide">
-            <h1>Child&#039;s Swing Usage Guide<a class="headerlink" href="#child-s-swing-usage-guide" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Child&#039;s Swing Usage Guide<a class="headerlink" href="#child-s-swing-usage-guide" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
 
     <p>Welcome to the world of fun and laughter with our child&#039;s swing! Follow thesimple steps below to ensure a safe and enjoyable experience for your littleone.</p>
 
             <section class="section" id="table-of-contents">
-            <h2>Table of Contents<a class="headerlink" href="#table-of-contents" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h2>
+            <h2>Table of Contents<a class="headerlink" href="#table-of-contents" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h2>
 
 
 <ul>
@@ -29,7 +29,7 @@
             <hr />
     </section>
             <section class="section" id="installation">
-            <h2>Installation<a class="headerlink" href="#installation" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h2>
+            <h2>Installation<a class="headerlink" href="#installation" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h2>
 
     <p><img src="https://upload.wikimedia.org/wikipedia/commons/a/a3/Forgiveness_5.gif" alt="Swing Image"/></p>
 
@@ -49,7 +49,7 @@
 
     </section>
             <section class="section" id="usage">
-            <h2>Usage<a class="headerlink" href="#usage" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h2>
+            <h2>Usage<a class="headerlink" href="#usage" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h2>
 
 
 <ol>
@@ -87,7 +87,7 @@ end procedure
     <p>&quot;Swinging is not just a physical activity; it&#039;s a journey into the world ofimagination and joy.&quot;</p>
 </blockquote>
             <section class="section" id="additional-tips">
-            <h3>Additional Tips:<a class="headerlink" href="#additional-tips" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h3>
+            <h3>Additional Tips:<a class="headerlink" href="#additional-tips" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h3>
 
 
 <ul>
@@ -102,7 +102,7 @@ end procedure
     </section>
     </section>
             <section class="section" id="safety-guidelines">
-            <h2>Safety Guidelines<a class="headerlink" href="#safety-guidelines" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h2>
+            <h2>Safety Guidelines<a class="headerlink" href="#safety-guidelines" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h2>
 
 
 <ol>
@@ -122,7 +122,7 @@ end procedure
 
     </section>
             <section class="section" id="maintenance">
-            <h2>Maintenance<a class="headerlink" href="#maintenance" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h2>
+            <h2>Maintenance<a class="headerlink" href="#maintenance" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h2>
 
 
 <ol>
@@ -139,7 +139,7 @@ end procedure
 
     </section>
             <section class="section" id="troubleshooting">
-            <h2>Troubleshooting<a class="headerlink" href="#troubleshooting" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h2>
+            <h2>Troubleshooting<a class="headerlink" href="#troubleshooting" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h2>
 
 
 <ul>

--- a/tests/Integration/tests/php-domain/expected/index.html
+++ b/tests/Integration/tests/php-domain/expected/index.html
@@ -1,12 +1,12 @@
 <!-- content start -->
                 <section class="section" id="php-interface-with-implicit-namespace">
-            <h1>PHP Interface with implicit namespace<a class="headerlink" href="#php-interface-with-implicit-namespace" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>PHP Interface with implicit namespace<a class="headerlink" href="#php-interface-with-implicit-namespace" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
             <dl class="php interface">
     <dt class="sig sig-object php" id="typo3-cms-core-testinterface">
         <em class="property"><span class="pre">interface</span> </em>
         <span class="sig-name descname">
     <span class="pre fqn" data-fqn="\TYPO3\CMS\Core\TestInterface" title="\TYPO3\CMS\Core\TestInterface">TestInterface</span>
-</span><a class="headerlink" href="#typo3-cms-core-testinterface" data-id="typo3-cms-core-testinterface" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-rstCode=":php:interface:`somemanual:\TYPO3\CMS\Core\TestInterface`"  title="Reference this definition">¶</a>
+</span><a class="headerlink" href="#typo3-cms-core-testinterface" data-id="typo3-cms-core-testinterface" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-rstCode=":php:interface:`somemanual:\TYPO3\CMS\Core\TestInterface`"  title="Reference this definition"><i class="fa-solid fa-paragraph"></i></a>
     </dt>
     <dd>
                     <dl class="field-list simple">
@@ -21,7 +21,7 @@
 <span class="sig-name descname"><span class="pre">setDate</span></span>
 <span class="sig-paren">(</span>
 <em class="sig-param"><span class="pre">int $year</span></em>, <em class="sig-param"><span class="pre">int $month</span></em>, <em class="sig-param"><span class="pre">int $day</span></em><span class="sig-paren">)</span>
-        <a class="headerlink" href="#typo3-cms-core-testinterface-setdate" data-id="typo3-cms-core-testinterface-setdate" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-rstCode=":php:method:`somemanual:\TYPO3\CMS\Core\TestInterface::setDate`"  title="Reference this definition">¶</a>
+        <a class="headerlink" href="#typo3-cms-core-testinterface-setdate" data-id="typo3-cms-core-testinterface-setdate" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-rstCode=":php:method:`somemanual:\TYPO3\CMS\Core\TestInterface::setDate`"  title="Reference this definition"><i class="fa-solid fa-paragraph"></i></a>
     </dt>
     <dd>
 
@@ -34,7 +34,7 @@
 <span class="sig-paren">(</span>
 <span class="sig-paren">)</span>
 <em class="sig-returns"><span class="pre">: int</span></em>
-        <a class="headerlink" href="#typo3-cms-core-testinterface-getdate" data-id="typo3-cms-core-testinterface-getdate" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-rstCode=":php:method:`somemanual:\TYPO3\CMS\Core\TestInterface::getDate`"  title="Reference this definition">¶</a>
+        <a class="headerlink" href="#typo3-cms-core-testinterface-getdate" data-id="typo3-cms-core-testinterface-getdate" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-rstCode=":php:method:`somemanual:\TYPO3\CMS\Core\TestInterface::getDate`"  title="Reference this definition"><i class="fa-solid fa-paragraph"></i></a>
     </dt>
     <dd>
 

--- a/tests/Integration/tests/raw-forbidden/expected/index.html
+++ b/tests/Integration/tests/raw-forbidden/expected/index.html
@@ -1,5 +1,5 @@
 <!-- content start -->
                 <section class="section" id="raw-directive-must-not-work">
-            <h1>Raw directive must not work<a class="headerlink" href="#raw-directive-must-not-work" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Raw directive must not work<a class="headerlink" href="#raw-directive-must-not-work" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
     </section>
         <!-- content end -->

--- a/tests/Integration/tests/roles/role-composer-warning/expected/index.html
+++ b/tests/Integration/tests/roles/role-composer-warning/expected/index.html
@@ -1,6 +1,6 @@
 <!-- content start -->
                 <section class="section" id="document-title">
-            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
 
     <p>You can also install extensions like news and
 georgringer/news-administration.</p>

--- a/tests/Integration/tests/roles/role-composer/expected/index.html
+++ b/tests/Integration/tests/roles/role-composer/expected/index.html
@@ -1,6 +1,6 @@
 <!-- content start -->
                 <section class="section" id="document-title">
-            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
 
     <p>You can use the <a class="composer-link"
    href="https://packagist.org/packages/typo3/testing-framework"

--- a/tests/Integration/tests/roles/role-file/expected/index.html
+++ b/tests/Integration/tests/roles/role-file/expected/index.html
@@ -1,6 +1,6 @@
 <!-- content start -->
                 <section class="section" id="document-title">
-            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
 
     <p>Configure your manual in <code class="code-inline file" translate="no" title="File path">Documentation/<wbr>guides.<wbr>xml</code>.</p>
 

--- a/tests/Integration/tests/roles/role-issue-invalid/expected/index.html
+++ b/tests/Integration/tests/roles/role-issue-invalid/expected/index.html
@@ -1,6 +1,6 @@
 <!-- content start -->
                 <section class="section" id="document-title">
-            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
 
     <p>Lorem Ipsum Dolor. See also <a href="https://forge.typo3.org/">Forge</a> or <a href="https://forge.typo3.org/">Lorem Ipsum</a>.</p>
 

--- a/tests/Integration/tests/roles/role-issue/expected/index.html
+++ b/tests/Integration/tests/roles/role-issue/expected/index.html
@@ -1,6 +1,6 @@
 <!-- content start -->
                 <section class="section" id="document-title">
-            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
 
     <p>Lorem Ipsum Dolor. See also <a href="https://forge.typo3.org/issues/102056">forge#102056</a> or <a href="https://forge.typo3.org/issues/99508">Lorem Ipsum</a>.</p>
 

--- a/tests/Integration/tests/roles/role-t3ext/expected/index.html
+++ b/tests/Integration/tests/roles/role-t3ext/expected/index.html
@@ -1,6 +1,6 @@
 <!-- content start -->
                 <section class="section" id="document-title">
-            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
 
     <p>As an example, you may want to take a look at extension
 <a href="https://extensions.typo3.org/extension/fal_securedownload">EXT:fal_securedownload</a> or <a href="https://extensions.typo3.org/extension/news">EXT:news</a>, <a href="https://extensions.typo3.org/extension/news">news</a>.</p>

--- a/tests/Integration/tests/roles/role-t3src-core-prefered/expected/index.html
+++ b/tests/Integration/tests/roles/role-t3src-core-prefered/expected/index.html
@@ -1,6 +1,6 @@
 <!-- content start -->
                 <section class="section" id="document-title">
-            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
 
     <p>Here is an extract of <a href="https://github.com/typo3/typo3/blob/main/typo3/sysext/backend/Configuration/Backend/Routes.php">EXT:backend/Configuration/Backend/Routes.php (GitHub)</a>.</p>
 

--- a/tests/Integration/tests/roles/role-t3src/expected/index.html
+++ b/tests/Integration/tests/roles/role-t3src/expected/index.html
@@ -1,6 +1,6 @@
 <!-- content start -->
                 <section class="section" id="document-title">
-            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
 
     <p>Here is an extract of <a href="https://github.com/typo3/typo3/blob/12.4/typo3/sysext/backend/Configuration/Backend/Routes.php">EXT:backend/Configuration/Backend/Routes.php (GitHub)</a>.</p>
 

--- a/tests/Integration/tests/sidebar/expected/index.html
+++ b/tests/Integration/tests/sidebar/expected/index.html
@@ -3,7 +3,7 @@
             <a id="rest-confval"></a>
             <a id="rest-tabs"></a>
             <a id="rest-cards"></a>
-            <h1>Sidebar<a class="headerlink" href="#sidebar" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Sidebar<a class="headerlink" href="#sidebar" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
             <div class="sidebar">
     <p class="sidebar-title">reST content elements</p>
 

--- a/tests/Integration/tests/singlepage-by-toctree/expected/singlehtml/Index.html
+++ b/tests/Integration/tests/singlepage-by-toctree/expected/singlehtml/Index.html
@@ -1,7 +1,7 @@
 <!-- content start -->
     <article>
             <section class="section" id="root-index">
-            <h1>Root index<a class="headerlink" href="#root-index" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Root index<a class="headerlink" href="#root-index" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
 
     <p>Lorem Ipsum Dolor.</p>
 
@@ -45,7 +45,7 @@
         </article>
 <article>
             <section class="section" id="root-index">
-            <h1>Root index<a class="headerlink" href="#root-index" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Root index<a class="headerlink" href="#root-index" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
 
     <p>Lorem Ipsum Dolor.</p>
 
@@ -89,7 +89,7 @@
         </article>
 <article>
             <section class="section" id="one">
-            <h1>One<a class="headerlink" href="#one" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>One<a class="headerlink" href="#one" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
 
     <p>Lorem Ipsum Dolor 1</p>
 
@@ -98,7 +98,7 @@
         </article>
 <article>
             <section class="section" id="two">
-            <h1>Two<a class="headerlink" href="#two" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Two<a class="headerlink" href="#two" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
 
     <p>Lorem Ipsum Dolor. 2</p>
 
@@ -107,7 +107,7 @@
         </article>
 <article>
             <section class="section" id="three-point-something">
-            <h1>Three point something<a class="headerlink" href="#three-point-something" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Three point something<a class="headerlink" href="#three-point-something" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
 
     <p>Lorem Ipsum Dolor.</p>
 
@@ -130,7 +130,7 @@
         </article>
 <article>
             <section class="section" id="three">
-            <h1>Three<a class="headerlink" href="#three" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Three<a class="headerlink" href="#three" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
 
     <p>Lorem Ipsum Dolor. 3.</p>
 
@@ -139,7 +139,7 @@
         </article>
 <article>
             <section class="section" id="3-5">
-            <h1>3.5<a class="headerlink" href="#3-5" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>3.5<a class="headerlink" href="#3-5" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
 
     <p>Lorem Ipsum Dolor.</p>
 
@@ -148,7 +148,7 @@
         </article>
 <article>
             <section class="section" id="four">
-            <h1>Four<a class="headerlink" href="#four" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Four<a class="headerlink" href="#four" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
 
     <p>Lorem Ipsum Dolor. <a href="https://typ03.org">index</a></p>
 
@@ -157,7 +157,7 @@
         </article>
 <article>
             <section class="section" id="i-sqrt-1">
-            <h1>i (sqrt(-1))<a class="headerlink" href="#i-sqrt-1" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>i (sqrt(-1))<a class="headerlink" href="#i-sqrt-1" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
 
     <p>Irreal: orphan</p>
 
@@ -166,7 +166,7 @@
         </article>
 <article>
             <section class="section" id="pi">
-            <h1>Pi<a class="headerlink" href="#pi" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Pi<a class="headerlink" href="#pi" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
 
     <p>Irrational: Orphan</p>
 

--- a/tests/Integration/tests/singlepage/expected/singlehtml/Index.html
+++ b/tests/Integration/tests/singlepage/expected/singlehtml/Index.html
@@ -1,7 +1,7 @@
 <!-- content start -->
     <article>
             <section class="section" id="root-index">
-            <h1>Root index<a class="headerlink" href="#root-index" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Root index<a class="headerlink" href="#root-index" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
 
     <p>Lorem Ipsum Dolor. <a href="https://typ03.org">index</a></p>
 
@@ -10,7 +10,7 @@
         </article>
 <article>
             <section class="section" id="root-index">
-            <h1>Root index<a class="headerlink" href="#root-index" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Root index<a class="headerlink" href="#root-index" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
 
     <p>Lorem Ipsum Dolor. <a href="https://typ03.org">index</a></p>
 
@@ -19,7 +19,7 @@
         </article>
 <article>
             <section class="section" id="root-index">
-            <h1>Root index<a class="headerlink" href="#root-index" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Root index<a class="headerlink" href="#root-index" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
 
     <p>Lorem Ipsum Dolor. <a href="https://typ03.org">index</a></p>
 
@@ -28,7 +28,7 @@
         </article>
 <article>
             <section class="section" id="sub-index">
-            <h1>Sub index<a class="headerlink" href="#sub-index" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Sub index<a class="headerlink" href="#sub-index" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
 
     <p>Lorem Ipsum Dolor. <a href="https://typ03.org">index</a></p>
 

--- a/tests/Integration/tests/site-set-ext-syntax/expected/index.html
+++ b/tests/Integration/tests/site-set-ext-syntax/expected/index.html
@@ -1,6 +1,6 @@
 <!-- content start -->
                 <section class="section" id="site-set-configuration">
-            <h1>Site Set Configuration<a class="headerlink" href="#site-set-configuration" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Site Set Configuration<a class="headerlink" href="#site-set-configuration" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
 
 
 
@@ -359,7 +359,7 @@
     <dt id="confval-fluid-styled-content-styles-content-defaultheadertype" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">styles.<wbr>content.<wbr>default<wbr>Header<wbr>Type</span></code>
-                <a class="headerlink" href="#confval-fluid-styled-content-styles-content-defaultheadertype" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-fluid-styled-content-styles-content-defaultheadertype" data-rstCode=":confval:`styles.content.defaultHeaderType &lt;somemanual:fluid-styled-content-styles-content-defaultheadertype&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-fluid-styled-content-styles-content-defaultheadertype" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-fluid-styled-content-styles-content-defaultheadertype" data-rstCode=":confval:`styles.content.defaultHeaderType &lt;somemanual:fluid-styled-content-styles-content-defaultheadertype&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -393,7 +393,7 @@
     <dt id="confval-fluid-styled-content-styles-content-shortcut-tables" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">styles.<wbr>content.<wbr>shortcut.<wbr>tables</span></code>
-                <a class="headerlink" href="#confval-fluid-styled-content-styles-content-shortcut-tables" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-fluid-styled-content-styles-content-shortcut-tables" data-rstCode=":confval:`styles.content.shortcut.tables &lt;somemanual:fluid-styled-content-styles-content-shortcut-tables&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-fluid-styled-content-styles-content-shortcut-tables" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-fluid-styled-content-styles-content-shortcut-tables" data-rstCode=":confval:`styles.content.shortcut.tables &lt;somemanual:fluid-styled-content-styles-content-shortcut-tables&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -426,7 +426,7 @@
     <dt id="confval-fluid-styled-content-styles-content-allowtags" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">styles.<wbr>content.<wbr>allow<wbr>Tags</span></code>
-                <a class="headerlink" href="#confval-fluid-styled-content-styles-content-allowtags" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-fluid-styled-content-styles-content-allowtags" data-rstCode=":confval:`styles.content.allowTags &lt;somemanual:fluid-styled-content-styles-content-allowtags&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-fluid-styled-content-styles-content-allowtags" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-fluid-styled-content-styles-content-allowtags" data-rstCode=":confval:`styles.content.allowTags &lt;somemanual:fluid-styled-content-styles-content-allowtags&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -459,7 +459,7 @@
     <dt id="confval-fluid-styled-content-styles-content-image-lazyloading" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">styles.<wbr>content.<wbr>image.<wbr>lazy<wbr>Loading</span></code>
-                <a class="headerlink" href="#confval-fluid-styled-content-styles-content-image-lazyloading" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-fluid-styled-content-styles-content-image-lazyloading" data-rstCode=":confval:`styles.content.image.lazyLoading &lt;somemanual:fluid-styled-content-styles-content-image-lazyloading&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-fluid-styled-content-styles-content-image-lazyloading" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-fluid-styled-content-styles-content-image-lazyloading" data-rstCode=":confval:`styles.content.image.lazyLoading &lt;somemanual:fluid-styled-content-styles-content-image-lazyloading&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -493,7 +493,7 @@
     <dt id="confval-fluid-styled-content-styles-content-image-imagedecoding" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">styles.<wbr>content.<wbr>image.<wbr>image<wbr>Decoding</span></code>
-                <a class="headerlink" href="#confval-fluid-styled-content-styles-content-image-imagedecoding" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-fluid-styled-content-styles-content-image-imagedecoding" data-rstCode=":confval:`styles.content.image.imageDecoding &lt;somemanual:fluid-styled-content-styles-content-image-imagedecoding&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-fluid-styled-content-styles-content-image-imagedecoding" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-fluid-styled-content-styles-content-image-imagedecoding" data-rstCode=":confval:`styles.content.image.imageDecoding &lt;somemanual:fluid-styled-content-styles-content-image-imagedecoding&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -520,7 +520,7 @@
     <dt id="confval-fluid-styled-content-styles-content-textmedia-maxw" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">styles.<wbr>content.<wbr>textmedia.<wbr>max<wbr>W</span></code>
-                <a class="headerlink" href="#confval-fluid-styled-content-styles-content-textmedia-maxw" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-fluid-styled-content-styles-content-textmedia-maxw" data-rstCode=":confval:`styles.content.textmedia.maxW &lt;somemanual:fluid-styled-content-styles-content-textmedia-maxw&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-fluid-styled-content-styles-content-textmedia-maxw" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-fluid-styled-content-styles-content-textmedia-maxw" data-rstCode=":confval:`styles.content.textmedia.maxW &lt;somemanual:fluid-styled-content-styles-content-textmedia-maxw&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -554,7 +554,7 @@
     <dt id="confval-fluid-styled-content-styles-content-textmedia-maxwintext" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">styles.<wbr>content.<wbr>textmedia.<wbr>max<wbr>WIn<wbr>Text</span></code>
-                <a class="headerlink" href="#confval-fluid-styled-content-styles-content-textmedia-maxwintext" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-fluid-styled-content-styles-content-textmedia-maxwintext" data-rstCode=":confval:`styles.content.textmedia.maxWInText &lt;somemanual:fluid-styled-content-styles-content-textmedia-maxwintext&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-fluid-styled-content-styles-content-textmedia-maxwintext" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-fluid-styled-content-styles-content-textmedia-maxwintext" data-rstCode=":confval:`styles.content.textmedia.maxWInText &lt;somemanual:fluid-styled-content-styles-content-textmedia-maxwintext&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -588,7 +588,7 @@
     <dt id="confval-fluid-styled-content-styles-content-textmedia-columnspacing" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">styles.<wbr>content.<wbr>textmedia.<wbr>column<wbr>Spacing</span></code>
-                <a class="headerlink" href="#confval-fluid-styled-content-styles-content-textmedia-columnspacing" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-fluid-styled-content-styles-content-textmedia-columnspacing" data-rstCode=":confval:`styles.content.textmedia.columnSpacing &lt;somemanual:fluid-styled-content-styles-content-textmedia-columnspacing&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-fluid-styled-content-styles-content-textmedia-columnspacing" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-fluid-styled-content-styles-content-textmedia-columnspacing" data-rstCode=":confval:`styles.content.textmedia.columnSpacing &lt;somemanual:fluid-styled-content-styles-content-textmedia-columnspacing&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -622,7 +622,7 @@
     <dt id="confval-fluid-styled-content-styles-content-textmedia-rowspacing" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">styles.<wbr>content.<wbr>textmedia.<wbr>row<wbr>Spacing</span></code>
-                <a class="headerlink" href="#confval-fluid-styled-content-styles-content-textmedia-rowspacing" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-fluid-styled-content-styles-content-textmedia-rowspacing" data-rstCode=":confval:`styles.content.textmedia.rowSpacing &lt;somemanual:fluid-styled-content-styles-content-textmedia-rowspacing&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-fluid-styled-content-styles-content-textmedia-rowspacing" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-fluid-styled-content-styles-content-textmedia-rowspacing" data-rstCode=":confval:`styles.content.textmedia.rowSpacing &lt;somemanual:fluid-styled-content-styles-content-textmedia-rowspacing&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -656,7 +656,7 @@
     <dt id="confval-fluid-styled-content-styles-content-textmedia-textmargin" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">styles.<wbr>content.<wbr>textmedia.<wbr>text<wbr>Margin</span></code>
-                <a class="headerlink" href="#confval-fluid-styled-content-styles-content-textmedia-textmargin" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-fluid-styled-content-styles-content-textmedia-textmargin" data-rstCode=":confval:`styles.content.textmedia.textMargin &lt;somemanual:fluid-styled-content-styles-content-textmedia-textmargin&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-fluid-styled-content-styles-content-textmedia-textmargin" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-fluid-styled-content-styles-content-textmedia-textmargin" data-rstCode=":confval:`styles.content.textmedia.textMargin &lt;somemanual:fluid-styled-content-styles-content-textmedia-textmargin&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -690,7 +690,7 @@
     <dt id="confval-fluid-styled-content-styles-content-textmedia-bordercolor" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">styles.<wbr>content.<wbr>textmedia.<wbr>border<wbr>Color</span></code>
-                <a class="headerlink" href="#confval-fluid-styled-content-styles-content-textmedia-bordercolor" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-fluid-styled-content-styles-content-textmedia-bordercolor" data-rstCode=":confval:`styles.content.textmedia.borderColor &lt;somemanual:fluid-styled-content-styles-content-textmedia-bordercolor&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-fluid-styled-content-styles-content-textmedia-bordercolor" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-fluid-styled-content-styles-content-textmedia-bordercolor" data-rstCode=":confval:`styles.content.textmedia.borderColor &lt;somemanual:fluid-styled-content-styles-content-textmedia-bordercolor&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -724,7 +724,7 @@
     <dt id="confval-fluid-styled-content-styles-content-textmedia-borderwidth" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">styles.<wbr>content.<wbr>textmedia.<wbr>border<wbr>Width</span></code>
-                <a class="headerlink" href="#confval-fluid-styled-content-styles-content-textmedia-borderwidth" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-fluid-styled-content-styles-content-textmedia-borderwidth" data-rstCode=":confval:`styles.content.textmedia.borderWidth &lt;somemanual:fluid-styled-content-styles-content-textmedia-borderwidth&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-fluid-styled-content-styles-content-textmedia-borderwidth" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-fluid-styled-content-styles-content-textmedia-borderwidth" data-rstCode=":confval:`styles.content.textmedia.borderWidth &lt;somemanual:fluid-styled-content-styles-content-textmedia-borderwidth&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -758,7 +758,7 @@
     <dt id="confval-fluid-styled-content-styles-content-textmedia-borderpadding" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">styles.<wbr>content.<wbr>textmedia.<wbr>border<wbr>Padding</span></code>
-                <a class="headerlink" href="#confval-fluid-styled-content-styles-content-textmedia-borderpadding" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-fluid-styled-content-styles-content-textmedia-borderpadding" data-rstCode=":confval:`styles.content.textmedia.borderPadding &lt;somemanual:fluid-styled-content-styles-content-textmedia-borderpadding&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-fluid-styled-content-styles-content-textmedia-borderpadding" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-fluid-styled-content-styles-content-textmedia-borderpadding" data-rstCode=":confval:`styles.content.textmedia.borderPadding &lt;somemanual:fluid-styled-content-styles-content-textmedia-borderpadding&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -792,7 +792,7 @@
     <dt id="confval-fluid-styled-content-styles-content-textmedia-linkwrap-width" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">styles.<wbr>content.<wbr>textmedia.<wbr>link<wbr>Wrap.<wbr>width</span></code>
-                <a class="headerlink" href="#confval-fluid-styled-content-styles-content-textmedia-linkwrap-width" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-fluid-styled-content-styles-content-textmedia-linkwrap-width" data-rstCode=":confval:`styles.content.textmedia.linkWrap.width &lt;somemanual:fluid-styled-content-styles-content-textmedia-linkwrap-width&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-fluid-styled-content-styles-content-textmedia-linkwrap-width" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-fluid-styled-content-styles-content-textmedia-linkwrap-width" data-rstCode=":confval:`styles.content.textmedia.linkWrap.width &lt;somemanual:fluid-styled-content-styles-content-textmedia-linkwrap-width&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -826,7 +826,7 @@
     <dt id="confval-fluid-styled-content-styles-content-textmedia-linkwrap-height" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">styles.<wbr>content.<wbr>textmedia.<wbr>link<wbr>Wrap.<wbr>height</span></code>
-                <a class="headerlink" href="#confval-fluid-styled-content-styles-content-textmedia-linkwrap-height" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-fluid-styled-content-styles-content-textmedia-linkwrap-height" data-rstCode=":confval:`styles.content.textmedia.linkWrap.height &lt;somemanual:fluid-styled-content-styles-content-textmedia-linkwrap-height&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-fluid-styled-content-styles-content-textmedia-linkwrap-height" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-fluid-styled-content-styles-content-textmedia-linkwrap-height" data-rstCode=":confval:`styles.content.textmedia.linkWrap.height &lt;somemanual:fluid-styled-content-styles-content-textmedia-linkwrap-height&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -860,7 +860,7 @@
     <dt id="confval-fluid-styled-content-styles-content-textmedia-linkwrap-newwindow" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">styles.<wbr>content.<wbr>textmedia.<wbr>link<wbr>Wrap.<wbr>new<wbr>Window</span></code>
-                <a class="headerlink" href="#confval-fluid-styled-content-styles-content-textmedia-linkwrap-newwindow" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-fluid-styled-content-styles-content-textmedia-linkwrap-newwindow" data-rstCode=":confval:`styles.content.textmedia.linkWrap.newWindow &lt;somemanual:fluid-styled-content-styles-content-textmedia-linkwrap-newwindow&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-fluid-styled-content-styles-content-textmedia-linkwrap-newwindow" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-fluid-styled-content-styles-content-textmedia-linkwrap-newwindow" data-rstCode=":confval:`styles.content.textmedia.linkWrap.newWindow &lt;somemanual:fluid-styled-content-styles-content-textmedia-linkwrap-newwindow&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -894,7 +894,7 @@
     <dt id="confval-fluid-styled-content-styles-content-textmedia-linkwrap-lightboxenabled" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">styles.<wbr>content.<wbr>textmedia.<wbr>link<wbr>Wrap.<wbr>lightbox<wbr>Enabled</span></code>
-                <a class="headerlink" href="#confval-fluid-styled-content-styles-content-textmedia-linkwrap-lightboxenabled" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-fluid-styled-content-styles-content-textmedia-linkwrap-lightboxenabled" data-rstCode=":confval:`styles.content.textmedia.linkWrap.lightboxEnabled &lt;somemanual:fluid-styled-content-styles-content-textmedia-linkwrap-lightboxenabled&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-fluid-styled-content-styles-content-textmedia-linkwrap-lightboxenabled" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-fluid-styled-content-styles-content-textmedia-linkwrap-lightboxenabled" data-rstCode=":confval:`styles.content.textmedia.linkWrap.lightboxEnabled &lt;somemanual:fluid-styled-content-styles-content-textmedia-linkwrap-lightboxenabled&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -928,7 +928,7 @@
     <dt id="confval-fluid-styled-content-styles-content-textmedia-linkwrap-lightboxcssclass" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">styles.<wbr>content.<wbr>textmedia.<wbr>link<wbr>Wrap.<wbr>lightbox<wbr>Css<wbr>Class</span></code>
-                <a class="headerlink" href="#confval-fluid-styled-content-styles-content-textmedia-linkwrap-lightboxcssclass" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-fluid-styled-content-styles-content-textmedia-linkwrap-lightboxcssclass" data-rstCode=":confval:`styles.content.textmedia.linkWrap.lightboxCssClass &lt;somemanual:fluid-styled-content-styles-content-textmedia-linkwrap-lightboxcssclass&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-fluid-styled-content-styles-content-textmedia-linkwrap-lightboxcssclass" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-fluid-styled-content-styles-content-textmedia-linkwrap-lightboxcssclass" data-rstCode=":confval:`styles.content.textmedia.linkWrap.lightboxCssClass &lt;somemanual:fluid-styled-content-styles-content-textmedia-linkwrap-lightboxcssclass&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -962,7 +962,7 @@
     <dt id="confval-fluid-styled-content-styles-content-textmedia-linkwrap-lightboxrelattribute" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">styles.<wbr>content.<wbr>textmedia.<wbr>link<wbr>Wrap.<wbr>lightbox<wbr>Rel<wbr>Attribute</span></code>
-                <a class="headerlink" href="#confval-fluid-styled-content-styles-content-textmedia-linkwrap-lightboxrelattribute" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-fluid-styled-content-styles-content-textmedia-linkwrap-lightboxrelattribute" data-rstCode=":confval:`styles.content.textmedia.linkWrap.lightboxRelAttribute &lt;somemanual:fluid-styled-content-styles-content-textmedia-linkwrap-lightboxrelattribute&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-fluid-styled-content-styles-content-textmedia-linkwrap-lightboxrelattribute" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-fluid-styled-content-styles-content-textmedia-linkwrap-lightboxrelattribute" data-rstCode=":confval:`styles.content.textmedia.linkWrap.lightboxRelAttribute &lt;somemanual:fluid-styled-content-styles-content-textmedia-linkwrap-lightboxrelattribute&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -996,7 +996,7 @@
     <dt id="confval-fluid-styled-content-styles-content-links-exttarget" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">styles.<wbr>content.<wbr>links.<wbr>ext<wbr>Target</span></code>
-                <a class="headerlink" href="#confval-fluid-styled-content-styles-content-links-exttarget" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-fluid-styled-content-styles-content-links-exttarget" data-rstCode=":confval:`styles.content.links.extTarget &lt;somemanual:fluid-styled-content-styles-content-links-exttarget&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-fluid-styled-content-styles-content-links-exttarget" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-fluid-styled-content-styles-content-links-exttarget" data-rstCode=":confval:`styles.content.links.extTarget &lt;somemanual:fluid-styled-content-styles-content-links-exttarget&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -1029,7 +1029,7 @@
     <dt id="confval-fluid-styled-content-styles-content-links-keep" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">styles.<wbr>content.<wbr>links.<wbr>keep</span></code>
-                <a class="headerlink" href="#confval-fluid-styled-content-styles-content-links-keep" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-fluid-styled-content-styles-content-links-keep" data-rstCode=":confval:`styles.content.links.keep &lt;somemanual:fluid-styled-content-styles-content-links-keep&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-fluid-styled-content-styles-content-links-keep" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-fluid-styled-content-styles-content-links-keep" data-rstCode=":confval:`styles.content.links.keep &lt;somemanual:fluid-styled-content-styles-content-links-keep&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -1063,7 +1063,7 @@
     <dt id="confval-fluid-styled-content-styles-templates-templaterootpath" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">styles.<wbr>templates.<wbr>template<wbr>Root<wbr>Path</span></code>
-                <a class="headerlink" href="#confval-fluid-styled-content-styles-templates-templaterootpath" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-fluid-styled-content-styles-templates-templaterootpath" data-rstCode=":confval:`styles.templates.templateRootPath &lt;somemanual:fluid-styled-content-styles-templates-templaterootpath&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-fluid-styled-content-styles-templates-templaterootpath" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-fluid-styled-content-styles-templates-templaterootpath" data-rstCode=":confval:`styles.templates.templateRootPath &lt;somemanual:fluid-styled-content-styles-templates-templaterootpath&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -1089,7 +1089,7 @@
     <dt id="confval-fluid-styled-content-styles-templates-partialrootpath" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">styles.<wbr>templates.<wbr>partial<wbr>Root<wbr>Path</span></code>
-                <a class="headerlink" href="#confval-fluid-styled-content-styles-templates-partialrootpath" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-fluid-styled-content-styles-templates-partialrootpath" data-rstCode=":confval:`styles.templates.partialRootPath &lt;somemanual:fluid-styled-content-styles-templates-partialrootpath&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-fluid-styled-content-styles-templates-partialrootpath" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-fluid-styled-content-styles-templates-partialrootpath" data-rstCode=":confval:`styles.templates.partialRootPath &lt;somemanual:fluid-styled-content-styles-templates-partialrootpath&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -1115,7 +1115,7 @@
     <dt id="confval-fluid-styled-content-styles-templates-layoutrootpath" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">styles.<wbr>templates.<wbr>layout<wbr>Root<wbr>Path</span></code>
-                <a class="headerlink" href="#confval-fluid-styled-content-styles-templates-layoutrootpath" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-fluid-styled-content-styles-templates-layoutrootpath" data-rstCode=":confval:`styles.templates.layoutRootPath &lt;somemanual:fluid-styled-content-styles-templates-layoutrootpath&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-fluid-styled-content-styles-templates-layoutrootpath" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-fluid-styled-content-styles-templates-layoutrootpath" data-rstCode=":confval:`styles.templates.layoutRootPath &lt;somemanual:fluid-styled-content-styles-templates-layoutrootpath&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>

--- a/tests/Integration/tests/site-set-failure/expected/index.html
+++ b/tests/Integration/tests/site-set-failure/expected/index.html
@@ -1,5 +1,5 @@
 <!-- content start -->
                 <section class="section" id="site-set-configuration">
-            <h1>Site Set Configuration<a class="headerlink" href="#site-set-configuration" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Site Set Configuration<a class="headerlink" href="#site-set-configuration" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
     </section>
         <!-- content end -->

--- a/tests/Integration/tests/site-set-labels-autoload/expected/index.html
+++ b/tests/Integration/tests/site-set-labels-autoload/expected/index.html
@@ -1,6 +1,6 @@
 <!-- content start -->
                 <section class="section" id="site-set-configuration">
-            <h1>Site Set Configuration<a class="headerlink" href="#site-set-configuration" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Site Set Configuration<a class="headerlink" href="#site-set-configuration" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
 
 
 
@@ -373,7 +373,7 @@
     <dt id="confval-felogin-felogin-pid" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">felogin.<wbr>pid</span></code>
-                <a class="headerlink" href="#confval-felogin-felogin-pid" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-pid" data-rstCode=":confval:`felogin.pid &lt;somemanual:felogin-felogin-pid&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-felogin-felogin-pid" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-pid" data-rstCode=":confval:`felogin.pid &lt;somemanual:felogin-felogin-pid&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -407,7 +407,7 @@
     <dt id="confval-felogin-felogin-recursive" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">felogin.<wbr>recursive</span></code>
-                <a class="headerlink" href="#confval-felogin-felogin-recursive" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-recursive" data-rstCode=":confval:`felogin.recursive &lt;somemanual:felogin-felogin-recursive&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-felogin-felogin-recursive" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-recursive" data-rstCode=":confval:`felogin.recursive &lt;somemanual:felogin-felogin-recursive&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -441,7 +441,7 @@
     <dt id="confval-felogin-felogin-showforgotpassword" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">felogin.<wbr>show<wbr>Forgot<wbr>Password</span></code>
-                <a class="headerlink" href="#confval-felogin-felogin-showforgotpassword" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-showforgotpassword" data-rstCode=":confval:`felogin.showForgotPassword &lt;somemanual:felogin-felogin-showforgotpassword&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-felogin-felogin-showforgotpassword" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-showforgotpassword" data-rstCode=":confval:`felogin.showForgotPassword &lt;somemanual:felogin-felogin-showforgotpassword&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -475,7 +475,7 @@
     <dt id="confval-felogin-felogin-showpermalogin" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">felogin.<wbr>show<wbr>Perma<wbr>Login</span></code>
-                <a class="headerlink" href="#confval-felogin-felogin-showpermalogin" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-showpermalogin" data-rstCode=":confval:`felogin.showPermaLogin &lt;somemanual:felogin-felogin-showpermalogin&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-felogin-felogin-showpermalogin" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-showpermalogin" data-rstCode=":confval:`felogin.showPermaLogin &lt;somemanual:felogin-felogin-showpermalogin&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -509,7 +509,7 @@
     <dt id="confval-felogin-felogin-showlogoutformafterlogin" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">felogin.<wbr>show<wbr>Logout<wbr>Form<wbr>After<wbr>Login</span></code>
-                <a class="headerlink" href="#confval-felogin-felogin-showlogoutformafterlogin" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-showlogoutformafterlogin" data-rstCode=":confval:`felogin.showLogoutFormAfterLogin &lt;somemanual:felogin-felogin-showlogoutformafterlogin&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-felogin-felogin-showlogoutformafterlogin" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-showlogoutformafterlogin" data-rstCode=":confval:`felogin.showLogoutFormAfterLogin &lt;somemanual:felogin-felogin-showlogoutformafterlogin&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -543,7 +543,7 @@
     <dt id="confval-felogin-felogin-emailfrom" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">felogin.<wbr>email<wbr>From</span></code>
-                <a class="headerlink" href="#confval-felogin-felogin-emailfrom" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-emailfrom" data-rstCode=":confval:`felogin.emailFrom &lt;somemanual:felogin-felogin-emailfrom&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-felogin-felogin-emailfrom" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-emailfrom" data-rstCode=":confval:`felogin.emailFrom &lt;somemanual:felogin-felogin-emailfrom&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -570,7 +570,7 @@
     <dt id="confval-felogin-felogin-emailfromname" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">felogin.<wbr>email<wbr>From<wbr>Name</span></code>
-                <a class="headerlink" href="#confval-felogin-felogin-emailfromname" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-emailfromname" data-rstCode=":confval:`felogin.emailFromName &lt;somemanual:felogin-felogin-emailfromname&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-felogin-felogin-emailfromname" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-emailfromname" data-rstCode=":confval:`felogin.emailFromName &lt;somemanual:felogin-felogin-emailfromname&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -597,7 +597,7 @@
     <dt id="confval-felogin-felogin-replytoemail" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">felogin.<wbr>reply<wbr>To<wbr>Email</span></code>
-                <a class="headerlink" href="#confval-felogin-felogin-replytoemail" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-replytoemail" data-rstCode=":confval:`felogin.replyToEmail &lt;somemanual:felogin-felogin-replytoemail&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-felogin-felogin-replytoemail" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-replytoemail" data-rstCode=":confval:`felogin.replyToEmail &lt;somemanual:felogin-felogin-replytoemail&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -624,7 +624,7 @@
     <dt id="confval-felogin-felogin-dateformat" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">felogin.<wbr>date<wbr>Format</span></code>
-                <a class="headerlink" href="#confval-felogin-felogin-dateformat" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-dateformat" data-rstCode=":confval:`felogin.dateFormat &lt;somemanual:felogin-felogin-dateformat&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-felogin-felogin-dateformat" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-dateformat" data-rstCode=":confval:`felogin.dateFormat &lt;somemanual:felogin-felogin-dateformat&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -658,7 +658,7 @@
     <dt id="confval-felogin-felogin-email-layoutrootpath" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">felogin.<wbr>email.<wbr>layout<wbr>Root<wbr>Path</span></code>
-                <a class="headerlink" href="#confval-felogin-felogin-email-layoutrootpath" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-email-layoutrootpath" data-rstCode=":confval:`felogin.email.layoutRootPath &lt;somemanual:felogin-felogin-email-layoutrootpath&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-felogin-felogin-email-layoutrootpath" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-email-layoutrootpath" data-rstCode=":confval:`felogin.email.layoutRootPath &lt;somemanual:felogin-felogin-email-layoutrootpath&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -685,7 +685,7 @@
     <dt id="confval-felogin-felogin-email-templaterootpath" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">felogin.<wbr>email.<wbr>template<wbr>Root<wbr>Path</span></code>
-                <a class="headerlink" href="#confval-felogin-felogin-email-templaterootpath" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-email-templaterootpath" data-rstCode=":confval:`felogin.email.templateRootPath &lt;somemanual:felogin-felogin-email-templaterootpath&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-felogin-felogin-email-templaterootpath" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-email-templaterootpath" data-rstCode=":confval:`felogin.email.templateRootPath &lt;somemanual:felogin-felogin-email-templaterootpath&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -719,7 +719,7 @@
     <dt id="confval-felogin-felogin-email-partialrootpath" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">felogin.<wbr>email.<wbr>partial<wbr>Root<wbr>Path</span></code>
-                <a class="headerlink" href="#confval-felogin-felogin-email-partialrootpath" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-email-partialrootpath" data-rstCode=":confval:`felogin.email.partialRootPath &lt;somemanual:felogin-felogin-email-partialrootpath&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-felogin-felogin-email-partialrootpath" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-email-partialrootpath" data-rstCode=":confval:`felogin.email.partialRootPath &lt;somemanual:felogin-felogin-email-partialrootpath&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -746,7 +746,7 @@
     <dt id="confval-felogin-felogin-email-templatename" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">felogin.<wbr>email.<wbr>template<wbr>Name</span></code>
-                <a class="headerlink" href="#confval-felogin-felogin-email-templatename" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-email-templatename" data-rstCode=":confval:`felogin.email.templateName &lt;somemanual:felogin-felogin-email-templatename&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-felogin-felogin-email-templatename" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-email-templatename" data-rstCode=":confval:`felogin.email.templateName &lt;somemanual:felogin-felogin-email-templatename&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -780,7 +780,7 @@
     <dt id="confval-felogin-felogin-redirectmode" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">felogin.<wbr>redirect<wbr>Mode</span></code>
-                <a class="headerlink" href="#confval-felogin-felogin-redirectmode" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-redirectmode" data-rstCode=":confval:`felogin.redirectMode &lt;somemanual:felogin-felogin-redirectmode&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-felogin-felogin-redirectmode" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-redirectmode" data-rstCode=":confval:`felogin.redirectMode &lt;somemanual:felogin-felogin-redirectmode&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -807,7 +807,7 @@
     <dt id="confval-felogin-felogin-redirectfirstmethod" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">felogin.<wbr>redirect<wbr>First<wbr>Method</span></code>
-                <a class="headerlink" href="#confval-felogin-felogin-redirectfirstmethod" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-redirectfirstmethod" data-rstCode=":confval:`felogin.redirectFirstMethod &lt;somemanual:felogin-felogin-redirectfirstmethod&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-felogin-felogin-redirectfirstmethod" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-redirectfirstmethod" data-rstCode=":confval:`felogin.redirectFirstMethod &lt;somemanual:felogin-felogin-redirectfirstmethod&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -841,7 +841,7 @@
     <dt id="confval-felogin-felogin-redirectpagelogin" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">felogin.<wbr>redirect<wbr>Page<wbr>Login</span></code>
-                <a class="headerlink" href="#confval-felogin-felogin-redirectpagelogin" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-redirectpagelogin" data-rstCode=":confval:`felogin.redirectPageLogin &lt;somemanual:felogin-felogin-redirectpagelogin&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-felogin-felogin-redirectpagelogin" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-redirectpagelogin" data-rstCode=":confval:`felogin.redirectPageLogin &lt;somemanual:felogin-felogin-redirectpagelogin&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -875,7 +875,7 @@
     <dt id="confval-felogin-felogin-redirectpageloginerror" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">felogin.<wbr>redirect<wbr>Page<wbr>Login<wbr>Error</span></code>
-                <a class="headerlink" href="#confval-felogin-felogin-redirectpageloginerror" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-redirectpageloginerror" data-rstCode=":confval:`felogin.redirectPageLoginError &lt;somemanual:felogin-felogin-redirectpageloginerror&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-felogin-felogin-redirectpageloginerror" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-redirectpageloginerror" data-rstCode=":confval:`felogin.redirectPageLoginError &lt;somemanual:felogin-felogin-redirectpageloginerror&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -909,7 +909,7 @@
     <dt id="confval-felogin-felogin-redirectpagelogout" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">felogin.<wbr>redirect<wbr>Page<wbr>Logout</span></code>
-                <a class="headerlink" href="#confval-felogin-felogin-redirectpagelogout" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-redirectpagelogout" data-rstCode=":confval:`felogin.redirectPageLogout &lt;somemanual:felogin-felogin-redirectpagelogout&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-felogin-felogin-redirectpagelogout" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-redirectpagelogout" data-rstCode=":confval:`felogin.redirectPageLogout &lt;somemanual:felogin-felogin-redirectpagelogout&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -943,7 +943,7 @@
     <dt id="confval-felogin-felogin-redirectdisable" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">felogin.<wbr>redirect<wbr>Disable</span></code>
-                <a class="headerlink" href="#confval-felogin-felogin-redirectdisable" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-redirectdisable" data-rstCode=":confval:`felogin.redirectDisable &lt;somemanual:felogin-felogin-redirectdisable&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-felogin-felogin-redirectdisable" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-redirectdisable" data-rstCode=":confval:`felogin.redirectDisable &lt;somemanual:felogin-felogin-redirectdisable&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -977,7 +977,7 @@
     <dt id="confval-felogin-felogin-forgotlinkhashvalidtime" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">felogin.<wbr>forgot<wbr>Link<wbr>Hash<wbr>Valid<wbr>Time</span></code>
-                <a class="headerlink" href="#confval-felogin-felogin-forgotlinkhashvalidtime" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-forgotlinkhashvalidtime" data-rstCode=":confval:`felogin.forgotLinkHashValidTime &lt;somemanual:felogin-felogin-forgotlinkhashvalidtime&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-felogin-felogin-forgotlinkhashvalidtime" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-forgotlinkhashvalidtime" data-rstCode=":confval:`felogin.forgotLinkHashValidTime &lt;somemanual:felogin-felogin-forgotlinkhashvalidtime&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -1011,7 +1011,7 @@
     <dt id="confval-felogin-felogin-domains" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">felogin.<wbr>domains</span></code>
-                <a class="headerlink" href="#confval-felogin-felogin-domains" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-domains" data-rstCode=":confval:`felogin.domains &lt;somemanual:felogin-felogin-domains&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-felogin-felogin-domains" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-domains" data-rstCode=":confval:`felogin.domains &lt;somemanual:felogin-felogin-domains&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -1038,7 +1038,7 @@
     <dt id="confval-felogin-felogin-exposenonexistentuserinforgotpassworddialog" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">felogin.<wbr>expose<wbr>Nonexistent<wbr>User<wbr>In<wbr>Forgot<wbr>Password<wbr>Dialog</span></code>
-                <a class="headerlink" href="#confval-felogin-felogin-exposenonexistentuserinforgotpassworddialog" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-exposenonexistentuserinforgotpassworddialog" data-rstCode=":confval:`felogin.exposeNonexistentUserInForgotPasswordDialog &lt;somemanual:felogin-felogin-exposenonexistentuserinforgotpassworddialog&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-felogin-felogin-exposenonexistentuserinforgotpassworddialog" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-exposenonexistentuserinforgotpassworddialog" data-rstCode=":confval:`felogin.exposeNonexistentUserInForgotPasswordDialog &lt;somemanual:felogin-felogin-exposenonexistentuserinforgotpassworddialog&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -1072,7 +1072,7 @@
     <dt id="confval-felogin-felogin-view-templaterootpath" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">felogin.<wbr>view.<wbr>template<wbr>Root<wbr>Path</span></code>
-                <a class="headerlink" href="#confval-felogin-felogin-view-templaterootpath" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-view-templaterootpath" data-rstCode=":confval:`felogin.view.templateRootPath &lt;somemanual:felogin-felogin-view-templaterootpath&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-felogin-felogin-view-templaterootpath" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-view-templaterootpath" data-rstCode=":confval:`felogin.view.templateRootPath &lt;somemanual:felogin-felogin-view-templaterootpath&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -1099,7 +1099,7 @@
     <dt id="confval-felogin-felogin-view-partialrootpath" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">felogin.<wbr>view.<wbr>partial<wbr>Root<wbr>Path</span></code>
-                <a class="headerlink" href="#confval-felogin-felogin-view-partialrootpath" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-view-partialrootpath" data-rstCode=":confval:`felogin.view.partialRootPath &lt;somemanual:felogin-felogin-view-partialrootpath&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-felogin-felogin-view-partialrootpath" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-view-partialrootpath" data-rstCode=":confval:`felogin.view.partialRootPath &lt;somemanual:felogin-felogin-view-partialrootpath&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -1126,7 +1126,7 @@
     <dt id="confval-felogin-felogin-view-layoutrootpath" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">felogin.<wbr>view.<wbr>layout<wbr>Root<wbr>Path</span></code>
-                <a class="headerlink" href="#confval-felogin-felogin-view-layoutrootpath" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-view-layoutrootpath" data-rstCode=":confval:`felogin.view.layoutRootPath &lt;somemanual:felogin-felogin-view-layoutrootpath&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-felogin-felogin-view-layoutrootpath" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-view-layoutrootpath" data-rstCode=":confval:`felogin.view.layoutRootPath &lt;somemanual:felogin-felogin-view-layoutrootpath&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>

--- a/tests/Integration/tests/site-set-labels/expected/index.html
+++ b/tests/Integration/tests/site-set-labels/expected/index.html
@@ -1,6 +1,6 @@
 <!-- content start -->
                 <section class="section" id="site-set-configuration">
-            <h1>Site Set Configuration<a class="headerlink" href="#site-set-configuration" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Site Set Configuration<a class="headerlink" href="#site-set-configuration" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
 
 
 
@@ -373,7 +373,7 @@
     <dt id="confval-felogin-felogin-pid" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">felogin.<wbr>pid</span></code>
-                <a class="headerlink" href="#confval-felogin-felogin-pid" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-pid" data-rstCode=":confval:`felogin.pid &lt;somemanual:felogin-felogin-pid&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-felogin-felogin-pid" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-pid" data-rstCode=":confval:`felogin.pid &lt;somemanual:felogin-felogin-pid&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -407,7 +407,7 @@
     <dt id="confval-felogin-felogin-recursive" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">felogin.<wbr>recursive</span></code>
-                <a class="headerlink" href="#confval-felogin-felogin-recursive" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-recursive" data-rstCode=":confval:`felogin.recursive &lt;somemanual:felogin-felogin-recursive&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-felogin-felogin-recursive" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-recursive" data-rstCode=":confval:`felogin.recursive &lt;somemanual:felogin-felogin-recursive&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -441,7 +441,7 @@
     <dt id="confval-felogin-felogin-showforgotpassword" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">felogin.<wbr>show<wbr>Forgot<wbr>Password</span></code>
-                <a class="headerlink" href="#confval-felogin-felogin-showforgotpassword" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-showforgotpassword" data-rstCode=":confval:`felogin.showForgotPassword &lt;somemanual:felogin-felogin-showforgotpassword&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-felogin-felogin-showforgotpassword" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-showforgotpassword" data-rstCode=":confval:`felogin.showForgotPassword &lt;somemanual:felogin-felogin-showforgotpassword&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -475,7 +475,7 @@
     <dt id="confval-felogin-felogin-showpermalogin" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">felogin.<wbr>show<wbr>Perma<wbr>Login</span></code>
-                <a class="headerlink" href="#confval-felogin-felogin-showpermalogin" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-showpermalogin" data-rstCode=":confval:`felogin.showPermaLogin &lt;somemanual:felogin-felogin-showpermalogin&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-felogin-felogin-showpermalogin" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-showpermalogin" data-rstCode=":confval:`felogin.showPermaLogin &lt;somemanual:felogin-felogin-showpermalogin&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -509,7 +509,7 @@
     <dt id="confval-felogin-felogin-showlogoutformafterlogin" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">felogin.<wbr>show<wbr>Logout<wbr>Form<wbr>After<wbr>Login</span></code>
-                <a class="headerlink" href="#confval-felogin-felogin-showlogoutformafterlogin" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-showlogoutformafterlogin" data-rstCode=":confval:`felogin.showLogoutFormAfterLogin &lt;somemanual:felogin-felogin-showlogoutformafterlogin&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-felogin-felogin-showlogoutformafterlogin" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-showlogoutformafterlogin" data-rstCode=":confval:`felogin.showLogoutFormAfterLogin &lt;somemanual:felogin-felogin-showlogoutformafterlogin&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -543,7 +543,7 @@
     <dt id="confval-felogin-felogin-emailfrom" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">felogin.<wbr>email<wbr>From</span></code>
-                <a class="headerlink" href="#confval-felogin-felogin-emailfrom" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-emailfrom" data-rstCode=":confval:`felogin.emailFrom &lt;somemanual:felogin-felogin-emailfrom&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-felogin-felogin-emailfrom" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-emailfrom" data-rstCode=":confval:`felogin.emailFrom &lt;somemanual:felogin-felogin-emailfrom&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -570,7 +570,7 @@
     <dt id="confval-felogin-felogin-emailfromname" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">felogin.<wbr>email<wbr>From<wbr>Name</span></code>
-                <a class="headerlink" href="#confval-felogin-felogin-emailfromname" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-emailfromname" data-rstCode=":confval:`felogin.emailFromName &lt;somemanual:felogin-felogin-emailfromname&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-felogin-felogin-emailfromname" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-emailfromname" data-rstCode=":confval:`felogin.emailFromName &lt;somemanual:felogin-felogin-emailfromname&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -597,7 +597,7 @@
     <dt id="confval-felogin-felogin-replytoemail" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">felogin.<wbr>reply<wbr>To<wbr>Email</span></code>
-                <a class="headerlink" href="#confval-felogin-felogin-replytoemail" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-replytoemail" data-rstCode=":confval:`felogin.replyToEmail &lt;somemanual:felogin-felogin-replytoemail&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-felogin-felogin-replytoemail" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-replytoemail" data-rstCode=":confval:`felogin.replyToEmail &lt;somemanual:felogin-felogin-replytoemail&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -624,7 +624,7 @@
     <dt id="confval-felogin-felogin-dateformat" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">felogin.<wbr>date<wbr>Format</span></code>
-                <a class="headerlink" href="#confval-felogin-felogin-dateformat" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-dateformat" data-rstCode=":confval:`felogin.dateFormat &lt;somemanual:felogin-felogin-dateformat&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-felogin-felogin-dateformat" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-dateformat" data-rstCode=":confval:`felogin.dateFormat &lt;somemanual:felogin-felogin-dateformat&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -658,7 +658,7 @@
     <dt id="confval-felogin-felogin-email-layoutrootpath" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">felogin.<wbr>email.<wbr>layout<wbr>Root<wbr>Path</span></code>
-                <a class="headerlink" href="#confval-felogin-felogin-email-layoutrootpath" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-email-layoutrootpath" data-rstCode=":confval:`felogin.email.layoutRootPath &lt;somemanual:felogin-felogin-email-layoutrootpath&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-felogin-felogin-email-layoutrootpath" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-email-layoutrootpath" data-rstCode=":confval:`felogin.email.layoutRootPath &lt;somemanual:felogin-felogin-email-layoutrootpath&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -685,7 +685,7 @@
     <dt id="confval-felogin-felogin-email-templaterootpath" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">felogin.<wbr>email.<wbr>template<wbr>Root<wbr>Path</span></code>
-                <a class="headerlink" href="#confval-felogin-felogin-email-templaterootpath" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-email-templaterootpath" data-rstCode=":confval:`felogin.email.templateRootPath &lt;somemanual:felogin-felogin-email-templaterootpath&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-felogin-felogin-email-templaterootpath" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-email-templaterootpath" data-rstCode=":confval:`felogin.email.templateRootPath &lt;somemanual:felogin-felogin-email-templaterootpath&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -719,7 +719,7 @@
     <dt id="confval-felogin-felogin-email-partialrootpath" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">felogin.<wbr>email.<wbr>partial<wbr>Root<wbr>Path</span></code>
-                <a class="headerlink" href="#confval-felogin-felogin-email-partialrootpath" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-email-partialrootpath" data-rstCode=":confval:`felogin.email.partialRootPath &lt;somemanual:felogin-felogin-email-partialrootpath&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-felogin-felogin-email-partialrootpath" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-email-partialrootpath" data-rstCode=":confval:`felogin.email.partialRootPath &lt;somemanual:felogin-felogin-email-partialrootpath&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -746,7 +746,7 @@
     <dt id="confval-felogin-felogin-email-templatename" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">felogin.<wbr>email.<wbr>template<wbr>Name</span></code>
-                <a class="headerlink" href="#confval-felogin-felogin-email-templatename" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-email-templatename" data-rstCode=":confval:`felogin.email.templateName &lt;somemanual:felogin-felogin-email-templatename&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-felogin-felogin-email-templatename" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-email-templatename" data-rstCode=":confval:`felogin.email.templateName &lt;somemanual:felogin-felogin-email-templatename&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -780,7 +780,7 @@
     <dt id="confval-felogin-felogin-redirectmode" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">felogin.<wbr>redirect<wbr>Mode</span></code>
-                <a class="headerlink" href="#confval-felogin-felogin-redirectmode" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-redirectmode" data-rstCode=":confval:`felogin.redirectMode &lt;somemanual:felogin-felogin-redirectmode&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-felogin-felogin-redirectmode" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-redirectmode" data-rstCode=":confval:`felogin.redirectMode &lt;somemanual:felogin-felogin-redirectmode&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -807,7 +807,7 @@
     <dt id="confval-felogin-felogin-redirectfirstmethod" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">felogin.<wbr>redirect<wbr>First<wbr>Method</span></code>
-                <a class="headerlink" href="#confval-felogin-felogin-redirectfirstmethod" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-redirectfirstmethod" data-rstCode=":confval:`felogin.redirectFirstMethod &lt;somemanual:felogin-felogin-redirectfirstmethod&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-felogin-felogin-redirectfirstmethod" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-redirectfirstmethod" data-rstCode=":confval:`felogin.redirectFirstMethod &lt;somemanual:felogin-felogin-redirectfirstmethod&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -841,7 +841,7 @@
     <dt id="confval-felogin-felogin-redirectpagelogin" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">felogin.<wbr>redirect<wbr>Page<wbr>Login</span></code>
-                <a class="headerlink" href="#confval-felogin-felogin-redirectpagelogin" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-redirectpagelogin" data-rstCode=":confval:`felogin.redirectPageLogin &lt;somemanual:felogin-felogin-redirectpagelogin&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-felogin-felogin-redirectpagelogin" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-redirectpagelogin" data-rstCode=":confval:`felogin.redirectPageLogin &lt;somemanual:felogin-felogin-redirectpagelogin&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -875,7 +875,7 @@
     <dt id="confval-felogin-felogin-redirectpageloginerror" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">felogin.<wbr>redirect<wbr>Page<wbr>Login<wbr>Error</span></code>
-                <a class="headerlink" href="#confval-felogin-felogin-redirectpageloginerror" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-redirectpageloginerror" data-rstCode=":confval:`felogin.redirectPageLoginError &lt;somemanual:felogin-felogin-redirectpageloginerror&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-felogin-felogin-redirectpageloginerror" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-redirectpageloginerror" data-rstCode=":confval:`felogin.redirectPageLoginError &lt;somemanual:felogin-felogin-redirectpageloginerror&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -909,7 +909,7 @@
     <dt id="confval-felogin-felogin-redirectpagelogout" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">felogin.<wbr>redirect<wbr>Page<wbr>Logout</span></code>
-                <a class="headerlink" href="#confval-felogin-felogin-redirectpagelogout" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-redirectpagelogout" data-rstCode=":confval:`felogin.redirectPageLogout &lt;somemanual:felogin-felogin-redirectpagelogout&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-felogin-felogin-redirectpagelogout" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-redirectpagelogout" data-rstCode=":confval:`felogin.redirectPageLogout &lt;somemanual:felogin-felogin-redirectpagelogout&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -943,7 +943,7 @@
     <dt id="confval-felogin-felogin-redirectdisable" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">felogin.<wbr>redirect<wbr>Disable</span></code>
-                <a class="headerlink" href="#confval-felogin-felogin-redirectdisable" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-redirectdisable" data-rstCode=":confval:`felogin.redirectDisable &lt;somemanual:felogin-felogin-redirectdisable&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-felogin-felogin-redirectdisable" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-redirectdisable" data-rstCode=":confval:`felogin.redirectDisable &lt;somemanual:felogin-felogin-redirectdisable&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -977,7 +977,7 @@
     <dt id="confval-felogin-felogin-forgotlinkhashvalidtime" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">felogin.<wbr>forgot<wbr>Link<wbr>Hash<wbr>Valid<wbr>Time</span></code>
-                <a class="headerlink" href="#confval-felogin-felogin-forgotlinkhashvalidtime" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-forgotlinkhashvalidtime" data-rstCode=":confval:`felogin.forgotLinkHashValidTime &lt;somemanual:felogin-felogin-forgotlinkhashvalidtime&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-felogin-felogin-forgotlinkhashvalidtime" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-forgotlinkhashvalidtime" data-rstCode=":confval:`felogin.forgotLinkHashValidTime &lt;somemanual:felogin-felogin-forgotlinkhashvalidtime&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -1011,7 +1011,7 @@
     <dt id="confval-felogin-felogin-domains" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">felogin.<wbr>domains</span></code>
-                <a class="headerlink" href="#confval-felogin-felogin-domains" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-domains" data-rstCode=":confval:`felogin.domains &lt;somemanual:felogin-felogin-domains&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-felogin-felogin-domains" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-domains" data-rstCode=":confval:`felogin.domains &lt;somemanual:felogin-felogin-domains&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -1038,7 +1038,7 @@
     <dt id="confval-felogin-felogin-exposenonexistentuserinforgotpassworddialog" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">felogin.<wbr>expose<wbr>Nonexistent<wbr>User<wbr>In<wbr>Forgot<wbr>Password<wbr>Dialog</span></code>
-                <a class="headerlink" href="#confval-felogin-felogin-exposenonexistentuserinforgotpassworddialog" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-exposenonexistentuserinforgotpassworddialog" data-rstCode=":confval:`felogin.exposeNonexistentUserInForgotPasswordDialog &lt;somemanual:felogin-felogin-exposenonexistentuserinforgotpassworddialog&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-felogin-felogin-exposenonexistentuserinforgotpassworddialog" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-exposenonexistentuserinforgotpassworddialog" data-rstCode=":confval:`felogin.exposeNonexistentUserInForgotPasswordDialog &lt;somemanual:felogin-felogin-exposenonexistentuserinforgotpassworddialog&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -1072,7 +1072,7 @@
     <dt id="confval-felogin-felogin-view-templaterootpath" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">felogin.<wbr>view.<wbr>template<wbr>Root<wbr>Path</span></code>
-                <a class="headerlink" href="#confval-felogin-felogin-view-templaterootpath" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-view-templaterootpath" data-rstCode=":confval:`felogin.view.templateRootPath &lt;somemanual:felogin-felogin-view-templaterootpath&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-felogin-felogin-view-templaterootpath" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-view-templaterootpath" data-rstCode=":confval:`felogin.view.templateRootPath &lt;somemanual:felogin-felogin-view-templaterootpath&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -1099,7 +1099,7 @@
     <dt id="confval-felogin-felogin-view-partialrootpath" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">felogin.<wbr>view.<wbr>partial<wbr>Root<wbr>Path</span></code>
-                <a class="headerlink" href="#confval-felogin-felogin-view-partialrootpath" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-view-partialrootpath" data-rstCode=":confval:`felogin.view.partialRootPath &lt;somemanual:felogin-felogin-view-partialrootpath&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-felogin-felogin-view-partialrootpath" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-view-partialrootpath" data-rstCode=":confval:`felogin.view.partialRootPath &lt;somemanual:felogin-felogin-view-partialrootpath&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -1126,7 +1126,7 @@
     <dt id="confval-felogin-felogin-view-layoutrootpath" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">felogin.<wbr>view.<wbr>layout<wbr>Root<wbr>Path</span></code>
-                <a class="headerlink" href="#confval-felogin-felogin-view-layoutrootpath" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-view-layoutrootpath" data-rstCode=":confval:`felogin.view.layoutRootPath &lt;somemanual:felogin-felogin-view-layoutrootpath&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-felogin-felogin-view-layoutrootpath" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-view-layoutrootpath" data-rstCode=":confval:`felogin.view.layoutRootPath &lt;somemanual:felogin-felogin-view-layoutrootpath&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>

--- a/tests/Integration/tests/site-set/expected/index.html
+++ b/tests/Integration/tests/site-set/expected/index.html
@@ -1,6 +1,6 @@
 <!-- content start -->
                 <section class="section" id="site-set-configuration">
-            <h1>Site Set Configuration<a class="headerlink" href="#site-set-configuration" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Site Set Configuration<a class="headerlink" href="#site-set-configuration" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
 
 
 
@@ -373,7 +373,7 @@
     <dt id="confval-felogin-felogin-pid" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">felogin.<wbr>pid</span></code>
-                <a class="headerlink" href="#confval-felogin-felogin-pid" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-pid" data-rstCode=":confval:`felogin.pid &lt;somemanual:felogin-felogin-pid&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-felogin-felogin-pid" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-pid" data-rstCode=":confval:`felogin.pid &lt;somemanual:felogin-felogin-pid&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -407,7 +407,7 @@
     <dt id="confval-felogin-felogin-recursive" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">felogin.<wbr>recursive</span></code>
-                <a class="headerlink" href="#confval-felogin-felogin-recursive" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-recursive" data-rstCode=":confval:`felogin.recursive &lt;somemanual:felogin-felogin-recursive&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-felogin-felogin-recursive" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-recursive" data-rstCode=":confval:`felogin.recursive &lt;somemanual:felogin-felogin-recursive&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -441,7 +441,7 @@
     <dt id="confval-felogin-felogin-showforgotpassword" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">felogin.<wbr>show<wbr>Forgot<wbr>Password</span></code>
-                <a class="headerlink" href="#confval-felogin-felogin-showforgotpassword" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-showforgotpassword" data-rstCode=":confval:`felogin.showForgotPassword &lt;somemanual:felogin-felogin-showforgotpassword&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-felogin-felogin-showforgotpassword" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-showforgotpassword" data-rstCode=":confval:`felogin.showForgotPassword &lt;somemanual:felogin-felogin-showforgotpassword&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -475,7 +475,7 @@
     <dt id="confval-felogin-felogin-showpermalogin" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">felogin.<wbr>show<wbr>Perma<wbr>Login</span></code>
-                <a class="headerlink" href="#confval-felogin-felogin-showpermalogin" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-showpermalogin" data-rstCode=":confval:`felogin.showPermaLogin &lt;somemanual:felogin-felogin-showpermalogin&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-felogin-felogin-showpermalogin" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-showpermalogin" data-rstCode=":confval:`felogin.showPermaLogin &lt;somemanual:felogin-felogin-showpermalogin&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -509,7 +509,7 @@
     <dt id="confval-felogin-felogin-showlogoutformafterlogin" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">felogin.<wbr>show<wbr>Logout<wbr>Form<wbr>After<wbr>Login</span></code>
-                <a class="headerlink" href="#confval-felogin-felogin-showlogoutformafterlogin" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-showlogoutformafterlogin" data-rstCode=":confval:`felogin.showLogoutFormAfterLogin &lt;somemanual:felogin-felogin-showlogoutformafterlogin&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-felogin-felogin-showlogoutformafterlogin" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-showlogoutformafterlogin" data-rstCode=":confval:`felogin.showLogoutFormAfterLogin &lt;somemanual:felogin-felogin-showlogoutformafterlogin&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -543,7 +543,7 @@
     <dt id="confval-felogin-felogin-emailfrom" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">felogin.<wbr>email<wbr>From</span></code>
-                <a class="headerlink" href="#confval-felogin-felogin-emailfrom" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-emailfrom" data-rstCode=":confval:`felogin.emailFrom &lt;somemanual:felogin-felogin-emailfrom&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-felogin-felogin-emailfrom" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-emailfrom" data-rstCode=":confval:`felogin.emailFrom &lt;somemanual:felogin-felogin-emailfrom&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -570,7 +570,7 @@
     <dt id="confval-felogin-felogin-emailfromname" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">felogin.<wbr>email<wbr>From<wbr>Name</span></code>
-                <a class="headerlink" href="#confval-felogin-felogin-emailfromname" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-emailfromname" data-rstCode=":confval:`felogin.emailFromName &lt;somemanual:felogin-felogin-emailfromname&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-felogin-felogin-emailfromname" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-emailfromname" data-rstCode=":confval:`felogin.emailFromName &lt;somemanual:felogin-felogin-emailfromname&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -597,7 +597,7 @@
     <dt id="confval-felogin-felogin-replytoemail" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">felogin.<wbr>reply<wbr>To<wbr>Email</span></code>
-                <a class="headerlink" href="#confval-felogin-felogin-replytoemail" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-replytoemail" data-rstCode=":confval:`felogin.replyToEmail &lt;somemanual:felogin-felogin-replytoemail&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-felogin-felogin-replytoemail" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-replytoemail" data-rstCode=":confval:`felogin.replyToEmail &lt;somemanual:felogin-felogin-replytoemail&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -624,7 +624,7 @@
     <dt id="confval-felogin-felogin-dateformat" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">felogin.<wbr>date<wbr>Format</span></code>
-                <a class="headerlink" href="#confval-felogin-felogin-dateformat" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-dateformat" data-rstCode=":confval:`felogin.dateFormat &lt;somemanual:felogin-felogin-dateformat&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-felogin-felogin-dateformat" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-dateformat" data-rstCode=":confval:`felogin.dateFormat &lt;somemanual:felogin-felogin-dateformat&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -658,7 +658,7 @@
     <dt id="confval-felogin-felogin-email-layoutrootpath" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">felogin.<wbr>email.<wbr>layout<wbr>Root<wbr>Path</span></code>
-                <a class="headerlink" href="#confval-felogin-felogin-email-layoutrootpath" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-email-layoutrootpath" data-rstCode=":confval:`felogin.email.layoutRootPath &lt;somemanual:felogin-felogin-email-layoutrootpath&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-felogin-felogin-email-layoutrootpath" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-email-layoutrootpath" data-rstCode=":confval:`felogin.email.layoutRootPath &lt;somemanual:felogin-felogin-email-layoutrootpath&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -685,7 +685,7 @@
     <dt id="confval-felogin-felogin-email-templaterootpath" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">felogin.<wbr>email.<wbr>template<wbr>Root<wbr>Path</span></code>
-                <a class="headerlink" href="#confval-felogin-felogin-email-templaterootpath" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-email-templaterootpath" data-rstCode=":confval:`felogin.email.templateRootPath &lt;somemanual:felogin-felogin-email-templaterootpath&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-felogin-felogin-email-templaterootpath" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-email-templaterootpath" data-rstCode=":confval:`felogin.email.templateRootPath &lt;somemanual:felogin-felogin-email-templaterootpath&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -719,7 +719,7 @@
     <dt id="confval-felogin-felogin-email-partialrootpath" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">felogin.<wbr>email.<wbr>partial<wbr>Root<wbr>Path</span></code>
-                <a class="headerlink" href="#confval-felogin-felogin-email-partialrootpath" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-email-partialrootpath" data-rstCode=":confval:`felogin.email.partialRootPath &lt;somemanual:felogin-felogin-email-partialrootpath&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-felogin-felogin-email-partialrootpath" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-email-partialrootpath" data-rstCode=":confval:`felogin.email.partialRootPath &lt;somemanual:felogin-felogin-email-partialrootpath&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -746,7 +746,7 @@
     <dt id="confval-felogin-felogin-email-templatename" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">felogin.<wbr>email.<wbr>template<wbr>Name</span></code>
-                <a class="headerlink" href="#confval-felogin-felogin-email-templatename" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-email-templatename" data-rstCode=":confval:`felogin.email.templateName &lt;somemanual:felogin-felogin-email-templatename&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-felogin-felogin-email-templatename" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-email-templatename" data-rstCode=":confval:`felogin.email.templateName &lt;somemanual:felogin-felogin-email-templatename&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -780,7 +780,7 @@
     <dt id="confval-felogin-felogin-redirectmode" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">felogin.<wbr>redirect<wbr>Mode</span></code>
-                <a class="headerlink" href="#confval-felogin-felogin-redirectmode" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-redirectmode" data-rstCode=":confval:`felogin.redirectMode &lt;somemanual:felogin-felogin-redirectmode&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-felogin-felogin-redirectmode" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-redirectmode" data-rstCode=":confval:`felogin.redirectMode &lt;somemanual:felogin-felogin-redirectmode&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -807,7 +807,7 @@
     <dt id="confval-felogin-felogin-redirectfirstmethod" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">felogin.<wbr>redirect<wbr>First<wbr>Method</span></code>
-                <a class="headerlink" href="#confval-felogin-felogin-redirectfirstmethod" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-redirectfirstmethod" data-rstCode=":confval:`felogin.redirectFirstMethod &lt;somemanual:felogin-felogin-redirectfirstmethod&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-felogin-felogin-redirectfirstmethod" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-redirectfirstmethod" data-rstCode=":confval:`felogin.redirectFirstMethod &lt;somemanual:felogin-felogin-redirectfirstmethod&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -841,7 +841,7 @@
     <dt id="confval-felogin-felogin-redirectpagelogin" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">felogin.<wbr>redirect<wbr>Page<wbr>Login</span></code>
-                <a class="headerlink" href="#confval-felogin-felogin-redirectpagelogin" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-redirectpagelogin" data-rstCode=":confval:`felogin.redirectPageLogin &lt;somemanual:felogin-felogin-redirectpagelogin&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-felogin-felogin-redirectpagelogin" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-redirectpagelogin" data-rstCode=":confval:`felogin.redirectPageLogin &lt;somemanual:felogin-felogin-redirectpagelogin&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -875,7 +875,7 @@
     <dt id="confval-felogin-felogin-redirectpageloginerror" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">felogin.<wbr>redirect<wbr>Page<wbr>Login<wbr>Error</span></code>
-                <a class="headerlink" href="#confval-felogin-felogin-redirectpageloginerror" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-redirectpageloginerror" data-rstCode=":confval:`felogin.redirectPageLoginError &lt;somemanual:felogin-felogin-redirectpageloginerror&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-felogin-felogin-redirectpageloginerror" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-redirectpageloginerror" data-rstCode=":confval:`felogin.redirectPageLoginError &lt;somemanual:felogin-felogin-redirectpageloginerror&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -909,7 +909,7 @@
     <dt id="confval-felogin-felogin-redirectpagelogout" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">felogin.<wbr>redirect<wbr>Page<wbr>Logout</span></code>
-                <a class="headerlink" href="#confval-felogin-felogin-redirectpagelogout" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-redirectpagelogout" data-rstCode=":confval:`felogin.redirectPageLogout &lt;somemanual:felogin-felogin-redirectpagelogout&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-felogin-felogin-redirectpagelogout" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-redirectpagelogout" data-rstCode=":confval:`felogin.redirectPageLogout &lt;somemanual:felogin-felogin-redirectpagelogout&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -943,7 +943,7 @@
     <dt id="confval-felogin-felogin-redirectdisable" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">felogin.<wbr>redirect<wbr>Disable</span></code>
-                <a class="headerlink" href="#confval-felogin-felogin-redirectdisable" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-redirectdisable" data-rstCode=":confval:`felogin.redirectDisable &lt;somemanual:felogin-felogin-redirectdisable&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-felogin-felogin-redirectdisable" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-redirectdisable" data-rstCode=":confval:`felogin.redirectDisable &lt;somemanual:felogin-felogin-redirectdisable&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -977,7 +977,7 @@
     <dt id="confval-felogin-felogin-forgotlinkhashvalidtime" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">felogin.<wbr>forgot<wbr>Link<wbr>Hash<wbr>Valid<wbr>Time</span></code>
-                <a class="headerlink" href="#confval-felogin-felogin-forgotlinkhashvalidtime" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-forgotlinkhashvalidtime" data-rstCode=":confval:`felogin.forgotLinkHashValidTime &lt;somemanual:felogin-felogin-forgotlinkhashvalidtime&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-felogin-felogin-forgotlinkhashvalidtime" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-forgotlinkhashvalidtime" data-rstCode=":confval:`felogin.forgotLinkHashValidTime &lt;somemanual:felogin-felogin-forgotlinkhashvalidtime&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -1011,7 +1011,7 @@
     <dt id="confval-felogin-felogin-domains" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">felogin.<wbr>domains</span></code>
-                <a class="headerlink" href="#confval-felogin-felogin-domains" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-domains" data-rstCode=":confval:`felogin.domains &lt;somemanual:felogin-felogin-domains&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-felogin-felogin-domains" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-domains" data-rstCode=":confval:`felogin.domains &lt;somemanual:felogin-felogin-domains&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -1038,7 +1038,7 @@
     <dt id="confval-felogin-felogin-exposenonexistentuserinforgotpassworddialog" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">felogin.<wbr>expose<wbr>Nonexistent<wbr>User<wbr>In<wbr>Forgot<wbr>Password<wbr>Dialog</span></code>
-                <a class="headerlink" href="#confval-felogin-felogin-exposenonexistentuserinforgotpassworddialog" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-exposenonexistentuserinforgotpassworddialog" data-rstCode=":confval:`felogin.exposeNonexistentUserInForgotPasswordDialog &lt;somemanual:felogin-felogin-exposenonexistentuserinforgotpassworddialog&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-felogin-felogin-exposenonexistentuserinforgotpassworddialog" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-exposenonexistentuserinforgotpassworddialog" data-rstCode=":confval:`felogin.exposeNonexistentUserInForgotPasswordDialog &lt;somemanual:felogin-felogin-exposenonexistentuserinforgotpassworddialog&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -1072,7 +1072,7 @@
     <dt id="confval-felogin-felogin-view-templaterootpath" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">felogin.<wbr>view.<wbr>template<wbr>Root<wbr>Path</span></code>
-                <a class="headerlink" href="#confval-felogin-felogin-view-templaterootpath" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-view-templaterootpath" data-rstCode=":confval:`felogin.view.templateRootPath &lt;somemanual:felogin-felogin-view-templaterootpath&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-felogin-felogin-view-templaterootpath" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-view-templaterootpath" data-rstCode=":confval:`felogin.view.templateRootPath &lt;somemanual:felogin-felogin-view-templaterootpath&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -1099,7 +1099,7 @@
     <dt id="confval-felogin-felogin-view-partialrootpath" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">felogin.<wbr>view.<wbr>partial<wbr>Root<wbr>Path</span></code>
-                <a class="headerlink" href="#confval-felogin-felogin-view-partialrootpath" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-view-partialrootpath" data-rstCode=":confval:`felogin.view.partialRootPath &lt;somemanual:felogin-felogin-view-partialrootpath&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-felogin-felogin-view-partialrootpath" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-view-partialrootpath" data-rstCode=":confval:`felogin.view.partialRootPath &lt;somemanual:felogin-felogin-view-partialrootpath&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -1126,7 +1126,7 @@
     <dt id="confval-felogin-felogin-view-layoutrootpath" class="d-flex justify-content-between">
         <div class="confval-header">
         <code class="sig-name descname"><span class="pre">felogin.<wbr>view.<wbr>layout<wbr>Root<wbr>Path</span></code>
-                <a class="headerlink" href="#confval-felogin-felogin-view-layoutrootpath" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-view-layoutrootpath" data-rstCode=":confval:`felogin.view.layoutRootPath &lt;somemanual:felogin-felogin-view-layoutrootpath&gt;`"  title="Reference this configuration value">¶</a>
+                <a class="headerlink" href="#confval-felogin-felogin-view-layoutrootpath" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="confval-felogin-felogin-view-layoutrootpath" data-rstCode=":confval:`felogin.view.layoutRootPath &lt;somemanual:felogin-felogin-view-layoutrootpath&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
         </div>
         <div class="confval-back-to-top">            <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>

--- a/tests/Integration/tests/table/csv-table/expected/index.html
+++ b/tests/Integration/tests/table/csv-table/expected/index.html
@@ -1,6 +1,6 @@
 <!-- content start -->
                 <section class="section" id="csv-table">
-            <h1>CSV table<a class="headerlink" href="#csv-table" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>CSV table<a class="headerlink" href="#csv-table" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
             <div class="table-responsive">
     <table class="table table-bordered align-default colwidths-grid">
                     <colgroup>

--- a/tests/Integration/tests/table/grid-table/expected/index.html
+++ b/tests/Integration/tests/table/grid-table/expected/index.html
@@ -1,6 +1,6 @@
 <!-- content start -->
                 <section class="section" id="grid-table">
-            <h1>Grid table<a class="headerlink" href="#grid-table" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Grid table<a class="headerlink" href="#grid-table" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
             <div class="table-responsive">
     <table class="table table-bordered align-default">
                             <thead>

--- a/tests/Integration/tests/table/simple-table/expected/index.html
+++ b/tests/Integration/tests/table/simple-table/expected/index.html
@@ -1,6 +1,6 @@
 <!-- content start -->
                 <section class="section" id="simple-table">
-            <h1>Simple table<a class="headerlink" href="#simple-table" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Simple table<a class="headerlink" href="#simple-table" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
             <div class="table-responsive">
     <table class="table table-bordered align-default">
                             <thead>

--- a/tests/Integration/tests/table/t3-field-list-table/expected/index.html
+++ b/tests/Integration/tests/table/t3-field-list-table/expected/index.html
@@ -1,6 +1,6 @@
 <!-- content start -->
                 <section class="section" id="t3-field-list-table-tables">
-            <h1>t3-field-list-table tables<a class="headerlink" href="#t3-field-list-table-tables" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>t3-field-list-table tables<a class="headerlink" href="#t3-field-list-table-tables" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
             <div class="table-responsive">
     <table class="table table-bordered align-default">
                             <thead>

--- a/tests/Integration/tests/table/table-directive/expected/index.html
+++ b/tests/Integration/tests/table/table-directive/expected/index.html
@@ -1,6 +1,6 @@
 <!-- content start -->
                 <section class="section" id="table-directive">
-            <h1>Table directive<a class="headerlink" href="#table-directive" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Table directive<a class="headerlink" href="#table-directive" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
             <div class="contents-wrapper">
         <ul class="menu-level">
     <li class="toc-item">
@@ -11,7 +11,7 @@
     </ul>
 </div>
             <section class="section" id="table-with-caption-and-column-width">
-            <h2>Table with caption and column width<a class="headerlink" href="#table-with-caption-and-column-width" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h2>
+            <h2>Table with caption and column width<a class="headerlink" href="#table-with-caption-and-column-width" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h2>
             <div class="table-responsive">
     <table class="table table-bordered align-default colwidths-grid" style="width: 100%;">
             <caption>My table caption</caption>

--- a/tests/Integration/tests/tabs/expected/index.html
+++ b/tests/Integration/tests/tabs/expected/index.html
@@ -1,6 +1,6 @@
 <!-- content start -->
                 <section class="section" id="tabs">
-            <h1>Tabs<a class="headerlink" href="#tabs" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Tabs<a class="headerlink" href="#tabs" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
             <div class="tabs">
     <ul class="nav nav-tabs" id="tab-tabs-1" role="tablist">
         <li class="nav-item" role="presentation">

--- a/tests/Integration/tests/toctree/expected/index.html
+++ b/tests/Integration/tests/toctree/expected/index.html
@@ -1,6 +1,6 @@
 <!-- content start -->
                 <section class="section" id="document-title">
-            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
 
     <p>Lorem Ipsum Dolor.</p>
 

--- a/tests/Integration/tests/toctree_level_one/expected/index.html
+++ b/tests/Integration/tests/toctree_level_one/expected/index.html
@@ -1,6 +1,6 @@
 <!-- content start -->
                 <section class="section" id="document-title">
-            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
 
     <p>Lorem Ipsum Dolor.</p>
 

--- a/tests/Integration/tests/viewhelper/expected/index.html
+++ b/tests/Integration/tests/viewhelper/expected/index.html
@@ -1,12 +1,12 @@
 <!-- content start -->
                 <section class="section" id="fluid-viewhelpers">
-            <h1>Fluid ViewHelpers<a class="headerlink" href="#fluid-viewhelpers" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Fluid ViewHelpers<a class="headerlink" href="#fluid-viewhelpers" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
 
     <p>See <a href="#viewhelper-typo3fluid-fluid-viewhelpers-splitviewhelper">split</a> or
 <a href="#viewhelper-argument-typo3-cms-fluid-viewhelpers-link-externalviewhelper-uri">uri</a>.</p>
 
             <section class="section" id="f-split">
-            <h2>f:split<a class="headerlink" href="#f-split" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h2>
+            <h2>f:split<a class="headerlink" href="#f-split" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h2>
 
 
     <p>The SplitViewHelper splits a string by the specified separator, which
@@ -19,9 +19,9 @@ This ViewHelper mimicks PHP&#039;s <code class="code-inline"
           aria-details="Dynamic server-side scripting language."
           data-bs-html="true">explode<wbr>()</code> function.</p>
 <section class="section" id="examples">
-            <h2>Examples<a class="headerlink" href="#examples" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h2>
+            <h2>Examples<a class="headerlink" href="#examples" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h2>
             <section class="section" id="split-with-a-separator">
-            <h3>Split with a separator<a class="headerlink" href="#split-with-a-separator" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h3>
+            <h3>Split with a separator<a class="headerlink" href="#split-with-a-separator" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h3>
             <div class="code-block-wrapper" translate="no">
 
     <pre class="code-block"><code>&lt;f:split value=&quot;1,5,8&quot; separator=&quot;,&quot; /&gt;</code></pre>
@@ -44,7 +44,7 @@ This ViewHelper mimicks PHP&#039;s <code class="code-inline"
 </div>
     </section>
             <section class="section" id="split-using-tag-content-as-value">
-            <h3>Split using tag content as value<a class="headerlink" href="#split-using-tag-content-as-value" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h3>
+            <h3>Split using tag content as value<a class="headerlink" href="#split-using-tag-content-as-value" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h3>
             <div class="code-block-wrapper" translate="no">
 
     <pre class="code-block"><code>&lt;f:split separator=&quot;-&quot;&gt;1-5-8&lt;/f:split&gt;</code></pre>
@@ -67,7 +67,7 @@ This ViewHelper mimicks PHP&#039;s <code class="code-inline"
 </div>
     </section>
             <section class="section" id="split-with-a-limit">
-            <h3>Split with a limit<a class="headerlink" href="#split-with-a-limit" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h3>
+            <h3>Split with a limit<a class="headerlink" href="#split-with-a-limit" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h3>
             <div class="code-block-wrapper" translate="no">
 
     <pre class="code-block"><code>&lt;f:split value=&quot;1,5,8&quot; separator=&quot;,&quot; limit=&quot;2&quot; /&gt;</code></pre>
@@ -105,7 +105,7 @@ This ViewHelper mimicks PHP&#039;s <code class="code-inline"
     <dt id="viewhelper-argument-typo3fluid-fluid-viewhelpers-splitviewhelper-limit" class="d-flex justify-content-between">
         <div class="confval-header">
             <code class="sig-name descname"><span class="pre">limit</span></code>
-                            <a class="headerlink" href="#viewhelper-argument-typo3fluid-fluid-viewhelpers-splitviewhelper-limit" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="viewhelper-argument-typo3fluid-fluid-viewhelpers-splitviewhelper-limit" data-rstCode=":typo3:viewhelper-argument:`limit &lt;somemanual:typo3fluid-fluid-viewhelpers-splitviewhelper-limit&gt;`"  title="Reference this configuration value">¶</a>
+                            <a class="headerlink" href="#viewhelper-argument-typo3fluid-fluid-viewhelpers-splitviewhelper-limit" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="viewhelper-argument-typo3fluid-fluid-viewhelpers-splitviewhelper-limit" data-rstCode=":typo3:viewhelper-argument:`limit &lt;somemanual:typo3fluid-fluid-viewhelpers-splitviewhelper-limit&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
             </div>
         <div class="confval-back-to-top">                <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -126,7 +126,7 @@ This ViewHelper mimicks PHP&#039;s <code class="code-inline"
     <dt id="viewhelper-argument-typo3fluid-fluid-viewhelpers-splitviewhelper-separator" class="d-flex justify-content-between">
         <div class="confval-header">
             <code class="sig-name descname"><span class="pre">separator</span></code>
-                            <a class="headerlink" href="#viewhelper-argument-typo3fluid-fluid-viewhelpers-splitviewhelper-separator" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="viewhelper-argument-typo3fluid-fluid-viewhelpers-splitviewhelper-separator" data-rstCode=":typo3:viewhelper-argument:`separator &lt;somemanual:typo3fluid-fluid-viewhelpers-splitviewhelper-separator&gt;`"  title="Reference this configuration value">¶</a>
+                            <a class="headerlink" href="#viewhelper-argument-typo3fluid-fluid-viewhelpers-splitviewhelper-separator" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="viewhelper-argument-typo3fluid-fluid-viewhelpers-splitviewhelper-separator" data-rstCode=":typo3:viewhelper-argument:`separator &lt;somemanual:typo3fluid-fluid-viewhelpers-splitviewhelper-separator&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
             </div>
         <div class="confval-back-to-top">                <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -147,7 +147,7 @@ This ViewHelper mimicks PHP&#039;s <code class="code-inline"
     <dt id="viewhelper-argument-typo3fluid-fluid-viewhelpers-splitviewhelper-value" class="d-flex justify-content-between">
         <div class="confval-header">
             <code class="sig-name descname"><span class="pre">value</span></code>
-                            <a class="headerlink" href="#viewhelper-argument-typo3fluid-fluid-viewhelpers-splitviewhelper-value" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="viewhelper-argument-typo3fluid-fluid-viewhelpers-splitviewhelper-value" data-rstCode=":typo3:viewhelper-argument:`value &lt;somemanual:typo3fluid-fluid-viewhelpers-splitviewhelper-value&gt;`"  title="Reference this configuration value">¶</a>
+                            <a class="headerlink" href="#viewhelper-argument-typo3fluid-fluid-viewhelpers-splitviewhelper-value" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="viewhelper-argument-typo3fluid-fluid-viewhelpers-splitviewhelper-value" data-rstCode=":typo3:viewhelper-argument:`value &lt;somemanual:typo3fluid-fluid-viewhelpers-splitviewhelper-value&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
             </div>
         <div class="confval-back-to-top">                <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -177,9 +177,9 @@ This ViewHelper mimicks PHP&#039;s <code class="code-inline"
           aria-details="Dynamic server-side scripting language."
           data-bs-html="true">explode<wbr>()</code> function.</p>
 <section class="section" id="examples">
-            <h2>Examples<a class="headerlink" href="#examples" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h2>
+            <h2>Examples<a class="headerlink" href="#examples" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h2>
             <section class="section" id="split-with-a-separator">
-            <h3>Split with a separator<a class="headerlink" href="#split-with-a-separator" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h3>
+            <h3>Split with a separator<a class="headerlink" href="#split-with-a-separator" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h3>
             <div class="code-block-wrapper" translate="no">
 
     <pre class="code-block"><code>&lt;f:split value=&quot;1,5,8&quot; separator=&quot;,&quot; /&gt;</code></pre>
@@ -202,7 +202,7 @@ This ViewHelper mimicks PHP&#039;s <code class="code-inline"
 </div>
     </section>
             <section class="section" id="split-using-tag-content-as-value">
-            <h3>Split using tag content as value<a class="headerlink" href="#split-using-tag-content-as-value" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h3>
+            <h3>Split using tag content as value<a class="headerlink" href="#split-using-tag-content-as-value" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h3>
             <div class="code-block-wrapper" translate="no">
 
     <pre class="code-block"><code>&lt;f:split separator=&quot;-&quot;&gt;1-5-8&lt;/f:split&gt;</code></pre>
@@ -225,7 +225,7 @@ This ViewHelper mimicks PHP&#039;s <code class="code-inline"
 </div>
     </section>
             <section class="section" id="split-with-a-limit">
-            <h3>Split with a limit<a class="headerlink" href="#split-with-a-limit" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h3>
+            <h3>Split with a limit<a class="headerlink" href="#split-with-a-limit" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h3>
             <div class="code-block-wrapper" translate="no">
 
     <pre class="code-block"><code>&lt;f:split value=&quot;1,5,8&quot; separator=&quot;,&quot; limit=&quot;2&quot; /&gt;</code></pre>
@@ -325,14 +325,14 @@ This ViewHelper mimicks PHP&#039;s <code class="code-inline"
 </dl>
     </section>
             <section class="section" id="f-link-external">
-            <h2>f:link.external<a class="headerlink" href="#f-link-external" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h2>
+            <h2>f:link.external<a class="headerlink" href="#f-link-external" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h2>
 
 
     <p>A ViewHelper for creating links to external targets.</p>
 <section class="section" id="examples">
-            <h2>Examples<a class="headerlink" href="#examples" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h2>
+            <h2>Examples<a class="headerlink" href="#examples" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h2>
             <section class="section" id="default">
-            <h3>Default<a class="headerlink" href="#default" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h3>
+            <h3>Default<a class="headerlink" href="#default" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h3>
             <div class="code-block-wrapper" translate="no">
 
     <pre class="code-block"><code>&lt;f:link.external uri=&quot;https://www.typo3.org&quot; target=&quot;_blank&quot;&gt;external link&lt;/f:link.external&gt;
@@ -360,7 +360,7 @@ This ViewHelper mimicks PHP&#039;s <code class="code-inline"
 </div>
     </section>
             <section class="section" id="custom-default-scheme">
-            <h3>Custom default scheme<a class="headerlink" href="#custom-default-scheme" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h3>
+            <h3>Custom default scheme<a class="headerlink" href="#custom-default-scheme" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h3>
             <div class="code-block-wrapper" translate="no">
 
     <pre class="code-block"><code>&lt;f:link.external uri=&quot;typo3.org&quot; defaultScheme=&quot;ftp&quot;&gt;external ftp link&lt;/f:link.external&gt;
@@ -408,7 +408,7 @@ This ViewHelper mimicks PHP&#039;s <code class="code-inline"
     <dt id="viewhelper-argument-typo3-cms-fluid-viewhelpers-link-externalviewhelper-uri" class="d-flex justify-content-between">
         <div class="confval-header">
             <code class="sig-name descname"><span class="pre">uri</span></code>
-                            <a class="headerlink" href="#viewhelper-argument-typo3-cms-fluid-viewhelpers-link-externalviewhelper-uri" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="viewhelper-argument-typo3-cms-fluid-viewhelpers-link-externalviewhelper-uri" data-rstCode=":typo3:viewhelper-argument:`uri &lt;somemanual:typo3-cms-fluid-viewhelpers-link-externalviewhelper-uri&gt;`"  title="Reference this configuration value">¶</a>
+                            <a class="headerlink" href="#viewhelper-argument-typo3-cms-fluid-viewhelpers-link-externalviewhelper-uri" data-bs-toggle="modal" data-bs-target="#linkReferenceModal" data-id="viewhelper-argument-typo3-cms-fluid-viewhelpers-link-externalviewhelper-uri" data-rstCode=":typo3:viewhelper-argument:`uri &lt;somemanual:typo3-cms-fluid-viewhelpers-link-externalviewhelper-uri&gt;`"  title="Reference this configuration value"><i class="fa-solid fa-paragraph"></i></a>
             </div>
         <div class="confval-back-to-top">                <a href="#" class="backToTop" title="Back to top"><i class="fa-solid fa-arrow-up fa-xs"></i></a>        </div>
     </dt>
@@ -428,7 +428,7 @@ This ViewHelper mimicks PHP&#039;s <code class="code-inline"
 </dl>
     </section>
             <section class="section" id="f-deprecated">
-            <h2>f:deprecated<a class="headerlink" href="#f-deprecated" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h2>
+            <h2>f:deprecated<a class="headerlink" href="#f-deprecated" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h2>
                                     <div class="versionchange deprecated">
                 <p class="versionmodified">
                     <span class="versionicon"><i class="fa-solid fa-ban"></i></span> Deprecated </p>
@@ -451,7 +451,7 @@ This ViewHelper mimicks PHP&#039;s <code class="code-inline"
 
     </section>
             <section class="section" id="formvh-be-maximumfilesize">
-            <h2>formvh:be.maximumFileSize<a class="headerlink" href="#formvh-be-maximumfilesize" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h2>
+            <h2>formvh:be.maximumFileSize<a class="headerlink" href="#formvh-be-maximumfilesize" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h2>
                                     <div class="admonition warning" role="alert">
                 <p class="admonition-title">Internal</p>
                 <p>This ViewHelper is marked as internal. It is subject to be

--- a/tests/Integration/tests/youtube-invalid/expected/index.html
+++ b/tests/Integration/tests/youtube-invalid/expected/index.html
@@ -1,6 +1,6 @@
 <!-- content start -->
                 <section class="section" id="youtube-directive">
-            <h1>Youtube directive<a class="headerlink" href="#youtube-directive" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Youtube directive<a class="headerlink" href="#youtube-directive" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
 
     <p>Video cannot be displayed</p>
 

--- a/tests/Integration/tests/youtube/expected/index.html
+++ b/tests/Integration/tests/youtube/expected/index.html
@@ -1,6 +1,6 @@
 <!-- content start -->
                 <section class="section" id="youtube-directive">
-            <h1>Youtube directive<a class="headerlink" href="#youtube-directive" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">¶</a></h1>
+            <h1>Youtube directive<a class="headerlink" href="#youtube-directive" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
             <div class="ratio ratio-16x9">
 <iframe src="https://www.youtube-nocookie.com/embed/wNxO-aXY5Yw">
 </iframe>


### PR DESCRIPTION
Currently pilcrows are displayed in search results both in elastic search and google. They take up space, add no information and are not nice to look at

![image](https://github.com/user-attachments/assets/3ddb7a4d-028e-4b20-9444-9529ef004f80)
