### PR TITLE
[BUGFIX] Prevent interlink from referencing itself

### DIFF
--- a/packages/typo3-docs-theme/resources/config/typo3-docs-theme.php
+++ b/packages/typo3-docs-theme/resources/config/typo3-docs-theme.php
@@ -18,6 +18,7 @@ use phpDocumentor\Guides\RestructuredText\Parser\Productions\DocumentRule;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use T3Docs\Typo3DocsTheme\Api\Typo3ApiService;
 use T3Docs\Typo3DocsTheme\Compiler\NodeTransformers\ConfvalMenuNodeTransformer;
+use T3Docs\Typo3DocsTheme\Compiler\NodeTransformers\RemoveInterlinkSelfReferencesFromCrossReferenceNodeTransformer;
 use T3Docs\Typo3DocsTheme\Directives\ConfvalMenuDirective;
 use T3Docs\Typo3DocsTheme\Directives\DirectoryTreeDirective;
 use T3Docs\Typo3DocsTheme\Directives\GroupTabDirective;
@@ -79,6 +80,8 @@ return static function (ContainerConfigurator $container): void {
         ->instanceof(BaseDirective::class)
         ->tag('phpdoc.guides.directive')
         ->set(ConfvalMenuNodeTransformer::class)
+        ->tag('phpdoc.guides.compiler.nodeTransformers')
+        ->set(RemoveInterlinkSelfReferencesFromCrossReferenceNodeTransformer::class)
         ->tag('phpdoc.guides.compiler.nodeTransformers')
         ->set(TwigExtension::class)
         ->set(TwigExtension::class)

--- a/packages/typo3-docs-theme/src/Compiler/NodeTransformers/RemoveInterlinkSelfReferencesFromCrossReferenceNodeTransformer.php
+++ b/packages/typo3-docs-theme/src/Compiler/NodeTransformers/RemoveInterlinkSelfReferencesFromCrossReferenceNodeTransformer.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link https://phpdoc.org
+ */
+
+namespace T3Docs\Typo3DocsTheme\Compiler\NodeTransformers;
+
+use phpDocumentor\Guides\Compiler\CompilerContextInterface;
+use phpDocumentor\Guides\Compiler\NodeTransformer;
+use phpDocumentor\Guides\Nodes\Inline\CrossReferenceNode;
+use phpDocumentor\Guides\Nodes\Inline\DocReferenceNode;
+use phpDocumentor\Guides\Nodes\Inline\ReferenceNode;
+use phpDocumentor\Guides\Nodes\Node;
+use T3Docs\Typo3DocsTheme\Settings\Typo3DocsThemeSettings;
+
+use function assert;
+
+/** @implements NodeTransformer<CrossReferenceNode> */
+final class RemoveInterlinkSelfReferencesFromCrossReferenceNodeTransformer implements NodeTransformer
+{
+    public function __construct(
+        private readonly Typo3DocsThemeSettings $themeSettings,
+    ) {}
+
+    public function enterNode(Node $node, CompilerContextInterface $compilerContext): Node
+    {
+        return $node;
+    }
+
+    public function leaveNode(Node $node, CompilerContextInterface $compilerContext): Node|null
+    {
+        assert($node instanceof CrossReferenceNode);
+        if (!$this->themeSettings->hasSettings('interlink_shortcode')) {
+            return $node;
+        }
+        $interlink = $this->themeSettings->getSettings('interlink_shortcode');
+        if ($interlink === '' || $node->getInterlinkDomain() !== $interlink) {
+            return $node;
+        }
+        // Remove interlink references to the own current document
+        if ($node instanceof ReferenceNode) {
+            $newRef = new ReferenceNode(
+                $node->getTargetReference(),
+                $node->getValue(),
+                '',
+                $node->getLinkType(),
+                $node->getPrefix()
+            );
+            return $newRef;
+        }
+        if ($node instanceof DocReferenceNode) {
+            $newDocRef = new DocReferenceNode(
+                $node->getTargetReference(),
+                $node->getValue(),
+            );
+            return $newDocRef;
+        }
+        return $node;
+    }
+
+    public function supports(Node $node): bool
+    {
+        return $node instanceof CrossReferenceNode;
+    }
+
+    public function getPriority(): int
+    {
+        return 1000;
+    }
+}

--- a/tests/Integration/tests/interlink/interlink-self/expected/index.html
+++ b/tests/Integration/tests/interlink/interlink-self/expected/index.html
@@ -1,0 +1,9 @@
+<!-- content start -->
+                <section class="section" id="document-title" data-rst-anchor="start">
+            <a id="start"></a>
+            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline"><i class="fa-solid fa-paragraph"></i></a></h1>
+
+    <p>See <a href="#">Document Title</a> or <a href="#start">Document Title</a>.</p>
+
+    </section>
+        <!-- content end -->

--- a/tests/Integration/tests/interlink/interlink-self/input/guides.xml
+++ b/tests/Integration/tests/interlink/interlink-self/input/guides.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<guides
+        xmlns="https://www.phpdoc.org/guides"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://www.phpdoc.org/guides vendor/phpdocumentor/guides-cli/resources/schema/guides.xsd"
+>
+    <extension class="\T3Docs\Typo3DocsTheme\DependencyInjection\Typo3DocsThemeExtension"
+               typo3-core-preferred="main"
+               interlink-shortcode="changelog"
+    />
+    <project title="Core"
+             release="main"
+             version="main"
+             copyright="since 1997 by the TYPO3 contributors"
+    />
+</guides>

--- a/tests/Integration/tests/interlink/interlink-self/input/index.rst
+++ b/tests/Integration/tests/interlink/interlink-self/input/index.rst
@@ -1,0 +1,8 @@
+
+..  _start:
+
+==============
+Document Title
+==============
+
+See :doc:`changelog:index` or :ref:`changelog:start`.


### PR DESCRIPTION
If the interlink domain used in a reference is the same like the interlink_shortcode of the current document use internal references instead.

Resolves https://github.com/TYPO3-Documentation/render-guides/issues/672