### PR TITLE
[TASK] Add "--minimal-test" CLI option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,12 +124,12 @@ test: test-integration test-unit test-xml test-docs test-rendertest ## Runs all 
 .PHONY: test-docs
 test-docs: ## Runs project generation tests
 	@echo "$(ENV_INFO)"
-	$(PHP_BIN) vendor/bin/guides --no-progress Documentation --output="/tmp/test" --config=Documentation --fail-on-log
+	$(PHP_BIN) vendor/bin/guides --no-progress Documentation --output="/tmp/test" --config=Documentation --minimal-test
 
 .PHONY: test-rendertest
 test-rendertest: ## Runs rendering with Documentation-rendertest
 	@echo "$(ENV_INFO)"
-	$(PHP_BIN) vendor/bin/guides --no-progress Documentation-rendertest --output="Documentation-GENERATED-rendertest" --config=Documentation-rendertest --fail-on-log
+	$(PHP_BIN) vendor/bin/guides --no-progress Documentation-rendertest --output="Documentation-GENERATED-rendertest" --config=Documentation-rendertest --minimal-test
 
 .PHONY: rendertest
 rendertest: ## Runs rendering with Documentation-rendertest

--- a/packages/typo3-docs-theme/src/EventListeners/AddThemeSettingsToProjectNode.php
+++ b/packages/typo3-docs-theme/src/EventListeners/AddThemeSettingsToProjectNode.php
@@ -17,6 +17,21 @@ final class AddThemeSettingsToProjectNode
     public function __invoke(PostProjectNodeCreated $event): void
     {
         $projectNode = $event->getProjectNode();
+
+        // Native parsing of argv because we do not have the original ArgvInput
+        // available, and neither the InputDefinition. That's ok for the
+        // very basic parsing of a global option.
+        if (in_array('--minimal-test', $_SERVER['argv'] ?? [], true)) {
+            $settings = $event->getSettings();
+
+            // Set up input arguments for our minimal test. Will override
+            // other input arguments. Can be extended later, so we have
+            // control also in the further command flow.
+            $settings->setOutputFormats(['singlepage']);
+            $settings->setFailOnError('1');
+            // Unsure: what is "fail-on-log". It's not available here.
+        }
+
         foreach ($this->themeSettings->getAllSettings() as $key => $setting) {
             if (trim($setting) !== '') {
                 $projectNode->addVariable($key, new PlainTextInlineNode($setting));

--- a/packages/typo3-docs-theme/src/EventListeners/AddThemeSettingsToProjectNode.php
+++ b/packages/typo3-docs-theme/src/EventListeners/AddThemeSettingsToProjectNode.php
@@ -28,8 +28,7 @@ final class AddThemeSettingsToProjectNode
             // other input arguments. Can be extended later, so we have
             // control also in the further command flow.
             $settings->setOutputFormats(['singlepage']);
-            $settings->setFailOnError('1');
-            // Unsure: what is "fail-on-log". It's not available here.
+            $settings->setFailOnError('warning'); // 'error' for "no warnings"
         }
 
         foreach ($this->themeSettings->getAllSettings() as $key => $setting) {

--- a/packages/typo3-guides-extension/src/Command/RunDecorator.php
+++ b/packages/typo3-guides-extension/src/Command/RunDecorator.php
@@ -49,6 +49,7 @@ final class RunDecorator extends Command
             'Render a specific localization (for example "de_DE", "ru_RU", ...)',
         );
 
+        // This option is evaluated in the PostProjectNodeCreated event in packages/typo3-docs-theme/src/EventListeners/AddThemeSettingsToProjectNode.php
         $this->innerCommand->addOption(
             'minimal-test',
             null,
@@ -78,15 +79,6 @@ final class RunDecorator extends Command
 
         if (!isset($options['--output'])) {
             $options['--output'] = getcwd() . '/' . self::DEFAULT_OUTPUT_DIRECTORY;
-        }
-
-        if ($input->getParameterOption('--minimal-test')) {
-            // Set up input arguments for our minimal test. Will override
-            // other input arguments. Can be extended later, so we have
-            // control also in the further command flow.
-            $options['--output-format'] = ['singlepage'];
-            $options['--fail-on-log'] = true;
-            $options['--fail-on-error'] = true;
         }
 
         $input = new ArrayInput(

--- a/packages/typo3-guides-extension/src/Command/RunDecorator.php
+++ b/packages/typo3-guides-extension/src/Command/RunDecorator.php
@@ -9,6 +9,7 @@ use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Process\Process;
@@ -48,6 +49,13 @@ final class RunDecorator extends Command
             'Render a specific localization (for example "de_DE", "ru_RU", ...)',
         );
 
+        $this->innerCommand->addOption(
+            'minimal-test',
+            null,
+            InputOption::VALUE_NONE,
+            'Apply preset for minimal testing (format=singlepage)',
+        );
+
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -70,6 +78,15 @@ final class RunDecorator extends Command
 
         if (!isset($options['--output'])) {
             $options['--output'] = getcwd() . '/' . self::DEFAULT_OUTPUT_DIRECTORY;
+        }
+
+        if ($input->getParameterOption('--minimal-test')) {
+            // Set up input arguments for our minimal test. Will override
+            // other input arguments. Can be extended later, so we have
+            // control also in the further command flow.
+            $options['--output-format'] = ['singlepage'];
+            $options['--fail-on-log'] = true;
+            $options['--fail-on-error'] = true;
         }
 
         $input = new ArrayInput(


### PR DESCRIPTION
This allows us to control specific settings needed for mininmal tests (like setting only a single output format) or more for the future.

Closes #764 