### PR TITLE
Reduce gap between argument signature and description

### DIFF
--- a/packages/typo3-api/template/css/custom.css.twig
+++ b/packages/typo3-api/template/css/custom.css.twig
@@ -30,3 +30,7 @@
     mask-image: url('data:image/svg+xml;utf8,{{ include('icons/method.svg.twig', {'hue': colours.hue(parameter.color|default('phpdocumentor-green'))})|trim|raw }}');
     background: var(--primary-color);
 }
+
+section.phpdocumentor-description {
+  margin-top: 0;
+}


### PR DESCRIPTION
This makes it clear that these two belong together

See https://github.com/TYPO3-Documentation/render-guides/blob/401acaf662d8fb6f6a833fc30cc89766567023cf/packages/typo3-docs-theme/assets/sass/layout/_structure.scss#L79