### PR TITLE
[TASK] Add verbose error when docker entrypoint fails

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -105,7 +105,22 @@ if [ "${MY_UID}" -eq "0" ]; then
         fi
 
         addgroup typo3 --gid=$GID;
+
+        if [ $? -ne 0 ]; then
+            echo "Error: Failed to add group 'typo3' inside docker container."
+            echo "This can happen if docker does not run as root. Please add the"
+            echo "argument '--user=\$(id -u):\$(id -g)' to your 'docker run...' call."
+            exit 1
+        fi
+
         adduser -h $(pwd) -D -G typo3 --uid=$UID typo3;
+
+        if [ $? -ne 0 ]; then
+            echo "Error: Failed to add user 'typo3' inside docker container."
+            echo "This can happen if docker does not run as root. Please add the"
+            echo "argument '--user=\$(id -u):\$(id -g)' to your 'docker run...' call."
+            exit 1
+        fi
 
         # su behaves inconsistently with -c followed by flags
         # Workaround: run the entrypoint and commands as a standalone script


### PR DESCRIPTION
A common problem for macOS users running docker as non-root is that omitting a '--user' option makes our entrypoint.sh script try to on-the-fly create a matching user.

(See https://github.com/FriendsOfTYPO3/tea/issues/1490)

This patch adds a verbose error message to hint at the problem.