### PR TITLE
559 style command lists

### DIFF
--- a/.ddev/commands/web/npm-watch
+++ b/.ddev/commands/web/npm-watch
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+cd packages/typo3-docs-theme
+npm run watch

--- a/Documentation-rendertest/Cards/Index.rst
+++ b/Documentation-rendertest/Cards/Index.rst
@@ -185,20 +185,6 @@ Cards with complex footer
         be carried out before and after the core is updated.
 
         ..  card-footer::
-            :button-styles: default
-
-            :ref:`13-dev <t3upgrade/dev:minor>`
-            :ref:`12.4 <t3upgrade/stable:minor>`
-            :ref:`11.5 <t3upgrade/oldstable:minor>`
-
-    ..  card:: `Minor upgrades <https://docs.typo3.org/m/typo3/guide-installation/12.4/en-us/Minor/Index.html>`__
-
-        Minor updates (for example 12.4.1 to 12.4.2)
-        contain bugfixes and/or security updates.
-        This chapter details how updates are installed and highlights what tasks need to
-        be carried out before and after the core is updated.
-
-        ..  card-footer::
             :button-styles: secondary
 
             `13-dev <https://docs.typo3.org/m/typo3/guide-installation/main/en-us/Minor/Index.html>`__

--- a/Documentation-rendertest/Typesetting/Index.rst
+++ b/Documentation-rendertest/Typesetting/Index.rst
@@ -62,6 +62,12 @@ Level 6 Header
 At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd
 gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
 
+Long Header with code and linebreak At vero eos ea rebum `subtypes_addlist`
+===========================================================
+
+At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd
+gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
+
 ..  _emphasis:
 
 Emphasis

--- a/Documentation/Developer/InterlinkInventories.rst
+++ b/Documentation/Developer/InterlinkInventories.rst
@@ -89,18 +89,6 @@ These inventories can be used by default in any rendered documentation:
 
     URL: https://docs.typo3.org/m/typo3/tutorial-editors/main/en-us/
 
-*   Title: :doc:`t3install:Index`
-
-    Inventory key: :doc:`t3install <t3install:Index>`
-
-    URL: https://docs.typo3.org/m/typo3/guide-installation/main/en-us/
-
-*   Title: :doc:`t3upgrade:Index`
-
-    Inventory key: :doc:`t3upgrade <t3upgrade:Index>`
-
-    URL: https://docs.typo3.org/m/typo3/guide-installation/main/en-us/
-
 *   Title: :doc:`t3sitepackage:Index`
 
     Inventory key: :doc:`t3sitepackage <t3sitepackage:Index>`
@@ -118,12 +106,6 @@ These inventories can be used by default in any rendered documentation:
     Inventory key: :doc:`t3translate <t3translate:Index>`
 
     URL: https://docs.typo3.org/m/typo3/guide-frontendlocalization/main/en-us/
-
-*   Title: :doc:`t3ts45:Index`
-
-    Inventory key: :doc:`t3ts45 <t3ts45:Index>`
-
-    URL: https://docs.typo3.org/m/typo3/tutorial-typoscript-in-45-minutes/main/en-us/
 
 *   Title: :doc:`h2document:Index`
 

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,10 @@ assets-install: ## Installs the node-modules needed to build the assets.
 assets-debug: ## Builds assets, keeping the sourcemap. It copies the output files directly into Documentation-GENERATED-temp so they can be tested without reloading.
 	ddev npm-debug
 
+.PHONE: assets-watch
+assets-watch: ## Watches changes of sass files and build automatically on change
+	ddev npm-watch
+
 .PHONE: build-phar
 build-phar: ## Creates a guides.phar file (github workflow)
 	./tools/build-phar.sh

--- a/packages/typo3-docs-theme/Gruntfile.js
+++ b/packages/typo3-docs-theme/Gruntfile.js
@@ -167,7 +167,7 @@ module.exports = function (grunt) {
       /* Compile sass changes into theme directory */
       sass: {
         files: [
-          '<%= paths.source %>sass/*.scss'
+          '<%= paths.source %>sass/**/*.scss'
         ],
         tasks: ['sass']
       }

--- a/packages/typo3-docs-theme/assets/sass/_variables.scss
+++ b/packages/typo3-docs-theme/assets/sass/_variables.scss
@@ -119,7 +119,8 @@ $h5-font-size: 1em;
 $h6-font-size: .85em;
 
 $headings-font-weight: $font-weight-bold;
-$headings-margin-bottom: .5em;
+$headings-margin-bottom: .3em;
+$headings-line-height: 1.4;
 
 //
 // Components

--- a/packages/typo3-docs-theme/assets/sass/components/_code.scss
+++ b/packages/typo3-docs-theme/assets/sass/components/_code.scss
@@ -9,7 +9,7 @@ code {
  */
 .code-block {
     margin-bottom: 0;
-    padding: .75rem;
+    padding: 0.75rem 2rem 0.75rem 0.75rem;
 
     & [data-line-number]::before {
         color: $gray-600;

--- a/packages/typo3-docs-theme/assets/sass/components/_command.scss
+++ b/packages/typo3-docs-theme/assets/sass/components/_command.scss
@@ -1,0 +1,20 @@
+dl.command {
+    @extend .confval;
+
+    & > dt {
+        a:not([class*=headerlink]) {
+            float: right;
+        }
+    }
+
+    .command-description {
+        margin-block: $spacer;
+    }
+
+    .command-options,
+    .command-arguments {
+        section {
+            margin-left: calc($spacer * 2);
+        }
+    }
+}

--- a/packages/typo3-docs-theme/assets/sass/components/_command.scss
+++ b/packages/typo3-docs-theme/assets/sass/components/_command.scss
@@ -1,5 +1,5 @@
 dl.command {
-    @extend .confval;
+    @extend .property-card;
 
     & > dt {
         a:not([class*=headerlink]) {

--- a/packages/typo3-docs-theme/assets/sass/components/directives/_confval.scss
+++ b/packages/typo3-docs-theme/assets/sass/components/directives/_confval.scss
@@ -1,27 +1,4 @@
 
 dl.confval {
-    background-color: $white;
-    border-radius: $border-radius;
-    margin-bottom: $spacer * 1.5;
-    padding-bottom: $spacer * .3;
-    border: solid 3px $light;
-    border-top-color: $gray-500;
-    word-wrap: anywhere;
-    white-space: normal;
-    & > dt {
-        display: block;
-        background-color: $light;
-        color: color-contrast($light);
-        font-size: $h4-font-size;
-        padding: .25em .5em;
-        margin-bottom: .75em;
-        code {
-            color: color-contrast($light);
-            word-wrap: anywhere;
-            white-space: normal;
-        }
-    }
-    & > dd {
-        margin-right: 1rem;
-    }
+    @extend .property-card;
 }

--- a/packages/typo3-docs-theme/assets/sass/components/directives/_phpdomain.scss
+++ b/packages/typo3-docs-theme/assets/sass/components/directives/_phpdomain.scss
@@ -3,47 +3,6 @@
 //
 .rst-content {
     dl.php {
-        border-radius: $border-radius;
-        margin-bottom: $spacer;
-        padding-bottom: $spacer * .3;
-        .descname {
-            background-color: transparent;
-            border: none;
-            color: $code-color;
-            font-size: 100%;
-            padding: 0;
-        }
-        .optional {
-            padding: 0 .25em;
-        }
-        code {
-            padding: 0 .25em;
-        }
-        .pre {
-            font-family: $font-family-monospace;
-        }
-        .headerlink,
-        .optional {
-            color: $body-color;
-        }
-        .viewcode-link {
-            padding-left: 1em;
-        }
-        & > dt {
-            background-color: lighten($info, 50%);
-            border-radius: $border-radius;
-            border-top: solid 3px $info;
-            color: darken($info, 50%);
-            display: inline-block;
-            font-size: $font-size-base;
-            margin-bottom: calc(#{$spacer} / 2);
-            padding: .25em .5em;
-            position: relative;
-        }
-        dl.php > dt {
-            background-color: $lighter;
-            border-top: 2px solid darken($lighter, 30%);
-            color: color-contrast($lighter);
-        }
+        @extend .property-card;
     }
 }

--- a/packages/typo3-docs-theme/assets/sass/components/directives/_propertyCard.scss
+++ b/packages/typo3-docs-theme/assets/sass/components/directives/_propertyCard.scss
@@ -1,0 +1,32 @@
+//
+// _propertyCard.scss used to display confvals, commands and php-classes
+//
+.property-card {
+    background-color: $white;
+    border-radius: $border-radius;
+    margin-bottom: $spacer * 1.5;
+    padding-bottom: $spacer * .3;
+    border: solid 3px $light;
+    border-top-color: $gray-500;
+    word-wrap: anywhere;
+    white-space: normal;
+
+    & > dt {
+        display: block;
+        background-color: $light;
+        color: color-contrast($light);
+        font-size: $h4-font-size;
+        padding: .25em .5em;
+        margin-bottom: .75em;
+
+        code {
+            color: color-contrast($light);
+            word-wrap: anywhere;
+            white-space: normal;
+        }
+    }
+
+    & > dd {
+        margin-right: 1rem;
+    }
+}

--- a/packages/typo3-docs-theme/assets/sass/theme.scss
+++ b/packages/typo3-docs-theme/assets/sass/theme.scss
@@ -50,6 +50,7 @@
 
 // Styles for special directives
 @import 'components/directives/admonition';
+@import 'components/directives/propertyCard';
 @import 'components/directives/confval.scss';
 @import 'components/directives/fieldlist';
 @import 'components/directives/phpdomain';

--- a/packages/typo3-docs-theme/assets/sass/theme.scss
+++ b/packages/typo3-docs-theme/assets/sass/theme.scss
@@ -29,6 +29,7 @@
 @import 'components/button';
 @import 'components/card';
 @import 'components/code';
+@import 'components/command';
 @import 'components/directoryTree';
 @import 'components/frame';
 @import 'components/images';

--- a/packages/typo3-docs-theme/package-lock.json
+++ b/packages/typo3-docs-theme/package-lock.json
@@ -22,7 +22,7 @@
                 "grunt-exec": "^3.0.0",
                 "grunt-sass": "^3.1.0",
                 "grunt-stylelint": "^0.20.1",
-                "sass": "^1.80.4",
+                "sass": "^1.80.5",
                 "stylelint": "^16.10.0"
             },
             "engines": {
@@ -3004,9 +3004,9 @@
             "dev": true
         },
         "node_modules/sass": {
-            "version": "1.80.4",
-            "resolved": "https://registry.npmjs.org/sass/-/sass-1.80.4.tgz",
-            "integrity": "sha512-rhMQ2tSF5CsuuspvC94nPM9rToiAFw2h3JTrLlgmNw1MH79v8Cr3DH6KF6o6r+8oofY3iYVPUf66KzC8yuVN1w==",
+            "version": "1.80.5",
+            "resolved": "https://registry.npmjs.org/sass/-/sass-1.80.5.tgz",
+            "integrity": "sha512-TQd2aoQl/+zsxRMEDSxVdpPIqeq9UFc6pr7PzkugiTx3VYCFPUaa3P4RrBQsqok4PO200Vkz0vXQBNlg7W907g==",
             "dev": true,
             "dependencies": {
                 "@parcel/watcher": "^2.4.1",

--- a/packages/typo3-docs-theme/package.json
+++ b/packages/typo3-docs-theme/package.json
@@ -17,7 +17,7 @@
         "grunt-exec": "^3.0.0",
         "grunt-sass": "^3.1.0",
         "grunt-stylelint": "^0.20.1",
-        "sass": "^1.80.4",
+        "sass": "^1.80.5",
         "stylelint": "^16.10.0"
     },
     "scripts": {

--- a/packages/typo3-docs-theme/package.json
+++ b/packages/typo3-docs-theme/package.json
@@ -22,7 +22,8 @@
     },
     "scripts": {
         "build": "grunt build",
-        "debug": "grunt debug"
+        "debug": "grunt debug",
+        "watch": "grunt watch"
     },
     "engines": {
         "node": ">=18.15.0 <21.0.0"

--- a/packages/typo3-docs-theme/resources/public/css/theme.css
+++ b/packages/typo3-docs-theme/resources/public/css/theme.css
@@ -25233,7 +25233,7 @@ ul[class*=horizbuttons-][class*=-note-] > li:hover, ul[class*=horizbuttons-][cla
   content: "\f071";
 }
 
-dl.confval {
+.property-card, .rst-content dl.php, dl.confval {
   background-color: #ffffff;
   border-radius: 0.375rem;
   margin-bottom: 1.5rem;
@@ -25243,7 +25243,7 @@ dl.confval {
   word-wrap: anywhere;
   white-space: normal;
 }
-dl.confval > dt {
+.property-card > dt, .rst-content dl.php > dt, dl.confval > dt {
   display: block;
   background-color: rgb(242.25, 242.25, 242.25);
   color: #000;
@@ -25251,12 +25251,12 @@ dl.confval > dt {
   padding: 0.25em 0.5em;
   margin-bottom: 0.75em;
 }
-dl.confval > dt code {
+.property-card > dt code, .rst-content dl.php > dt code, dl.confval > dt code {
   color: #000;
   word-wrap: anywhere;
   white-space: normal;
 }
-dl.confval > dd {
+.property-card > dd, .rst-content dl.php > dd, dl.confval > dd {
   margin-right: 1rem;
 }
 
@@ -25290,51 +25290,6 @@ dl.field-list > dt:after {
     margin: 0;
   }
 }
-.rst-content dl.php {
-  border-radius: 0.375rem;
-  margin-bottom: 1rem;
-  padding-bottom: 0.3rem;
-}
-.rst-content dl.php .descname {
-  background-color: transparent;
-  border: none;
-  color: hsl(350, 100%, 40%);
-  font-size: 100%;
-  padding: 0;
-}
-.rst-content dl.php .optional {
-  padding: 0 0.25em;
-}
-.rst-content dl.php code {
-  padding: 0 0.25em;
-}
-.rst-content dl.php .pre {
-  font-family: "Source Code Pro", monospace;
-}
-.rst-content dl.php .headerlink,
-.rst-content dl.php .optional {
-  color: #212529;
-}
-.rst-content dl.php .viewcode-link {
-  padding-left: 1em;
-}
-.rst-content dl.php > dt {
-  background-color: rgb(243.846473029, 250.2365145228, 252.153526971);
-  border-radius: 0.375rem;
-  border-top: solid 3px #319fc0;
-  color: black;
-  display: inline-block;
-  font-size: 1rem;
-  margin-bottom: calc(1rem / 2);
-  padding: 0.25em 0.5em;
-  position: relative;
-}
-.rst-content dl.php dl.php > dt {
-  background-color: rgb(247.35, 247.35, 247.35);
-  border-top: 2px solid rgb(170.85, 170.85, 170.85);
-  color: #000;
-}
-
 .sidebar {
   margin: 0;
   margin-bottom: 1rem;

--- a/packages/typo3-docs-theme/resources/public/css/theme.css
+++ b/packages/typo3-docs-theme/resources/public/css/theme.css
@@ -23693,7 +23693,7 @@ code {
  */
 .code-block {
   margin-bottom: 0;
-  padding: 0.75rem;
+  padding: 0.75rem 2rem 0.75rem 0.75rem;
 }
 .code-block [data-line-number]::before {
   color: #999999;

--- a/packages/typo3-docs-theme/resources/public/css/theme.css
+++ b/packages/typo3-docs-theme/resources/public/css/theme.css
@@ -11310,9 +11310,9 @@ hr {
 
 h1, .h1, h2, .h2, h3, .h3, h4, .h4, h5, .h5, h6, .h6 {
   margin-top: 0;
-  margin-bottom: 0.5em;
+  margin-bottom: 0.3em;
   font-weight: 600;
-  line-height: 1.2;
+  line-height: 1.4;
   color: var(--bs-heading-color);
 }
 

--- a/packages/typo3-docs-theme/resources/public/css/theme.css
+++ b/packages/typo3-docs-theme/resources/public/css/theme.css
@@ -23831,6 +23831,17 @@ code {
     max-width: 60vw;
   }
 }
+dl.command > dt a:not([class*=headerlink]) {
+  float: right;
+}
+dl.command .command-description {
+  margin-block: 1rem;
+}
+dl.command .command-options section,
+dl.command .command-arguments section {
+  margin-left: 2rem;
+}
+
 .directory-tree ul {
   margin-bottom: 0;
   list-style: none;

--- a/packages/typo3-docs-theme/resources/public/css/theme.css
+++ b/packages/typo3-docs-theme/resources/public/css/theme.css
@@ -25244,7 +25244,7 @@ ul[class*=horizbuttons-][class*=-note-] > li:hover, ul[class*=horizbuttons-][cla
   content: "\f071";
 }
 
-.property-card, .rst-content dl.php, dl.confval {
+.property-card, .rst-content dl.php, dl.confval, dl.command {
   background-color: #ffffff;
   border-radius: 0.375rem;
   margin-bottom: 1.5rem;
@@ -25254,7 +25254,7 @@ ul[class*=horizbuttons-][class*=-note-] > li:hover, ul[class*=horizbuttons-][cla
   word-wrap: anywhere;
   white-space: normal;
 }
-.property-card > dt, .rst-content dl.php > dt, dl.confval > dt {
+.property-card > dt, .rst-content dl.php > dt, dl.confval > dt, dl.command > dt {
   display: block;
   background-color: rgb(242.25, 242.25, 242.25);
   color: #000;
@@ -25262,12 +25262,12 @@ ul[class*=horizbuttons-][class*=-note-] > li:hover, ul[class*=horizbuttons-][cla
   padding: 0.25em 0.5em;
   margin-bottom: 0.75em;
 }
-.property-card > dt code, .rst-content dl.php > dt code, dl.confval > dt code {
+.property-card > dt code, .rst-content dl.php > dt code, dl.confval > dt code, dl.command > dt code {
   color: #000;
   word-wrap: anywhere;
   white-space: normal;
 }
-.property-card > dd, .rst-content dl.php > dd, dl.confval > dd {
+.property-card > dd, .rst-content dl.php > dd, dl.confval > dd, dl.command > dd {
   margin-right: 1rem;
 }
 
@@ -25942,4 +25942,3 @@ section.confval-section {
 .rubric {
   font-weight: 700;
 }
-

--- a/packages/typo3-docs-theme/resources/public/css/theme.css
+++ b/packages/typo3-docs-theme/resources/public/css/theme.css
@@ -25942,3 +25942,4 @@ section.confval-section {
 .rubric {
   font-weight: 700;
 }
+

--- a/packages/typo3-version-handling/src/DefaultInventories.php
+++ b/packages/typo3-version-handling/src/DefaultInventories.php
@@ -14,12 +14,9 @@ enum DefaultInventories: string
     case t3tsref = 't3tsref';
     case t3viewhelper = 't3viewhelper';
     case t3editors = 't3editors';
-    case t3install = 't3install'; // for legacy reasons
-    case t3upgrade = 't3upgrade';
     case t3sitepackage = 't3sitepackage';
     case t3start = 't3start';
     case t3translate = 't3translate';
-    case t3ts45 = 't3ts45';
     case h2document = 'h2document';
     case t3content = 't3content';
     case t3writing = 't3writing';
@@ -49,12 +46,10 @@ enum DefaultInventories: string
 
             // Official Core Tutorials and Guides
             DefaultInventories::t3editors => 'https://docs.typo3.org/m/typo3/tutorial-editors/{typo3_version}/en-us/',
-            DefaultInventories::t3install => 'https://docs.typo3.org/m/typo3/guide-installation/{typo3_version}/en-us/',
-            DefaultInventories::t3upgrade => 'https://docs.typo3.org/m/typo3/guide-installation/{typo3_version}/en-us/',
             DefaultInventories::t3sitepackage => 'https://docs.typo3.org/m/typo3/tutorial-sitepackage/{typo3_version}/en-us/',
             DefaultInventories::t3start => 'https://docs.typo3.org/m/typo3/tutorial-getting-started/{typo3_version}/en-us/',
             DefaultInventories::t3translate => 'https://docs.typo3.org/m/typo3/guide-frontendlocalization/{typo3_version}/en-us/',
-            DefaultInventories::t3ts45 => 'https://docs.typo3.org/m/typo3/tutorial-typoscript-in-45-minutes/{typo3_version}/en-us/',
+
 
             // Team Guides, they are commonly not versioned
             DefaultInventories::h2document => 'https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/',

--- a/tests/Integration/tests/guides-inventories/expected/index.html
+++ b/tests/Integration/tests/guides-inventories/expected/index.html
@@ -12,17 +12,14 @@
             <li>t3docs</li>
             <li>t3editors</li>
             <li>t3exceptions</li>
-            <li>t3install</li>
             <li>t3org</li>
             <li>t3renderguides</li>
             <li>t3sitepackage</li>
             <li>t3start</li>
             <li>t3tca</li>
             <li>t3translate</li>
-            <li>t3ts45</li>
             <li>t3tsconfig</li>
             <li>t3tsref</li>
-            <li>t3upgrade</li>
             <li>t3viewhelper</li>
             <li>t3writing</li>
     </ul>


### PR DESCRIPTION
resolves #599 

![image](https://github.com/user-attachments/assets/b6571685-f9e1-423f-9d25-439af8a6b6b1)

the commands are now styled like the confvals. 

Also I added the watch command in the Gruntfile.js

And I fixed the offset of the copy button in scrolling code blocks: 
Before:
![image](https://github.com/user-attachments/assets/fb789257-fa6a-4a36-8b0c-030d75e7b3d9)

After: 
![image](https://github.com/user-attachments/assets/9eb2c24c-6cfd-476b-b0eb-6e31b60b2787)
