### PR TITLE
[TASK] Delete removed guides from default inventories

### DIFF
--- a/Documentation-rendertest/Cards/Index.rst
+++ b/Documentation-rendertest/Cards/Index.rst
@@ -185,20 +185,6 @@ Cards with complex footer
         be carried out before and after the core is updated.
 
         ..  card-footer::
-            :button-styles: default
-
-            :ref:`13-dev <t3upgrade/dev:minor>`
-            :ref:`12.4 <t3upgrade/stable:minor>`
-            :ref:`11.5 <t3upgrade/oldstable:minor>`
-
-    ..  card:: `Minor upgrades <https://docs.typo3.org/m/typo3/guide-installation/12.4/en-us/Minor/Index.html>`__
-
-        Minor updates (for example 12.4.1 to 12.4.2)
-        contain bugfixes and/or security updates.
-        This chapter details how updates are installed and highlights what tasks need to
-        be carried out before and after the core is updated.
-
-        ..  card-footer::
             :button-styles: secondary
 
             `13-dev <https://docs.typo3.org/m/typo3/guide-installation/main/en-us/Minor/Index.html>`__

--- a/Documentation/Developer/InterlinkInventories.rst
+++ b/Documentation/Developer/InterlinkInventories.rst
@@ -89,18 +89,6 @@ These inventories can be used by default in any rendered documentation:
 
     URL: https://docs.typo3.org/m/typo3/tutorial-editors/main/en-us/
 
-*   Title: :doc:`t3install:Index`
-
-    Inventory key: :doc:`t3install <t3install:Index>`
-
-    URL: https://docs.typo3.org/m/typo3/guide-installation/main/en-us/
-
-*   Title: :doc:`t3upgrade:Index`
-
-    Inventory key: :doc:`t3upgrade <t3upgrade:Index>`
-
-    URL: https://docs.typo3.org/m/typo3/guide-installation/main/en-us/
-
 *   Title: :doc:`t3sitepackage:Index`
 
     Inventory key: :doc:`t3sitepackage <t3sitepackage:Index>`
@@ -118,12 +106,6 @@ These inventories can be used by default in any rendered documentation:
     Inventory key: :doc:`t3translate <t3translate:Index>`
 
     URL: https://docs.typo3.org/m/typo3/guide-frontendlocalization/main/en-us/
-
-*   Title: :doc:`t3ts45:Index`
-
-    Inventory key: :doc:`t3ts45 <t3ts45:Index>`
-
-    URL: https://docs.typo3.org/m/typo3/tutorial-typoscript-in-45-minutes/main/en-us/
 
 *   Title: :doc:`h2document:Index`
 

--- a/packages/typo3-version-handling/src/DefaultInventories.php
+++ b/packages/typo3-version-handling/src/DefaultInventories.php
@@ -14,12 +14,9 @@ enum DefaultInventories: string
     case t3tsref = 't3tsref';
     case t3viewhelper = 't3viewhelper';
     case t3editors = 't3editors';
-    case t3install = 't3install'; // for legacy reasons
-    case t3upgrade = 't3upgrade';
     case t3sitepackage = 't3sitepackage';
     case t3start = 't3start';
     case t3translate = 't3translate';
-    case t3ts45 = 't3ts45';
     case h2document = 'h2document';
     case t3content = 't3content';
     case t3writing = 't3writing';
@@ -49,12 +46,10 @@ enum DefaultInventories: string
 
             // Official Core Tutorials and Guides
             DefaultInventories::t3editors => 'https://docs.typo3.org/m/typo3/tutorial-editors/{typo3_version}/en-us/',
-            DefaultInventories::t3install => 'https://docs.typo3.org/m/typo3/guide-installation/{typo3_version}/en-us/',
-            DefaultInventories::t3upgrade => 'https://docs.typo3.org/m/typo3/guide-installation/{typo3_version}/en-us/',
             DefaultInventories::t3sitepackage => 'https://docs.typo3.org/m/typo3/tutorial-sitepackage/{typo3_version}/en-us/',
             DefaultInventories::t3start => 'https://docs.typo3.org/m/typo3/tutorial-getting-started/{typo3_version}/en-us/',
             DefaultInventories::t3translate => 'https://docs.typo3.org/m/typo3/guide-frontendlocalization/{typo3_version}/en-us/',
-            DefaultInventories::t3ts45 => 'https://docs.typo3.org/m/typo3/tutorial-typoscript-in-45-minutes/{typo3_version}/en-us/',
+
 
             // Team Guides, they are commonly not versioned
             DefaultInventories::h2document => 'https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/',

--- a/tests/Integration/tests/guides-inventories/expected/index.html
+++ b/tests/Integration/tests/guides-inventories/expected/index.html
@@ -12,17 +12,14 @@
             <li>t3docs</li>
             <li>t3editors</li>
             <li>t3exceptions</li>
-            <li>t3install</li>
             <li>t3org</li>
             <li>t3renderguides</li>
             <li>t3sitepackage</li>
             <li>t3start</li>
             <li>t3tca</li>
             <li>t3translate</li>
-            <li>t3ts45</li>
             <li>t3tsconfig</li>
             <li>t3tsref</li>
-            <li>t3upgrade</li>
             <li>t3viewhelper</li>
             <li>t3writing</li>
     </ul>


### PR DESCRIPTION
They are not available anymore for any supported TYPO3 version