### PR TITLE
[TASK] Use GitHub actions/download-artifact@v4

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -27,6 +27,9 @@ jobs:
         run: |
           echo IMAGE_NAME=$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]') >> $GITHUB_ENV
 
+      - name: Set platform name variable
+        run: echo "PLATFORM_NAME=${{ matrix.platform }}" | sed 's/\//-/g' >> $GITHUB_ENV
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
@@ -75,9 +78,10 @@ jobs:
           touch "/tmp/digests/${digest#sha256:}"
       -
         name: Upload digest
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: digests
+          name: digests-${{ env.PLATFORM_NAME }}
+          overwrite: true
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
@@ -94,9 +98,10 @@ jobs:
 
       -
         name: Download digests
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: digests
+          pattern: digests-*
+          merge-multiple: true
           path: /tmp/digests
       -
         name: Set up Docker Buildx


### PR DESCRIPTION
The old @v3 version will be retired in December with two brownouts later in November.

This commits will:

* Make distinct unmutable digests during the artifact CREATION (prefixed "digests-linux-amd64", "digests-linux-arm-v7", "digests-linux-arm64") and upload them
* On the "merge" step, retrieve these digests and merge them into one single digest that is then used for the docker imagetools creation command.

Hat tips to Andreas Kienast and Stefan Bürk! :)