### PR TITLE
[TASK] Add TODO hint to update intercept when changing versions

### DIFF
--- a/packages/typo3-version-handling/src/Typo3VersionMapping.php
+++ b/packages/typo3-version-handling/src/Typo3VersionMapping.php
@@ -20,6 +20,9 @@ enum Typo3VersionMapping: string
     public function getVersion(): string
     {
         return match ($this) {
+            // @TODO - When changing these versions, please
+            //         also do a PR on https://github.com/TYPO3GmbH/site-intercept/blob/develop/legacy_hook/composer.json
+            //         to raise the required composer package version!
             Typo3VersionMapping::Dev => 'main',
             Typo3VersionMapping::Stable => '13.4',
             Typo3VersionMapping::OldStable => '12.4',


### PR DESCRIPTION
When a new TYPO3 release is made and the order of stable->oldstable changes by one version, the permalink tool offered via interecept (https://docs.typo3.org/permalink/xxx:yyy@zzz) must be updated, too.