### PR TITLE
Remove docker armv7 build

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -18,7 +18,6 @@ jobs:
       matrix:
         platform:
           - linux/amd64
-          - linux/arm/v7
           - linux/arm64
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
AMD64 is the most supported cpu architecture, and ARM64 is used in modern apple laptops and some other devices. 

armv7 is not supported by the major platforms as this is an old 32 bit cpu. I think nobody is actually using this.