### PR TITLE
[FEAT] Redirect generator based on git changes.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,4 @@ tools/
 vendor/
 Dockerfile
 *.rst
+build

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,3 +20,6 @@ ENV TYPO3AZUREEDGEURIVERSION=$TYPO3AZUREEDGEURIVERSION
 WORKDIR /project
 ENTRYPOINT [ "/opt/guides/entrypoint.sh" ]
 CMD ["-h"]
+
+RUN apk add --no-cache \
+    git

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -77,6 +77,9 @@ elif [ "$1" = "configure" ]; then
 elif [ "$1" = "render" ]; then
     ENTRYPOINT="${ENTRYPOINT_DEFAULT}"
     shift
+elif [ "$1" = "create-redirects-from-git" ]; then
+    ENTRYPOINT="${ENTRYPOINT_SYMFONY_COMMANDS} create-redirects-from-git"
+    shift
 else
     # Default: "render"; no shifting.
     ENTRYPOINT="${ENTRYPOINT_DEFAULT}"

--- a/packages/typo3-guides-cli/bin/typo3-guides
+++ b/packages/typo3-guides-cli/bin/typo3-guides
@@ -9,6 +9,7 @@ use T3Docs\GuidesCli\Command\InitCommand;
 use T3Docs\GuidesCli\Command\MigrateSettingsCommand;
 use T3Docs\GuidesCli\Command\ConfigureCommand;
 use T3Docs\GuidesCli\Command\LintGuidesXmlCommand;
+use T3Docs\GuidesCli\Command\CreateRedirectsFromGitCommand;
 
 use Symfony\Component\Console\Application;
 
@@ -39,5 +40,6 @@ $application->add(new MigrateSettingsCommand());
 $application->add(new InitCommand());
 $application->add(new ConfigureCommand());
 $application->add(new LintGuidesXmlCommand());
+$application->add(new CreateRedirectsFromGitCommand());
 
 $application->run();

--- a/packages/typo3-guides-cli/src/Command/CreateRedirectsFromGitCommand.php
+++ b/packages/typo3-guides-cli/src/Command/CreateRedirectsFromGitCommand.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace T3Docs\GuidesCli\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Console\Input\InputOption;
+use T3Docs\GuidesCli\Git\GitChangeDetector;
+use T3Docs\GuidesCli\Redirect\RedirectCreator;
+
+final class CreateRedirectsFromGitCommand extends Command
+{
+    protected static $defaultName = 'create-redirects-from-git';
+
+    private GitChangeDetector $gitChangeDetector;
+    private RedirectCreator $redirectCreator;
+
+    public function __construct(
+        ?GitChangeDetector $gitChangeDetector = null,
+        ?RedirectCreator $redirectCreator = null
+    ) {
+        parent::__construct();
+        $this->gitChangeDetector = $gitChangeDetector ?? new GitChangeDetector();
+        $this->redirectCreator = $redirectCreator ?? new RedirectCreator();
+    }
+
+    protected function configure(): void
+    {
+        $this->setDescription('Creates nginx redirects for files moved in a GitHub pull request.');
+        $this->setHelp(
+            <<<'EOT'
+                The <info>%command.name%</info> command analyzes git history to detect moved files
+                in the current branch/PR and creates appropriate nginx redirects for them.
+
+                <info>$ php %command.name% [options]</info>
+
+                EOT
+        );
+
+        $this->addOption(
+            'base-branch',
+            'b',
+            InputOption::VALUE_REQUIRED,
+            'The base branch to compare changes against (default: main)',
+            'main'
+        );
+
+        $this->addOption(
+            'docs-path',
+            'd',
+            InputOption::VALUE_REQUIRED,
+            'Path to the Documentation directory',
+            'Documentation'
+        );
+
+        $this->addOption(
+            'output-file',
+            'o',
+            InputOption::VALUE_REQUIRED,
+            'Path to the nginx redirect configuration output file',
+            'redirects.nginx.conf'
+        );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $baseBranch = $input->getOption('base-branch');
+        $docsPath = $input->getOption('docs-path');
+        $outputFile = $input->getOption('output-file');
+
+        $io->title('Creating nginx redirects from git history');
+        $io->text("Base branch: {$baseBranch}");
+        $io->text("Documentation path: {$docsPath}");
+        $io->text("Output file: {$outputFile}");
+
+        try {
+            $movedFiles = $this->gitChangeDetector->detectMovedFiles($baseBranch, $docsPath);
+
+            if (empty($movedFiles)) {
+                $io->success('No moved files detected in this PR.');
+                return Command::SUCCESS;
+            }
+
+            $io->section('Detected moved files:');
+            foreach ($movedFiles as $oldPath => $newPath) {
+                $io->text("- <info>{$oldPath}</info> → <info>{$newPath}</info>");
+            }
+
+            $this->redirectCreator->setNginxRedirectFile($outputFile);
+
+
+            $createdRedirects = $this->redirectCreator->createRedirects($movedFiles, $docsPath);
+
+            $io->section('Created nginx redirects:');
+            foreach ($createdRedirects as $source => $target) {
+                $sourceUrl = str_replace($docsPath . '/', '', $source);
+                $sourceUrl = preg_replace('/\.(rst|md)$/', '', $sourceUrl);
+
+                $targetUrl = str_replace($docsPath . '/', '', $target);
+                $targetUrl = preg_replace('/\.(rst|md)$/', '', $targetUrl);
+
+                $io->text("- <info>/{$sourceUrl}</info> → <info>/{$targetUrl}</info>");
+            }
+
+            $io->success(sprintf('Nginx redirects created successfully in %s!', $outputFile));
+            return Command::SUCCESS;
+        } catch (\Exception $e) {
+            $io->error($e->getMessage());
+            return Command::FAILURE;
+        }
+    }
+}

--- a/packages/typo3-guides-cli/src/Command/CreateRedirectsFromGitCommand.php
+++ b/packages/typo3-guides-cli/src/Command/CreateRedirectsFromGitCommand.php
@@ -64,6 +64,20 @@ final class CreateRedirectsFromGitCommand extends Command
             'Path to the nginx redirect configuration output file',
             'redirects.nginx.conf'
         );
+        $this->addOption(
+            'versions',
+            'r',
+            InputOption::VALUE_REQUIRED,
+            'Regex of versions to include',
+            '(main|13.4|12.4)'
+        );
+        $this->addOption(
+            'path',
+            'p',
+            InputOption::VALUE_REQUIRED,
+            'Path, for example /m/typo3/reference-coreapi/',
+            '/'
+        );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -78,6 +92,10 @@ final class CreateRedirectsFromGitCommand extends Command
         $io->text("Base branch: {$baseBranch}");
         $io->text("Documentation path: {$docsPath}");
         $io->text("Output file: {$outputFile}");
+        $versions = $input->getOption('versions');
+        $io->text("Versions regex: {$versions}");
+        $path = $input->getOption('path');
+        $io->text("Path: {$path}");
 
         try {
             $movedFiles = $this->gitChangeDetector->detectMovedFiles($baseBranch, $docsPath);
@@ -95,7 +113,7 @@ final class CreateRedirectsFromGitCommand extends Command
             $this->redirectCreator->setNginxRedirectFile($outputFile);
 
 
-            $createdRedirects = $this->redirectCreator->createRedirects($movedFiles, $docsPath);
+            $createdRedirects = $this->redirectCreator->createRedirects($movedFiles, $docsPath, $versions, $path);
 
             $io->section('Created nginx redirects:');
             foreach ($createdRedirects as $source => $target) {

--- a/packages/typo3-guides-cli/src/Command/CreateRedirectsFromGitCommand.php
+++ b/packages/typo3-guides-cli/src/Command/CreateRedirectsFromGitCommand.php
@@ -87,14 +87,39 @@ final class CreateRedirectsFromGitCommand extends Command
         $baseBranch = $input->getOption('base-branch');
         $docsPath = $input->getOption('docs-path');
         $outputFile = $input->getOption('output-file');
+        $versions = $input->getOption('versions');
+        $path = $input->getOption('path');
+
+        if (!is_string($baseBranch)) {
+            $io->error('Base branch must be a string.');
+            return Command::FAILURE;
+        }
+
+        if (!is_string($docsPath)) {
+            $io->error('Documentation path must be a string.');
+            return Command::FAILURE;
+        }
+
+        if (!is_string($outputFile)) {
+            $io->error('Output file must be a string.');
+            return Command::FAILURE;
+        }
+
+        if (!is_string($versions) || preg_match($versions, '') === false) {
+            $io->error('Versions must be valid regex.');
+            return Command::FAILURE;
+        }
+
+        if (!is_string($path)) {
+            $io->error('Path must be a string.');
+            return Command::FAILURE;
+        }
 
         $io->title('Creating nginx redirects from git history');
         $io->text("Base branch: {$baseBranch}");
         $io->text("Documentation path: {$docsPath}");
         $io->text("Output file: {$outputFile}");
-        $versions = $input->getOption('versions');
         $io->text("Versions regex: {$versions}");
-        $path = $input->getOption('path');
         $io->text("Path: {$path}");
 
         try {
@@ -122,6 +147,10 @@ final class CreateRedirectsFromGitCommand extends Command
 
                 $targetUrl = str_replace($docsPath . '/', '', $target);
                 $targetUrl = preg_replace('/\.(rst|md)$/', '', $targetUrl);
+                if (is_string($targetUrl) === false) {
+                    $io->error('Target construct failed');
+                    return Command::FAILURE;
+                }
 
                 $io->text("- <info>/{$sourceUrl}</info> → <info>/{$targetUrl}</info>");
             }

--- a/packages/typo3-guides-cli/src/Git/GitChangeDetector.php
+++ b/packages/typo3-guides-cli/src/Git/GitChangeDetector.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace T3Docs\GuidesCli\Git;
+
+/**
+ * Detects file changes in git, specifically focusing on moved files
+ */
+class GitChangeDetector
+{
+    public function detectMovedFiles(string $baseBranch, string $docsPath): array
+    {
+        $movedFiles = [];
+
+        // Get the common ancestor commit between current branch and base branch
+        $mergeBase = trim($this->executeGitCommand("merge-base {$baseBranch} HEAD"));
+
+        if (empty($mergeBase)) {
+            throw new \RuntimeException('Could not determine merge base with the specified branch.');
+        }
+
+        // Use git diff to find renamed files
+        // --diff-filter=R shows only renamed files
+        // -M detects renames
+        // --name-status shows the status and filenames
+        $command = "diff {$mergeBase} HEAD --diff-filter=R -M --name-status";
+        $output = $this->executeGitCommand($command);
+
+        // Parse the output to extract renamed files
+        $lines = explode("\n", $output);
+        foreach ($lines as $line) {
+            if (empty($line)) {
+                continue;
+            }
+
+            // Format is: R<score>\t<old-file>\t<new-file>
+            $parts = preg_split('/\s+/', $line, 3);
+
+            if (count($parts) !== 3 || !str_starts_with($parts[0], 'R')) {
+                continue;
+            }
+
+            $oldPath = trim($parts[1]);
+            $newPath = trim($parts[2]);
+
+            if ($this->isDocumentationFile($oldPath, $docsPath) && $this->isDocumentationFile($newPath, $docsPath)) {
+                $movedFiles[$oldPath] = $newPath;
+            }
+        }
+
+        return $movedFiles;
+    }
+
+    private function isDocumentationFile(string $filePath, string $docsPath): bool
+    {
+        return str_starts_with($filePath, $docsPath)
+            && (str_ends_with($filePath, '.rst') || str_ends_with($filePath, '.md'));
+    }
+
+    private function executeGitCommand(string $command): string
+    {
+        $fullCommand = "git {$command} 2>&1";
+        $output = [];
+        $returnCode = 0;
+
+        exec($fullCommand, $output, $returnCode);
+
+        if ($returnCode !== 0) {
+            throw new \RuntimeException('Git command failed: ' . implode("\n", $output));
+        }
+
+        return implode("\n", $output);
+    }
+}

--- a/packages/typo3-guides-cli/src/Git/GitChangeDetector.php
+++ b/packages/typo3-guides-cli/src/Git/GitChangeDetector.php
@@ -9,6 +9,7 @@ namespace T3Docs\GuidesCli\Git;
  */
 class GitChangeDetector
 {
+    /** @return array<string, string> */
     public function detectMovedFiles(string $baseBranch, string $docsPath): array
     {
         $movedFiles = [];
@@ -36,6 +37,9 @@ class GitChangeDetector
 
             // Format is: R<score>\t<old-file>\t<new-file>
             $parts = preg_split('/\s+/', $line, 3);
+            if ($parts === false) {
+                continue;
+            }
 
             if (count($parts) !== 3 || !str_starts_with($parts[0], 'R')) {
                 continue;

--- a/packages/typo3-guides-cli/src/Redirect/RedirectCreator.php
+++ b/packages/typo3-guides-cli/src/Redirect/RedirectCreator.php
@@ -11,7 +11,7 @@ class RedirectCreator
 {
     private string $nginxRedirectFile = 'redirects.nginx.conf';
 
-    public function createRedirects(array $movedFiles, string $docsPath): array
+    public function createRedirects(array $movedFiles, string $docsPath, string $versions, string $path): array
     {
         $createdRedirects = [];
         $nginxRedirects = [];
@@ -23,7 +23,7 @@ class RedirectCreator
             $oldUrlPath = $this->convertToUrlPath($oldRelativePath);
             $newUrlPath = $this->convertToUrlPath($newRelativePath);
 
-            $nginxRedirects[] = "location = /{$oldUrlPath} { return 301 /{$newUrlPath}; }";
+            $nginxRedirects[] = sprintf("location = ^%s%s/en-us/%s { return 301 %s$1/en-us/%s; }", $path, $versions, $oldUrlPath, $path, $newUrlPath);
 
             $createdRedirects[$oldPath] = $newPath;
         }

--- a/packages/typo3-guides-cli/src/Redirect/RedirectCreator.php
+++ b/packages/typo3-guides-cli/src/Redirect/RedirectCreator.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace T3Docs\GuidesCli\Redirect;
+
+/**
+ * Creates nginx redirect configurations for moved documentation files
+ */
+class RedirectCreator
+{
+    private string $nginxRedirectFile = 'redirects.nginx.conf';
+
+    public function createRedirects(array $movedFiles, string $docsPath): array
+    {
+        $createdRedirects = [];
+        $nginxRedirects = [];
+
+        foreach ($movedFiles as $oldPath => $newPath) {
+            $oldRelativePath = $this->stripDocsPathPrefix($oldPath, $docsPath);
+            $newRelativePath = $this->stripDocsPathPrefix($newPath, $docsPath);
+
+            $oldUrlPath = $this->convertToUrlPath($oldRelativePath);
+            $newUrlPath = $this->convertToUrlPath($newRelativePath);
+
+            $nginxRedirects[] = "location = /{$oldUrlPath} { return 301 /{$newUrlPath}; }";
+
+            $createdRedirects[$oldPath] = $newPath;
+        }
+
+        if (!empty($nginxRedirects)) {
+            $nginxConfig = "# Nginx redirects for moved files in Documentation\n";
+            $nginxConfig .= "# Generated on: " . date('Y-m-d H:i:s') . "\n\n";
+            $nginxConfig .= implode("\n", $nginxRedirects) . "\n";
+
+            file_put_contents($this->nginxRedirectFile, $nginxConfig);
+        }
+
+        return $createdRedirects;
+    }
+
+    /**
+     * Set a custom path for the nginx redirect configuration file
+     */
+    public function setNginxRedirectFile(string $filePath): void
+    {
+        $this->nginxRedirectFile = $filePath;
+    }
+
+    private function stripDocsPathPrefix(string $path, string $docsPath): string
+    {
+        if (str_starts_with($path, $docsPath . '/')) {
+            return substr($path, strlen($docsPath) + 1);
+        }
+        return $path;
+    }
+
+    private function convertToUrlPath(string $path): string
+    {
+        $path = preg_replace('/\.(rst|md)$/', '.html', $path);
+
+        if (basename($path) === 'Index') {
+            $path = dirname($path);
+            if ($path === '.') {
+                $path = '';
+            }
+        }
+
+        return ltrim($path, '/');
+    }
+}

--- a/packages/typo3-guides-cli/src/Redirect/RedirectCreator.php
+++ b/packages/typo3-guides-cli/src/Redirect/RedirectCreator.php
@@ -11,6 +11,10 @@ class RedirectCreator
 {
     private string $nginxRedirectFile = 'redirects.nginx.conf';
 
+    /**
+     * @param array<string, string> $movedFiles
+     * @return array<string, string>
+     */
     public function createRedirects(array $movedFiles, string $docsPath, string $versions, string $path): array
     {
         $createdRedirects = [];
@@ -58,6 +62,9 @@ class RedirectCreator
     private function convertToUrlPath(string $path): string
     {
         $path = preg_replace('/\.(rst|md)$/', '.html', $path);
+        if (is_string($path) === false) {
+            throw new \RuntimeException('Failed to convert path to URL format');
+        }
 
         if (basename($path) === 'Index') {
             $path = dirname($path);


### PR DESCRIPTION
This is a prove of concept PR, showcasing how we could possibly generate a list of redirects. This is not complete and should be evaluated carefully. 

The purpose of the new command is to be able to automatically create directs for file that have been removed. For now we only use the git history, but we might want to expand this. For example to use the perma links used within most documentation.

To test this command you have to build the docker file for your local development. Using `make docker-build` .
After that the command can be tested on you local machine. 

```
docker run -i --rm --user 1000 -v${PWD}:/project typo3-docs:local create-redirects-from-git -b 3eb3cfc
```

Where `3eb3cfc` is a short sha of the project you are processing. In my example I used: https://github.com/TYPO3-Documentation/TYPO3CMS-Guide-HowToDocument

The output of the command is now written to a file: `redirects.nginx.conf` 

```
# Nginx redirects for moved files in Documentation
# Generated on: 2025-06-10 20:22:48

location = /HowToAddTranslation { return 301 /Advanced/HowToAddTranslation; }
location = /GeneralConventions/ReviewInformation { return 301 /Advanced/ReviewInformation; }
location = /About { return 301 /Basics/About; }
location = /BasicPrinciples { return 301 /Basics/BasicPrinciples; }
location = /GeneralConventions/CodingGuidelines { return 301 /Basics/GeneralConventions/CodingGuidelines; }
location = /GeneralConventions/ContentStyleGuide { return 301 /Basics/GeneralConventions/ContentStyleGuide; }
location = /GeneralConventions/Format { return 301 /Basics/GeneralConventions/Format; }
location = /GeneralConventions/Glossary { return 301 /Basics/GeneralConventions/Glossary; }
location = /GeneralConventions/GuidelinesForImages { return 301 /Basics/GeneralConventions/GuidelinesForImages; }
location = /GeneralConventions { return 301 /Basics/GeneralConventions; }
location = /GeneralConventions/Licenses { return 301 /Basics/GeneralConventions/Licenses; }
```

 This is just a real quick showcase, we could implement this for example in the github action, to automatically create a pr or issue to publish the content. 