### PR TITLE
Move Permalink in link reference modal to top

### DIFF
--- a/packages/typo3-docs-theme/resources/template/structure/layoutParts/linkReferenceModal.html.twig
+++ b/packages/typo3-docs-theme/resources/template/structure/layoutParts/linkReferenceModal.html.twig
@@ -12,11 +12,6 @@
             <div class="modal-body">
                 <div class="alert alert-success d-none" id="permalink-alert-success" role="alert"></div>
                 <div class="mb-3">
-                    <label for="permalink-uri" class="col-form-label">URL</label>
-                    <div class="input-group">
-                        <input class="form-control code" id="permalink-uri" readonly>
-                        <button type="button" class="btn btn-outline-secondary copy-button" data-target="permalink-uri"><i class="far fa-clone"></i></button>
-                    </div>
                     <div class="permalink-short-wrapper">
                         <label for="permalink-short" class="col-form-label">Permalink (Shortlink)</label>
                         <div class="input-group">
@@ -24,6 +19,11 @@
                             <button type="button" class="btn btn-outline-secondary copy-button" data-target="permalink-short"><i class="far fa-clone"></i></button>
                         </div>
                         <p><em>Copy and freely share the link</em></p>
+                    </div>
+                    <label for="permalink-uri" class="col-form-label">URL</label>
+                    <div class="input-group">
+                        <input class="form-control code" id="permalink-uri" readonly>
+                        <button type="button" class="btn btn-outline-secondary copy-button" data-target="permalink-uri"><i class="far fa-clone"></i></button>
                     </div>
                 </div>
                 <div class="mb-3">


### PR DESCRIPTION
This promotes the Permalink and makes it more likely people use it instead of the URL

See #1081