### PR TITLE
[DOCS] Standardize license to Creative Commons BY 4.0

### DIFF
--- a/Documentation-markdowntest/Index.md
+++ b/Documentation-markdowntest/Index.md
@@ -2,6 +2,10 @@
 
 TYPO3 Extension adding Double Opt-In to the TYPO3 CMS Form Framework
 
+**License:** This document is published under the [Creative Commons BY 4.0](https://creativecommons.org/licenses/by/4.0/) license.
+
+---
+
 ## Installation
 
 Just install it as a TYPO3 Extension or with `composer require linawolf/form_double_opt_in`.

--- a/Documentation-rendertest/Index.rst
+++ b/Documentation-rendertest/Index.rst
@@ -4,6 +4,13 @@
 TYPO3 theme rendering test
 ==========================
 
+:License:
+   This document is published under the
+   `Creative Commons BY 4.0 <https://creativecommons.org/licenses/by/4.0/>`__
+   license.
+
+----
+
 This is taken from this repository:
 
 https://github.com/TYPO3-Documentation/sphinx_typo3_theme_rendering_test

--- a/Documentation-rendertest/Localization.de_DE/Index.rst
+++ b/Documentation-rendertest/Localization.de_DE/Index.rst
@@ -25,6 +25,11 @@ AUF DEUTSCH
 :Author:
    TYPO3
 
+:License:
+   This document is published under the
+   `Creative Commons BY 4.0 <https://creativecommons.org/licenses/by/4.0/>`__
+   license.
+
 :Rendered:
    |today|
 

--- a/Documentation-rendertest/Localization.fr_FR/Index.rst
+++ b/Documentation-rendertest/Localization.fr_FR/Index.rst
@@ -25,6 +25,11 @@ EN FRANCAIS
 :Author:
    TYPO3
 
+:License:
+   This document is published under the
+   `Creative Commons BY 4.0 <https://creativecommons.org/licenses/by/4.0/>`__
+   license.
+
 :Rendered:
    |today|
 

--- a/Documentation-rendertest/Localization.ru_RU/Index.rst
+++ b/Documentation-rendertest/Localization.ru_RU/Index.rst
@@ -150,8 +150,9 @@ TYPO3 - Ознакомительное пособие
    Участники проекта TYPO3
 
 :License:
-   Документ публикуется под
-   `Открытой на публикацию лицензией <https://www.opencontent.org/openpub/>`__.
+   This document is published under the
+   `Creative Commons BY 4.0 <https://creativecommons.org/licenses/by/4.0/>`__
+   license.
 
 :Rendered:
    |today|


### PR DESCRIPTION
## Summary

- Standardize all documentation licenses to Creative Commons BY 4.0
- Add missing license declarations to documentation files
- Fix incorrect license in Russian localization (was Open Publication License)

## Changes

| File | Change |
|------|--------|
| `Documentation-rendertest/Index.rst` | Added CC BY 4.0 license |
| `Documentation-rendertest/Localization.de_DE/Index.rst` | Added CC BY 4.0 license |
| `Documentation-rendertest/Localization.fr_FR/Index.rst` | Added CC BY 4.0 license |
| `Documentation-rendertest/Localization.ru_RU/Index.rst` | Changed from Open Publication to CC BY 4.0 |
| `Documentation-markdowntest/Index.md` | Added CC BY 4.0 license |

## Test plan

- [x] Verify all documentation files now have consistent CC BY 4.0 license