### PR TITLE
use reference links in the Documentation template

### DIFF
--- a/packages/typo3-guides-cli/resources/templates/rst/GetHelp.rst.twig
+++ b/packages/typo3-guides-cli/resources/templates/rst/GetHelp.rst.twig
@@ -6,8 +6,8 @@
 Where to get help
 =================
 
-You can get help in the :ref:`TYPO3 Slack <https://typo3.org/community/meet/chat-slack>`.
-Ask a question in the official :ref:`TYPO3 forum <https://talk.typo3.org/c/typo3-questions/19>`
+You can get help in the `TYPO3 Slack <https://typo3.org/community/meet/chat-slack>`_.
+Ask a question in the official `TYPO3 forum <https://talk.typo3.org/c/typo3-questions/19>_`
 or contact the extension author.
 
 ..  _report-issues:


### PR DESCRIPTION
The referenced help sites can be linked by means of tsref.