### PR TITLE
[FEATURE] Modernize float classes to Bootstrap 5 with deprecation handling

### DIFF
--- a/Documentation-rendertest/ImagesAndFigures/FloatAndAlignment.rst
+++ b/Documentation-rendertest/ImagesAndFigures/FloatAndAlignment.rst
@@ -20,7 +20,7 @@ Image float left
 
 .. |example-teaser-left| image:: ../images/q150_cccccc.png
    :alt: Left floating image
-   :class: float-left with-shadow
+   :class: float-start with-shadow
 
 |example-teaser-left|
 Typesetting is the composition of text by means of arranging physical
@@ -41,7 +41,7 @@ Image float right
 
 .. |example-teaser-right| image:: ../images/q150_cccccc.png
    :alt: Right floating image
-   :class: float-right with-shadow
+   :class: float-end with-shadow
 
 |example-teaser-right|
 Typesetting is the composition of text by means of arranging physical
@@ -62,7 +62,8 @@ Figure float left
 
 .. figure:: ../images/q150_cccccc.png
    :alt: Left floating figure
-   :class: float-left with-shadow
+   :align: left
+   :class: with-shadow
 
    A figure floated to the left
 
@@ -85,7 +86,8 @@ Figure float right
 
 .. figure:: ../images/q150_cccccc.png
    :alt: Right floating figure
-   :class: float-right with-shadow
+   :align: right
+   :class: with-shadow
 
    A figure floated to the right
 

--- a/packages/typo3-docs-theme/assets/sass/components/_images.scss
+++ b/packages/typo3-docs-theme/assets/sass/components/_images.scss
@@ -17,15 +17,20 @@ figure {
     &:not(:first-child) {
         @extend .mt-3;
     }
+    &.float-start,
+    &.float-end,
+    // Deprecated: legacy Bootstrap 4 class names — remove after migration period (see #1179)
     &.float-left,
     &.float-right {
         margin-bottom: $spacer;
         max-width: 50%;
     }
+    &.float-start,
     &.float-left {
         float: left;
         margin-right: $spacer;
     }
+    &.float-end,
     &.float-right {
         float: right;
         margin-left: $spacer;
@@ -37,6 +42,8 @@ figure {
 }
 
 @media (max-width: 575.98px) {
+    figure.float-start,
+    figure.float-end,
     figure.float-left,
     figure.float-right {
         float: none;

--- a/packages/typo3-docs-theme/assets/sass/components/_images.scss
+++ b/packages/typo3-docs-theme/assets/sass/components/_images.scss
@@ -21,17 +21,22 @@ figure {
         @extend .mt-3;
     }
 
+    &.float-start,
+    &.float-end,
+    // Deprecated: legacy Bootstrap 4 class names — remove after migration period (see #1179)
     &.float-left,
     &.float-right {
         margin-bottom: $spacer;
         max-width: 50%;
     }
 
+    &.float-start,
     &.float-left {
         float: left;
         margin-right: $spacer;
     }
 
+    &.float-end,
     &.float-right {
         float: right;
         margin-left: $spacer;
@@ -44,6 +49,8 @@ figure {
 }
 @media (max-width: 575.98px) {
 
+    figure.float-start,
+    figure.float-end,
     figure.float-left,
     figure.float-right {
         float: none;

--- a/packages/typo3-docs-theme/assets/sass/components/_rst.scss
+++ b/packages/typo3-docs-theme/assets/sass/components/_rst.scss
@@ -32,11 +32,14 @@
         display: inline-block;
         max-width: 100%;
         height: auto;
+        // Deprecated: legacy Bootstrap 4 class names — remove after migration period (see #1179)
+        &.float-start,
         &.float-left {
             float: left;
             margin-right: $spacer;
             margin-bottom: $spacer;
         }
+        &.float-end,
         &.float-right {
             float: right;
             margin-left: $spacer;
@@ -55,6 +58,17 @@
                 margin-right: 0;
                 max-width: 100%;
             }
+        }
+    }
+    @media (max-width: 575.98px) {
+        img.float-start,
+        img.float-end,
+        img.float-left,
+        img.float-right {
+            float: none;
+            max-width: 100%;
+            margin-left: 0;
+            margin-right: 0;
         }
     }
     .plantuml object {

--- a/packages/typo3-docs-theme/assets/sass/components/_rst.scss
+++ b/packages/typo3-docs-theme/assets/sass/components/_rst.scss
@@ -35,12 +35,15 @@
         max-width: 100%;
         height: auto;
 
+        // Deprecated: legacy Bootstrap 4 class names — remove after migration period (see #1179)
+        &.float-start,
         &.float-left {
             float: left;
             margin-right: $spacer;
             margin-bottom: $spacer;
         }
 
+        &.float-end,
         &.float-right {
             float: right;
             margin-left: $spacer;
@@ -61,6 +64,18 @@
                 margin-right: 0;
                 max-width: 100%;
             }
+        }
+    }
+
+    @media (max-width: 575.98px) {
+        img.float-start,
+        img.float-end,
+        img.float-left,
+        img.float-right {
+            float: none;
+            max-width: 100%;
+            margin-left: 0;
+            margin-right: 0;
         }
     }
 

--- a/packages/typo3-docs-theme/resources/config/typo3-docs-theme.php
+++ b/packages/typo3-docs-theme/resources/config/typo3-docs-theme.php
@@ -29,6 +29,7 @@ use T3Docs\Typo3DocsTheme\Compiler\NodeTransformers\Typo3TalkNodeTransformer;
 use T3Docs\Typo3DocsTheme\Directives\ConfvalMenuDirective;
 use T3Docs\Typo3DocsTheme\Directives\DirectoryTreeDirective;
 use T3Docs\Typo3DocsTheme\Directives\FigureDirective;
+use T3Docs\Typo3DocsTheme\Directives\ImageDirective;
 use T3Docs\Typo3DocsTheme\Directives\GlossaryDirective;
 use T3Docs\Typo3DocsTheme\Directives\GroupTabDirective;
 use T3Docs\Typo3DocsTheme\Directives\IncludeDirective;
@@ -203,6 +204,7 @@ return static function (ContainerConfigurator $container): void {
         ->set(DirectoryTreeDirective::class)
         ->set(FigureDirective::class)
         ->arg('$startingRule', service(DirectiveContentRule::class))
+        ->set(ImageDirective::class)
         ->set(GlossaryDirective::class)
         ->set(GroupTabDirective::class)
         ->set(IncludeDirective::class)

--- a/packages/typo3-docs-theme/resources/public/css/theme.css
+++ b/packages/typo3-docs-theme/resources/public/css/theme.css
@@ -24700,15 +24700,15 @@ dl.command .command-arguments section {
 figure figcaption p:last-child {
   margin-bottom: 0;
 }
-figure.float-left, figure.float-right {
+figure.float-start, figure.float-end, figure.float-left, figure.float-right {
   margin-bottom: 1rem;
   max-width: 50%;
 }
-figure.float-left {
+figure.float-start, figure.float-left {
   float: left;
   margin-right: 1rem;
 }
-figure.float-right {
+figure.float-end, figure.float-right {
   float: right;
   margin-left: 1rem;
 }
@@ -24718,6 +24718,8 @@ figure.align-center {
 }
 
 @media (max-width: 575.98px) {
+  figure.float-start,
+  figure.float-end,
   figure.float-left,
   figure.float-right {
     float: none;
@@ -24821,13 +24823,15 @@ article *:hover > a.headerlink, article *:hover > a.permalink, article *:hover .
   max-width: 100%;
   height: auto;
 }
-.rst-content img.float-left,
+.rst-content img.float-start, .rst-content img.float-left,
+.rst-content object.float-start,
 .rst-content object.float-left {
   float: left;
   margin-right: 1rem;
   margin-bottom: 1rem;
 }
-.rst-content img.float-right,
+.rst-content img.float-end, .rst-content img.float-right,
+.rst-content object.float-end,
 .rst-content object.float-right {
   float: right;
   margin-left: 1rem;
@@ -24840,13 +24844,14 @@ article *:hover > a.headerlink, article *:hover > a.permalink, article *:hover .
   margin-right: auto;
 }
 @media (max-width: 575.98px) {
-  .rst-content img.float-left, .rst-content img.float-right,
-  .rst-content object.float-left,
-  .rst-content object.float-right {
+  .rst-content img.float-start,
+  .rst-content img.float-end,
+  .rst-content img.float-left,
+  .rst-content img.float-right {
     float: none;
+    max-width: 100%;
     margin-left: 0;
     margin-right: 0;
-    max-width: 100%;
   }
 }
 .rst-content .plantuml object {

--- a/packages/typo3-docs-theme/resources/public/css/theme.css
+++ b/packages/typo3-docs-theme/resources/public/css/theme.css
@@ -25134,15 +25134,15 @@ dl.command .command-arguments section {
 figure figcaption p:last-child {
   margin-bottom: 0;
 }
-figure.float-left, figure.float-right {
+figure.float-start, figure.float-end, figure.float-left, figure.float-right {
   margin-bottom: 1rem;
   max-width: 50%;
 }
-figure.float-left {
+figure.float-start, figure.float-left {
   float: left;
   margin-right: 1rem;
 }
-figure.float-right {
+figure.float-end, figure.float-right {
   float: right;
   margin-left: 1rem;
 }
@@ -25152,6 +25152,8 @@ figure.align-center {
 }
 
 @media (max-width: 575.98px) {
+  figure.float-start,
+  figure.float-end,
   figure.float-left,
   figure.float-right {
     float: none;
@@ -25258,13 +25260,15 @@ article *:hover .headerNoindex {
   max-width: 100%;
   height: auto;
 }
-.rst-content img.float-left,
+.rst-content img.float-start, .rst-content img.float-left,
+.rst-content object.float-start,
 .rst-content object.float-left {
   float: left;
   margin-right: 1rem;
   margin-bottom: 1rem;
 }
-.rst-content img.float-right,
+.rst-content img.float-end, .rst-content img.float-right,
+.rst-content object.float-end,
 .rst-content object.float-right {
   float: right;
   margin-left: 1rem;
@@ -25284,6 +25288,17 @@ article *:hover .headerNoindex {
     margin-left: 0;
     margin-right: 0;
     max-width: 100%;
+  }
+}
+@media (max-width: 575.98px) {
+  .rst-content img.float-start,
+  .rst-content img.float-end,
+  .rst-content img.float-left,
+  .rst-content img.float-right {
+    float: none;
+    max-width: 100%;
+    margin-left: 0;
+    margin-right: 0;
   }
 }
 .rst-content .plantuml object {

--- a/packages/typo3-docs-theme/resources/template/body/figure.html.twig
+++ b/packages/typo3-docs-theme/resources/template/body/figure.html.twig
@@ -1,6 +1,11 @@
-{%- set alignMap = {'left': 'float-left', 'right': 'float-right', 'center': 'align-center'} -%}
+{# Maps RST :align: values to CSS classes. Duplicated in image.html.twig — keep in sync. #}
+{# See also: FigureDirective.php / ImageDirective.php for :class: float-left/right rewriting #}
+{%- set alignMap = {'left': 'float-start', 'right': 'float-end', 'center': 'align-center'} -%}
 {%- set alignClass = node.hasOption('align') ? alignMap[node.option('align')]|default('') : '' -%}
-{%- set classes = ([node.classesString, alignClass]|join(' '))|trim -%}
+{%- set classes = node.classesString|trim -%}
+{%- if alignClass and alignClass not in (classes ? classes|split(' ') : []) -%}
+    {%- set classes = ([classes, alignClass]|join(' '))|trim -%}
+{%- endif -%}
 <figure
     {%- if classes %} class="{{ classes }}"{% endif -%}
     {%- if node.hasOption('figwidth') %} style="{% if node.hasOption('figwidth') %}width: {{ node.option('figwidth') }};{% endif %}"{% endif -%}

--- a/packages/typo3-docs-theme/resources/template/body/image.html.twig
+++ b/packages/typo3-docs-theme/resources/template/body/image.html.twig
@@ -2,9 +2,14 @@
 {%- if node.hasOption('zoom') -%}
 <span data-zoom="{{ node.option('zoom') }}"{% if node.hasOption('gallery') %} data-gallery="{{ node.option('gallery') }}"{% endif %}{% if node.hasOption('zoom-factor') %} data-zoom-factor="{{ node.option('zoom-factor') }}"{% endif %}{% if node.hasOption('zoom-indicator') %} data-zoom-indicator="{{ node.option('zoom-indicator') }}"{% endif %}>
 {%- endif -%}
-{%- set alignMap = {'left': 'float-left', 'right': 'float-right', 'center': 'align-center'} -%}
+{# Maps RST :align: values to CSS classes. Duplicated in figure.html.twig — keep in sync. #}
+{# See also: FigureDirective.php / ImageDirective.php for :class: float-left/right rewriting #}
+{%- set alignMap = {'left': 'float-start', 'right': 'float-end', 'center': 'align-center'} -%}
 {%- set alignClass = node.hasOption('align') ? alignMap[node.option('align')]|default('') : '' -%}
-{%- set classes = ([node.classesString, alignClass]|join(' '))|trim -%}
+{%- set classes = node.classesString|trim -%}
+{%- if alignClass and alignClass not in (classes ? classes|split(' ') : []) -%}
+    {%- set classes = ([classes, alignClass]|join(' '))|trim -%}
+{%- endif -%}
 <img
     src="{%- if node.value is external_target -%} {{ node.value }} {%- else -%} {{ asset(node.value) }} {%- endif -%}"
     {% if node.hasOption('width') %}width="{{ node.option('width') }}"{% endif%}

--- a/packages/typo3-docs-theme/src/DependencyInjection/Typo3DocsThemeExtension.php
+++ b/packages/typo3-docs-theme/src/DependencyInjection/Typo3DocsThemeExtension.php
@@ -6,6 +6,7 @@ namespace T3Docs\Typo3DocsTheme\DependencyInjection;
 
 use phpDocumentor\Guides\NodeRenderers\TemplateNodeRenderer;
 use phpDocumentor\Guides\RestructuredText\Directives\FigureDirective as BaseFigureDirective;
+use phpDocumentor\Guides\RestructuredText\Directives\ImageDirective as BaseImageDirective;
 use phpDocumentor\Guides\TemplateRenderer;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
@@ -15,7 +16,6 @@ use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
-use T3Docs\Typo3DocsTheme\Directives\FigureDirective;
 use T3Docs\Typo3DocsTheme\Nodes\Inline\CodeInlineNode;
 use T3Docs\Typo3DocsTheme\Nodes\Inline\ComposerInlineNode;
 use T3Docs\Typo3DocsTheme\Nodes\Inline\FileInlineNode;
@@ -114,14 +114,19 @@ class Typo3DocsThemeExtension extends Extension implements PrependExtensionInter
     }
 
     /**
-     * Remove the base library's FigureDirective in favor of our custom implementation
-     * that supports zoom functionality.
+     * Remove the base library's directives in favor of our custom implementations.
+     *
+     * - FigureDirective: supports zoom functionality and float class deprecation
+     * - ImageDirective: uses composition to add float class deprecation handling
      */
     public function process(ContainerBuilder $container): void
     {
-        // Remove the base library's FigureDirective to let our custom one take over
         if ($container->hasDefinition(BaseFigureDirective::class)) {
             $container->removeDefinition(BaseFigureDirective::class);
+        }
+
+        if ($container->hasDefinition(BaseImageDirective::class)) {
+            $container->removeDefinition(BaseImageDirective::class);
         }
     }
 }

--- a/packages/typo3-docs-theme/src/DependencyInjection/Typo3DocsThemeExtension.php
+++ b/packages/typo3-docs-theme/src/DependencyInjection/Typo3DocsThemeExtension.php
@@ -6,6 +6,7 @@ namespace T3Docs\Typo3DocsTheme\DependencyInjection;
 
 use phpDocumentor\Guides\NodeRenderers\TemplateNodeRenderer;
 use phpDocumentor\Guides\RestructuredText\Directives\FigureDirective as BaseFigureDirective;
+use phpDocumentor\Guides\RestructuredText\Directives\ImageDirective as BaseImageDirective;
 use phpDocumentor\Guides\TemplateRenderer;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
@@ -15,7 +16,6 @@ use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
-use T3Docs\Typo3DocsTheme\Directives\FigureDirective;
 use T3Docs\Typo3DocsTheme\Nodes\Inline\CodeInlineNode;
 use T3Docs\Typo3DocsTheme\Nodes\Inline\ComposerInlineNode;
 use T3Docs\Typo3DocsTheme\Nodes\Inline\FileInlineNode;
@@ -140,14 +140,19 @@ class Typo3DocsThemeExtension extends Extension implements PrependExtensionInter
     }
 
     /**
-     * Remove the base library's FigureDirective in favor of our custom implementation
-     * that supports zoom functionality.
+     * Remove the base library's directives in favor of our custom implementations.
+     *
+     * - FigureDirective: supports zoom functionality and float class deprecation
+     * - ImageDirective: uses composition to add float class deprecation handling
      */
     public function process(ContainerBuilder $container): void
     {
-        // Remove the base library's FigureDirective to let our custom one take over
         if ($container->hasDefinition(BaseFigureDirective::class)) {
             $container->removeDefinition(BaseFigureDirective::class);
+        }
+
+        if ($container->hasDefinition(BaseImageDirective::class)) {
+            $container->removeDefinition(BaseImageDirective::class);
         }
     }
 }

--- a/packages/typo3-docs-theme/src/Directives/ImageDirective.php
+++ b/packages/typo3-docs-theme/src/Directives/ImageDirective.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace T3Docs\Typo3DocsTheme\Directives;
+
+use phpDocumentor\Guides\Nodes\Node;
+use phpDocumentor\Guides\ReferenceResolvers\DocumentNameResolverInterface;
+use phpDocumentor\Guides\RestructuredText\Directives\BaseDirective;
+use phpDocumentor\Guides\RestructuredText\Directives\ImageDirective as BaseImageDirective;
+use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
+use phpDocumentor\Guides\RestructuredText\Parser\Directive;
+use phpDocumentor\Guides\RestructuredText\Parser\DirectiveOption;
+use Psr\Log\LoggerInterface;
+
+use function is_string;
+
+/**
+ * Decorates the upstream ImageDirective to detect and rewrite deprecated float class names.
+ *
+ * Intercepts `:class: float-left` / `:class: float-right` and rewrites them to
+ * `float-start` / `float-end` (Bootstrap 5) before delegating to the upstream directive,
+ * emitting a deprecation warning.
+ *
+ * Uses composition instead of inheritance because the upstream class is declared final.
+ * The upstream instance is created internally to avoid Symfony service decoration
+ * side effects with tagged directive services.
+ *
+ * The deprecation warning additionally mentions `float-start`/`float-end` as
+ * alternatives because substitution images (|name|) do not support the `:align:`
+ * option — only `:class:` is available.
+ *
+ * Note: process() delegates to $this->inner->process() which internally calls
+ * BaseDirective::process() including withKeepExistingOptions(). We intentionally
+ * skip the outer BaseDirective::process() to avoid double-applying options.
+ *
+ * @see BaseImageDirective (upstream, composed)
+ * @see https://github.com/phpDocumentor/guides/issues/1303 (final removal request)
+ * @see FigureDirective (same float class rewriting for figures)
+ */
+final class ImageDirective extends BaseDirective
+{
+    use RewritesLegacyFloatClasses;
+
+    private readonly BaseImageDirective $inner;
+
+    public function __construct(
+        DocumentNameResolverInterface $documentNameResolver,
+        private readonly LoggerInterface $logger,
+    ) {
+        $this->inner = new BaseImageDirective($documentNameResolver);
+    }
+
+    public function getName(): string
+    {
+        return 'image';
+    }
+
+    public function process(
+        BlockContext $blockContext,
+        Directive $directive,
+    ): Node|null {
+        // Detect and rewrite legacy float classes before delegating to upstream
+        // See also: figure.html.twig / image.html.twig alignMap for :align: option mapping
+        if ($directive->hasOption('class')) {
+            $classValue = $directive->getOption('class')->getValue();
+            if (is_string($classValue) && $this->hasLegacyFloatClass($classValue)) {
+                $this->logger->warning(
+                    'Using `:class: float-left` / `:class: float-right` is deprecated. '
+                    . 'Use `:align: left` / `:align: right` instead, or `float-start` / `float-end` for substitution images.',
+                    $blockContext->getLoggerInformation(),
+                );
+                $directive->addOption(new DirectiveOption('class', $this->rewriteLegacyFloatClasses($classValue)));
+            }
+        }
+
+        return $this->inner->process($blockContext, $directive);
+    }
+}

--- a/packages/typo3-docs-theme/src/Directives/RewritesLegacyFloatClasses.php
+++ b/packages/typo3-docs-theme/src/Directives/RewritesLegacyFloatClasses.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace T3Docs\Typo3DocsTheme\Directives;
+
+use function preg_match;
+use function preg_replace;
+
+/**
+ * Shared logic for detecting and rewriting deprecated Bootstrap 4 float class names.
+ *
+ * Rewrites `float-left` → `float-start` and `float-right` → `float-end` (Bootstrap 5
+ * logical properties). Used by both FigureDirective and ImageDirective.
+ *
+ * @see FigureDirective
+ * @see ImageDirective
+ */
+trait RewritesLegacyFloatClasses
+{
+    private function hasLegacyFloatClass(string $classValue): bool
+    {
+        return (bool) preg_match('/\bfloat-(left|right)\b/', $classValue);
+    }
+
+    private function rewriteLegacyFloatClasses(string $classValue): string
+    {
+        return (string) preg_replace(
+            ['/\bfloat-left\b/', '/\bfloat-right\b/'],
+            ['float-start', 'float-end'],
+            $classValue,
+        );
+    }
+}

--- a/packages/typo3-docs-theme/tests/unit/Directives/FigureDirectiveTest.php
+++ b/packages/typo3-docs-theme/tests/unit/Directives/FigureDirectiveTest.php
@@ -1,0 +1,264 @@
+<?php
+
+declare(strict_types=1);
+
+namespace T3Docs\Typo3DocsTheme\Tests\Unit\Directives;
+
+use phpDocumentor\Guides\Nodes\CollectionNode;
+use phpDocumentor\Guides\Nodes\FigureNode;
+use phpDocumentor\Guides\Nodes\InlineCompoundNode;
+use phpDocumentor\Guides\ReferenceResolvers\DocumentNameResolverInterface;
+use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
+use phpDocumentor\Guides\RestructuredText\Parser\Directive;
+use phpDocumentor\Guides\RestructuredText\Parser\DirectiveOption;
+use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
+use phpDocumentor\Guides\RestructuredText\Parser\Productions\Rule;
+use phpDocumentor\Guides\ParserContext;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use T3Docs\Typo3DocsTheme\Directives\FigureDirective;
+
+final class FigureDirectiveTest extends TestCase
+{
+    private FigureDirective $subject;
+    private DocumentNameResolverInterface&MockObject $documentNameResolver;
+    /** @var Rule<CollectionNode>&MockObject */
+    private Rule&MockObject $startingRule;
+    private LoggerInterface&MockObject $logger;
+
+    protected function setUp(): void
+    {
+        $this->documentNameResolver = $this->createMock(DocumentNameResolverInterface::class);
+        $this->documentNameResolver->method('absoluteUrl')->willReturn('/resolved/image.png');
+        $this->startingRule = $this->createMock(Rule::class);
+        $this->logger = $this->createMock(LoggerInterface::class);
+
+        $this->subject = new FigureDirective(
+            $this->documentNameResolver,
+            $this->startingRule,
+            $this->logger,
+        );
+    }
+
+    #[Test]
+    public function getNameReturnsFigure(): void
+    {
+        self::assertSame('figure', $this->subject->getName());
+    }
+
+    #[Test]
+    public function processReturnsNullWhenStartingRuleReturnsNull(): void
+    {
+        $this->startingRule->method('apply')->willReturn(null);
+
+        $result = $this->subject->process(
+            $this->createBlockContext(),
+            new Directive('', 'figure', 'image.png'),
+        );
+
+        self::assertNull($result);
+    }
+
+    #[Test]
+    public function processRewritesLegacyFloatLeftClass(): void
+    {
+        $this->startingRule->method('apply')->willReturn(new CollectionNode([new InlineCompoundNode([])]));
+
+        $directive = new Directive('', 'figure', 'image.png', [
+            'class' => new DirectiveOption('class', 'float-left'),
+        ]);
+
+        $this->logger->expects(self::once())
+            ->method('warning')
+            ->with(self::stringContains('deprecated'));
+
+        $result = $this->subject->process($this->createBlockContext(), $directive);
+
+        self::assertInstanceOf(FigureNode::class, $result);
+        // The directive class option should be rewritten for postProcessNode
+        self::assertSame('float-start', $directive->getOption('class')->getValue());
+        // The inner image should NOT have float classes
+        self::assertNull($result->getImage()->getOption('class'));
+    }
+
+    #[Test]
+    public function processRewritesLegacyFloatRightClass(): void
+    {
+        $this->startingRule->method('apply')->willReturn(new CollectionNode([new InlineCompoundNode([])]));
+
+        $directive = new Directive('', 'figure', 'image.png', [
+            'class' => new DirectiveOption('class', 'float-right'),
+        ]);
+
+        $this->logger->expects(self::once())->method('warning');
+
+        $result = $this->subject->process($this->createBlockContext(), $directive);
+
+        self::assertInstanceOf(FigureNode::class, $result);
+        self::assertSame('float-end', $directive->getOption('class')->getValue());
+        self::assertNull($result->getImage()->getOption('class'));
+    }
+
+    #[Test]
+    public function processPreservesNonFloatClassesOnInnerImage(): void
+    {
+        $this->startingRule->method('apply')->willReturn(new CollectionNode([new InlineCompoundNode([])]));
+
+        $directive = new Directive('', 'figure', 'image.png', [
+            'class' => new DirectiveOption('class', 'with-shadow float-left'),
+        ]);
+
+        $this->logger->expects(self::once())->method('warning');
+
+        $result = $this->subject->process($this->createBlockContext(), $directive);
+
+        self::assertInstanceOf(FigureNode::class, $result);
+        // Directive updated with rewritten classes
+        self::assertSame('with-shadow float-start', $directive->getOption('class')->getValue());
+        // Inner image gets only non-float classes
+        self::assertSame('with-shadow', $result->getImage()->getOption('class'));
+    }
+
+    #[Test]
+    public function processDoesNotRewriteModernClasses(): void
+    {
+        $this->startingRule->method('apply')->willReturn(new CollectionNode([new InlineCompoundNode([])]));
+
+        $directive = new Directive('', 'figure', 'image.png', [
+            'class' => new DirectiveOption('class', 'float-start'),
+        ]);
+
+        $this->logger->expects(self::never())->method('warning');
+
+        $result = $this->subject->process($this->createBlockContext(), $directive);
+
+        self::assertInstanceOf(FigureNode::class, $result);
+        // Float classes stripped from inner image
+        self::assertNull($result->getImage()->getOption('class'));
+    }
+
+    #[Test]
+    public function processHandlesNoClassOption(): void
+    {
+        $this->startingRule->method('apply')->willReturn(new CollectionNode([new InlineCompoundNode([])]));
+
+        $directive = new Directive('', 'figure', 'image.png');
+
+        $this->logger->expects(self::never())->method('warning');
+
+        $result = $this->subject->process($this->createBlockContext(), $directive);
+
+        self::assertInstanceOf(FigureNode::class, $result);
+        self::assertNull($result->getImage()->getOption('class'));
+    }
+
+    #[Test]
+    public function processHandlesNonStringClassValue(): void
+    {
+        $this->startingRule->method('apply')->willReturn(new CollectionNode([new InlineCompoundNode([])]));
+
+        $directive = new Directive('', 'figure', 'image.png', [
+            'class' => new DirectiveOption('class', true),
+        ]);
+
+        $this->logger->expects(self::never())->method('warning');
+
+        $result = $this->subject->process($this->createBlockContext(), $directive);
+
+        self::assertInstanceOf(FigureNode::class, $result);
+    }
+
+    #[Test]
+    public function processFiltersInvalidZoomMode(): void
+    {
+        $this->startingRule->method('apply')->willReturn(new CollectionNode([new InlineCompoundNode([])]));
+
+        $directive = new Directive('', 'figure', 'image.png', [
+            'zoom' => new DirectiveOption('zoom', 'invalid-mode'),
+        ]);
+
+        $result = $this->subject->process($this->createBlockContext(), $directive);
+
+        self::assertInstanceOf(FigureNode::class, $result);
+        self::assertNull($result->getOption('zoom'));
+    }
+
+    #[Test]
+    #[DataProvider('validZoomModeProvider')]
+    public function processAcceptsValidZoomModes(string $mode): void
+    {
+        $this->startingRule->method('apply')->willReturn(new CollectionNode([new InlineCompoundNode([])]));
+
+        $directive = new Directive('', 'figure', 'image.png', [
+            'zoom' => new DirectiveOption('zoom', $mode),
+        ]);
+
+        $result = $this->subject->process($this->createBlockContext(), $directive);
+
+        self::assertInstanceOf(FigureNode::class, $result);
+        self::assertSame($mode, $result->getOption('zoom'));
+    }
+
+    /** @return \Generator<string, array{string}> */
+    public static function validZoomModeProvider(): \Generator
+    {
+        yield 'lightbox' => ['lightbox'];
+        yield 'gallery' => ['gallery'];
+        yield 'inline' => ['inline'];
+        yield 'lens' => ['lens'];
+    }
+
+    #[Test]
+    public function processPassesImageOptionsToImageNode(): void
+    {
+        $this->startingRule->method('apply')->willReturn(new CollectionNode([new InlineCompoundNode([])]));
+
+        $directive = new Directive('', 'figure', 'image.png', [
+            'width' => new DirectiveOption('width', '200'),
+            'height' => new DirectiveOption('height', '100'),
+            'alt' => new DirectiveOption('alt', 'test image'),
+            'scale' => new DirectiveOption('scale', '50'),
+        ]);
+
+        $result = $this->subject->process($this->createBlockContext(), $directive);
+
+        self::assertInstanceOf(FigureNode::class, $result);
+        self::assertSame('200', $result->getImage()->getOption('width'));
+        self::assertSame('100', $result->getImage()->getOption('height'));
+        self::assertSame('test image', $result->getImage()->getOption('alt'));
+        self::assertSame('50', $result->getImage()->getOption('scale'));
+    }
+
+    #[Test]
+    public function processStripsFloatStartFromInnerImage(): void
+    {
+        $this->startingRule->method('apply')->willReturn(new CollectionNode([new InlineCompoundNode([])]));
+
+        $directive = new Directive('', 'figure', 'image.png', [
+            'class' => new DirectiveOption('class', 'float-end with-border'),
+        ]);
+
+        $result = $this->subject->process($this->createBlockContext(), $directive);
+
+        self::assertInstanceOf(FigureNode::class, $result);
+        // Float-end stripped, only with-border remains
+        self::assertSame('with-border', $result->getImage()->getOption('class'));
+    }
+
+    private function createBlockContext(): BlockContext
+    {
+        $parserContext = $this->createMock(ParserContext::class);
+        $parserContext->method('getCurrentAbsolutePath')->willReturn('/test');
+        $parserContext->method('getLoggerInformation')->willReturn(['rst-file' => 'test.rst']);
+        $parserContext->method('getInitialHeaderLevel')->willReturn(1);
+
+        $documentParserContext = $this->createMock(DocumentParserContext::class);
+        $documentParserContext->method('getContext')->willReturn($parserContext);
+        $documentParserContext->method('getLoggerInformation')->willReturn(['rst-file' => 'test.rst']);
+
+        return new BlockContext($documentParserContext, '', false, 0);
+    }
+}

--- a/packages/typo3-docs-theme/tests/unit/Directives/ImageDirectiveTest.php
+++ b/packages/typo3-docs-theme/tests/unit/Directives/ImageDirectiveTest.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace T3Docs\Typo3DocsTheme\Tests\Unit\Directives;
+
+use phpDocumentor\Guides\Nodes\ImageNode;
+use phpDocumentor\Guides\ReferenceResolvers\DocumentNameResolverInterface;
+use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
+use phpDocumentor\Guides\RestructuredText\Parser\Directive;
+use phpDocumentor\Guides\RestructuredText\Parser\DirectiveOption;
+use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
+use phpDocumentor\Guides\ParserContext;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use T3Docs\Typo3DocsTheme\Directives\ImageDirective;
+
+final class ImageDirectiveTest extends TestCase
+{
+    private ImageDirective $subject;
+    private DocumentNameResolverInterface&MockObject $documentNameResolver;
+    private LoggerInterface&MockObject $logger;
+
+    protected function setUp(): void
+    {
+        $this->documentNameResolver = $this->createMock(DocumentNameResolverInterface::class);
+        $this->documentNameResolver->method('absoluteUrl')->willReturn('/resolved/image.png');
+        $this->logger = $this->createMock(LoggerInterface::class);
+        $this->subject = new ImageDirective($this->documentNameResolver, $this->logger);
+    }
+
+    #[Test]
+    public function getNameReturnsImage(): void
+    {
+        self::assertSame('image', $this->subject->getName());
+    }
+
+    #[Test]
+    public function processRewritesLegacyFloatLeftClass(): void
+    {
+        $directive = new Directive('', 'image', 'image.png', [
+            'class' => new DirectiveOption('class', 'float-left'),
+        ]);
+
+        $this->logger->expects(self::once())
+            ->method('warning')
+            ->with(self::stringContains('deprecated'));
+
+        $result = $this->subject->process($this->createBlockContext(), $directive);
+
+        self::assertInstanceOf(ImageNode::class, $result);
+        self::assertSame('float-start', $directive->getOption('class')->getValue());
+    }
+
+    #[Test]
+    public function processRewritesLegacyFloatRightClass(): void
+    {
+        $directive = new Directive('', 'image', 'image.png', [
+            'class' => new DirectiveOption('class', 'float-right'),
+        ]);
+
+        $this->logger->expects(self::once())
+            ->method('warning')
+            ->with(self::stringContains('deprecated'));
+
+        $result = $this->subject->process($this->createBlockContext(), $directive);
+
+        self::assertInstanceOf(ImageNode::class, $result);
+        self::assertSame('float-end', $directive->getOption('class')->getValue());
+    }
+
+    #[Test]
+    public function processRewritesLegacyClassWithOtherClasses(): void
+    {
+        $directive = new Directive('', 'image', 'image.png', [
+            'class' => new DirectiveOption('class', 'with-shadow float-left'),
+        ]);
+
+        $this->logger->expects(self::once())->method('warning');
+
+        $result = $this->subject->process($this->createBlockContext(), $directive);
+
+        self::assertInstanceOf(ImageNode::class, $result);
+        self::assertSame('with-shadow float-start', $directive->getOption('class')->getValue());
+    }
+
+    #[Test]
+    public function processDoesNotRewriteModernClasses(): void
+    {
+        $directive = new Directive('', 'image', 'image.png', [
+            'class' => new DirectiveOption('class', 'float-start'),
+        ]);
+
+        $this->logger->expects(self::never())->method('warning');
+
+        $result = $this->subject->process($this->createBlockContext(), $directive);
+
+        self::assertInstanceOf(ImageNode::class, $result);
+        self::assertSame('float-start', $directive->getOption('class')->getValue());
+    }
+
+    #[Test]
+    public function processHandlesNoClassOption(): void
+    {
+        $directive = new Directive('', 'image', 'image.png');
+
+        $this->logger->expects(self::never())->method('warning');
+
+        $result = $this->subject->process($this->createBlockContext(), $directive);
+
+        self::assertInstanceOf(ImageNode::class, $result);
+    }
+
+    #[Test]
+    public function processHandlesNonStringClassValue(): void
+    {
+        $directive = new Directive('', 'image', 'image.png', [
+            'class' => new DirectiveOption('class', true),
+        ]);
+
+        $this->logger->expects(self::never())->method('warning');
+
+        $result = $this->subject->process($this->createBlockContext(), $directive);
+
+        self::assertInstanceOf(ImageNode::class, $result);
+    }
+
+    private function createBlockContext(): BlockContext
+    {
+        $parserContext = $this->createMock(ParserContext::class);
+        $parserContext->method('getCurrentAbsolutePath')->willReturn('/test');
+        $parserContext->method('getLoggerInformation')->willReturn(['rst-file' => 'test.rst']);
+        $parserContext->method('getInitialHeaderLevel')->willReturn(1);
+
+        $documentParserContext = $this->createMock(DocumentParserContext::class);
+        $documentParserContext->method('getContext')->willReturn($parserContext);
+        $documentParserContext->method('getLoggerInformation')->willReturn(['rst-file' => 'test.rst']);
+
+        return new BlockContext($documentParserContext, '', false, 0);
+    }
+}

--- a/packages/typo3-docs-theme/tests/unit/Directives/RewritesLegacyFloatClassesTest.php
+++ b/packages/typo3-docs-theme/tests/unit/Directives/RewritesLegacyFloatClassesTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace T3Docs\Typo3DocsTheme\Tests\Unit\Directives;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use T3Docs\Typo3DocsTheme\Directives\RewritesLegacyFloatClasses;
+
+final class RewritesLegacyFloatClassesTest extends TestCase
+{
+    private object $subject;
+
+    protected function setUp(): void
+    {
+        // Anonymous class to expose the private trait methods for testing
+        $this->subject = new class () {
+            use RewritesLegacyFloatClasses;
+
+            public function callHasLegacyFloatClass(string $classValue): bool
+            {
+                return $this->hasLegacyFloatClass($classValue);
+            }
+
+            public function callRewriteLegacyFloatClasses(string $classValue): string
+            {
+                return $this->rewriteLegacyFloatClasses($classValue);
+            }
+        };
+    }
+
+    #[Test]
+    #[DataProvider('legacyFloatClassDetectionProvider')]
+    public function hasLegacyFloatClassDetectsCorrectly(string $classValue, bool $expected): void
+    {
+        self::assertSame($expected, $this->subject->callHasLegacyFloatClass($classValue));
+    }
+
+    /** @return \Generator<string, array{string, bool}> */
+    public static function legacyFloatClassDetectionProvider(): \Generator
+    {
+        yield 'float-left' => ['float-left', true];
+        yield 'float-right' => ['float-right', true];
+        yield 'float-left with other classes' => ['with-shadow float-left', true];
+        yield 'float-right with other classes' => ['float-right with-border', true];
+        yield 'both legacy classes' => ['float-left float-right', true];
+        yield 'modern float-start' => ['float-start', false];
+        yield 'modern float-end' => ['float-end', false];
+        yield 'no float classes' => ['with-shadow with-border', false];
+        yield 'empty string' => ['', false];
+        yield 'partial match float-leftover' => ['float-leftover', false];
+        yield 'partial match afloat-right' => ['afloat-right', false];
+    }
+
+    #[Test]
+    #[DataProvider('legacyFloatClassRewriteProvider')]
+    public function rewriteLegacyFloatClassesRewritesCorrectly(string $classValue, string $expected): void
+    {
+        self::assertSame($expected, $this->subject->callRewriteLegacyFloatClasses($classValue));
+    }
+
+    /** @return \Generator<string, array{string, string}> */
+    public static function legacyFloatClassRewriteProvider(): \Generator
+    {
+        yield 'float-left to float-start' => ['float-left', 'float-start'];
+        yield 'float-right to float-end' => ['float-right', 'float-end'];
+        yield 'preserves other classes' => ['with-shadow float-left', 'with-shadow float-start'];
+        yield 'rewrites both' => ['float-left float-right', 'float-start float-end'];
+        yield 'modern classes unchanged' => ['float-start', 'float-start'];
+        yield 'no float classes unchanged' => ['with-shadow', 'with-shadow'];
+        yield 'empty string unchanged' => ['', ''];
+    }
+}

--- a/tests/Integration/tests/images/Float/expected/index.html
+++ b/tests/Integration/tests/images/Float/expected/index.html
@@ -1,123 +1,386 @@
+<!DOCTYPE html>
+<html class="no-js" lang="en">
+<head>
+    <title>Float Tests
+        documentation</title>
+
+    
+<meta charset="utf-8">
+<meta content="width=device-width, initial-scale=1.0" name="viewport">
+<meta content="phpdocumentor/guides" name="generator">
+<meta content="" name="docsearch:name">
+<meta content="" name="docsearch:package_type">
+<meta content="" name="docsearch:release">
+<meta content="" name="docsearch:version">
+<meta content="2023-01-01T12:00:00+00:00" name="docsearch:modified">
+<meta content="2023-01-01T12:00:00+00:00" name="dc.modified">
+<meta content="2023-01-01T12:00:00+00:00" property="article:modified_time">
+    <link href="http://purl.org/dc/elements/1.1/" rel="schema.dc">
+<link href="_resources/css/theme.css" rel="stylesheet">
+<link href="https://docs.typo3.org/search/" rel="search" title="Search">
+<script src="https://cdn.typo3.com/typo3infrastructure/universe/dist/webcomponents-loader.js"></script>
+<script src="https://cdn.typo3.com/typo3infrastructure/universe/dist/typo3-universe.js" type="module"></script>
+                        <link href="#" rel="top" title="Float Tests"/>
+    </head>
+<body>
+<div class="page">
+    <header>
+    <div class="page-topbar">
+        <div class="page-topbar-inner">
+            <typo3-universe active="documentation">
+                <div style="display: block; height: 44px; background-color: #313131;"></div>
+            </typo3-universe>
+        </div>
+    </div>
+    <div class="page-header">
+        <div class="page-header-inner">
+            <div class="d-flex flex-wrap">
+                <div class="logo-wrapper">
+                    <a class="logo" href="https://docs.typo3.org/" title="TYPO3 Documentation">
+                        <img alt="TYPO3 Logo" class="logo-image" src="_resources/img/typo3-logo.svg" width="484" height="130">
+                    </a>
+                </div>
+                <div class="align-self-center order-lg-2 order-last">
+                    
+<div class="toc-header">
+    <div class="toc-title pe-3">
+                            <a class="toc-title-project" href="#">Float Tests</a>
+            </div>
+    </div>                </div>
+                <div class="ms-auto order-lg-3 d-flex">
+                    <div class="menu-search-wrapper">
+                        <button id="toc-toggle" class="btn btn-light d-block d-lg-none" tabindex="0" aria-controls="toc-collapse" aria-expanded="false">
+                            <i class="fas fa-bars"></i> <span class="visually-hidden">Mobile Menu</span>
+                        </button>
+                        <all-documentations-menu data-override-url="_resources/js/menu-proxy.php"></all-documentations-menu>
+                                                <search role="search">
+                            <form action="https://docs.typo3.org/search/search" id="global-search-form" method="get">
+                                <div class="sr-only"><label for="globalsearchinput">TYPO3 documentation...</label></div>
+                                <div class="input-group mb-3 mt-sm-3">
+                                    <select class="form-select search__scope" id="searchscope" name="scope">
+                                        <option value="">Search all</option>
+                                    </select>
+                                    <input autocomplete="off" class="form-control shadow-none" id="globalsearchinput" name="q" placeholder="TYPO3 documentation..." type="text" value="">
+                                    <button class="btn btn-light" type="submit"><i class="fa fa-search"></i>&nbsp;<span class="d-none d-md-inline">Search</span></button>
+                                </div>
+                            </form>
+                            <div id="global-search-root"></div>
+                        </search>
+                        <div class="position-relative d-inline-block">
+                            <button id="options-toggle" class="btn btn-light d-block" type="button" aria-expanded="false">
+                                <i class="fas fa-cog"></i> <span class="visually-hidden">Options</span>
+                            </button>
+
+                            <div id="options-panel"
+                                 class="shadow p-3"
+                                 role="menu"
+                                 aria-hidden="true">
+                                <h6 class="dropdown-header text-muted text-uppercase small mb-2">Options</h6>
+
+                                                                                                            <a class="dropdown-item d-flex align-items-center gap-2" href="_sources/index.rst.txt" rel="nofollow noopener" target="_blank">
+        <i class="fas fa-code"></i>
+        View source
+    </a>
+    <a class="dropdown-item d-flex align-items-center gap-2" href="https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/WritingDocsOfficial/GithubMethod.html" id="btnHowToEdit" rel="nofollow noopener" target="_blank">
+        <i class="fas fa-info-circle"></i>
+        How to edit
+    </a>
+                                                                                                                <a class="dropdown-item d-flex align-items-center gap-2" href="singlehtml/Index.html" target="_blank" rel="noopener">
+                                            <i class="fas fa-print"></i>
+                                            Full documentation (single file)
+                                        </a>
+                                                                                                </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</header>    <main class="page-main">
+        <div class="page-main-inner">
+            <div class="page-main-navigation">
+                <nav>
+
+                    <div id="toc-collapse">
+                                                <div aria-label="main navigation" class="toc"
+                             role="navigation">
+                                <all-documentations-menu-mobile
+        data-override-url="_resources/js/menu-proxy.php"></all-documentations-menu-mobile>
+    <div aria-label="Main navigation" class="main_menu" role="navigation">
+                <p class="caption">Float Tests</p>
+        
+    </div>
+                        </div>
+                    </div>
+                </nav>
+            </div>
+            <div class="page-main-content">
+                <div class="rst-content">                        <nav aria-label="breadcrumbs navigation" class="breadcrumb-bar" role="navigation">
+        
+<ol class="breadcrumb">
+                <li aria-current="page"  class="breadcrumb-item  active">Float Tests</li>
+        </ol>
+        <div class="breadcrumb-additions"></div>
+    </nav>
+                    
+<article class="document" itemscope="itemscope" itemtype="http://schema.org/Article" role="main">
+    <div itemprop="articleBody">
         <!-- content start -->
-                <section class="section" id="document-title">
-            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">&nbsp;<i class="fa-solid fa-link"></i></a></h1>
-            
-    <p>Lorem Ipsum Dolor.</p>
-
-            <section class="section" id="figure-align-left">
-            <h2>Figure align left<a class="headerlink" href="#figure-align-left" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">&nbsp;<i class="fa-solid fa-link"></i></a></h2>
-            <figure class="float-left">
+                <section class="section" id="float-tests">
+            <h1>Float Tests<a class="headerlink" href="#float-tests" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">&nbsp;<i class="fa-solid fa-link"></i></a></h1>
+            <section class="section" id="align-left">
+            <h2>Align Left<a class="headerlink" href="#align-left" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">&nbsp;<i class="fa-solid fa-link"></i></a></h2>
+            <figure class="float-start">
     <img
     src="typo3-logo.png"
-            alt="Left aligned figure"        />
+            alt="Left figure"        />
 
             
                     <figcaption>
-    <p>Caption for left-aligned figure</p>
+    <p>Left aligned figure</p>
 </figcaption>
             </figure>
     </section>
-            <section class="section" id="figure-align-right">
-            <h2>Figure align right<a class="headerlink" href="#figure-align-right" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">&nbsp;<i class="fa-solid fa-link"></i></a></h2>
-            <figure class="float-right">
+            <section class="section" id="align-right">
+            <h2>Align Right<a class="headerlink" href="#align-right" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">&nbsp;<i class="fa-solid fa-link"></i></a></h2>
+            <figure class="float-end">
     <img
     src="typo3-logo.png"
-            alt="Right aligned figure"        />
+            alt="Right figure"        />
 
             
                     <figcaption>
-    <p>Caption for right-aligned figure</p>
+    <p>Right aligned figure</p>
 </figcaption>
             </figure>
     </section>
-            <section class="section" id="figure-align-center">
-            <h2>Figure align center<a class="headerlink" href="#figure-align-center" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">&nbsp;<i class="fa-solid fa-link"></i></a></h2>
+            <section class="section" id="align-center">
+            <h2>Align Center<a class="headerlink" href="#align-center" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">&nbsp;<i class="fa-solid fa-link"></i></a></h2>
             <figure class="align-center">
     <img
     src="typo3-logo.png"
-            alt="Center aligned figure"        />
+            alt="Center figure"        />
 
             
                     <figcaption>
-    <p>Caption for center-aligned figure</p>
+    <p>Center aligned figure</p>
+</figcaption>
+            </figure>
+    </section>
+            <section class="section" id="legacy-figure-class">
+            <h2>Legacy Figure Class<a class="headerlink" href="#legacy-figure-class" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">&nbsp;<i class="fa-solid fa-link"></i></a></h2>
+            <figure class="float-start">
+    <img
+    src="typo3-logo.png"
+            alt="Legacy float-left figure"        />
+
+            
+                    <figcaption>
+    <p>Should rewrite to float-start</p>
+</figcaption>
+            </figure>
+    </section>
+            <section class="section" id="legacy-figure-right">
+            <h2>Legacy Figure Right<a class="headerlink" href="#legacy-figure-right" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">&nbsp;<i class="fa-solid fa-link"></i></a></h2>
+            <figure class="float-end">
+    <img
+    src="typo3-logo.png"
+            alt="Legacy float-right figure"        />
+
+            
+                    <figcaption>
+    <p>Should rewrite to float-end</p>
+</figcaption>
+            </figure>
+    </section>
+            <section class="section" id="legacy-image-left">
+            <h2>Legacy Image Left<a class="headerlink" href="#legacy-image-left" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">&nbsp;<i class="fa-solid fa-link"></i></a></h2>
+            <img
+    src="typo3-logo.png"
+            alt="Legacy float-left image"        class="float-start"/>
+    </section>
+            <section class="section" id="legacy-image-right">
+            <h2>Legacy Image Right<a class="headerlink" href="#legacy-image-right" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">&nbsp;<i class="fa-solid fa-link"></i></a></h2>
+            <img
+    src="typo3-logo.png"
+            alt="Legacy float-right image"        class="float-end"/>
+    </section>
+            <section class="section" id="mixed-legacy-with-extra-class">
+            <h2>Mixed Legacy With Extra Class<a class="headerlink" href="#mixed-legacy-with-extra-class" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">&nbsp;<i class="fa-solid fa-link"></i></a></h2>
+            <figure class="float-start with-shadow">
+    <img
+    src="typo3-logo.png"
+            alt="Mixed class figure"        />
+
+            
+                    <figcaption>
+    <p>Should rewrite float-left but keep with-shadow</p>
+</figcaption>
+            </figure>
+    </section>
+            <section class="section" id="align-plus-legacy-class">
+            <h2>Align Plus Legacy Class<a class="headerlink" href="#align-plus-legacy-class" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">&nbsp;<i class="fa-solid fa-link"></i></a></h2>
+            <figure class="float-start">
+    <img
+    src="typo3-logo.png"
+            alt="Both align and legacy class"        />
+
+            
+                    <figcaption>
+    <p>Should use align, class gets rewritten to float-start</p>
 </figcaption>
             </figure>
     </section>
             <section class="section" id="image-align-left">
-            <h2>Image align left<a class="headerlink" href="#image-align-left" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">&nbsp;<i class="fa-solid fa-link"></i></a></h2>
+            <h2>Image Align Left<a class="headerlink" href="#image-align-left" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">&nbsp;<i class="fa-solid fa-link"></i></a></h2>
             <img
     src="typo3-logo.png"
-            alt="Left aligned image"        class="float-left"/>
+            alt="Image align left"        class="float-start"/>
     </section>
             <section class="section" id="image-align-right">
-            <h2>Image align right<a class="headerlink" href="#image-align-right" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">&nbsp;<i class="fa-solid fa-link"></i></a></h2>
+            <h2>Image Align Right<a class="headerlink" href="#image-align-right" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">&nbsp;<i class="fa-solid fa-link"></i></a></h2>
             <img
     src="typo3-logo.png"
-            alt="Right aligned image"        class="float-right"/>
+            alt="Image align right"        class="float-end"/>
     </section>
-            <section class="section" id="image-align-center">
-            <h2>Image align center<a class="headerlink" href="#image-align-center" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">&nbsp;<i class="fa-solid fa-link"></i></a></h2>
+            <section class="section" id="modern-float-start-no-warning">
+            <h2>Modern Float Start (No Warning)<a class="headerlink" href="#modern-float-start-no-warning" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">&nbsp;<i class="fa-solid fa-link"></i></a></h2>
+            <figure class="float-start">
+    <img
+    src="typo3-logo.png"
+            alt="Modern float-start figure"        />
+
+            
+                    <figcaption>
+    <p>Already uses modern class, no rewriting needed</p>
+</figcaption>
+            </figure>
+    </section>
+            <section class="section" id="modern-float-end-image-no-warning">
+            <h2>Modern Float End Image (No Warning)<a class="headerlink" href="#modern-float-end-image-no-warning" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">&nbsp;<i class="fa-solid fa-link"></i></a></h2>
             <img
     src="typo3-logo.png"
-            alt="Center aligned image"        class="align-center"/>
+            alt="Modern float-end image"        class="float-end"/>
     </section>
-            <section class="section" id="figure-with-float-class">
-            <h2>Figure with float class<a class="headerlink" href="#figure-with-float-class" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">&nbsp;<i class="fa-solid fa-link"></i></a></h2>
-            <figure class="float-left">
-    <img
-    src="typo3-logo.png"
-            alt="Figure with float-left class"        />
-
+            <section class="section" id="substitution-image-left">
+            <h2>Substitution Image Left<a class="headerlink" href="#substitution-image-left" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">&nbsp;<i class="fa-solid fa-link"></i></a></h2>
             
-                    <figcaption>
-    <p>Float class on figure</p>
-</figcaption>
-            </figure>
-    </section>
-            <section class="section" id="figure-with-float-right-class">
-            <h2>Figure with float-right class<a class="headerlink" href="#figure-with-float-right-class" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">&nbsp;<i class="fa-solid fa-link"></i></a></h2>
-            <figure class="float-right">
-    <img
+    <p>Use the <img
     src="typo3-logo.png"
-            alt="Figure with float-right class"        />
+            alt="Substitution logo"        class="float-start"/> inline text here.</p>
 
-            
-                    <figcaption>
-    <p>Float-right class on figure</p>
-</figcaption>
-            </figure>
-    </section>
-            <section class="section" id="figure-with-float-class-and-extra-classes">
-            <h2>Figure with float class and extra classes<a class="headerlink" href="#figure-with-float-class-and-extra-classes" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">&nbsp;<i class="fa-solid fa-link"></i></a></h2>
-            <figure class="float-left with-shadow">
-    <img
-    src="typo3-logo.png"
-            alt="Figure with float and shadow"        />
-
-            
-                    <figcaption>
-    <p>Float class combined with other classes</p>
-</figcaption>
-            </figure>
-    </section>
-            <section class="section" id="image-with-float-class">
-            <h2>Image with float class<a class="headerlink" href="#image-with-float-class" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">&nbsp;<i class="fa-solid fa-link"></i></a></h2>
-            <img
-    src="typo3-logo.png"
-            alt="Image with float-right class"        class="float-right"/>
-    </section>
-            <section class="section" id="figure-with-align-and-extra-class">
-            <h2>Figure with align and extra class<a class="headerlink" href="#figure-with-align-and-extra-class" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">&nbsp;<i class="fa-solid fa-link"></i></a></h2>
-            <figure class="with-border float-left">
-    <img
-    src="typo3-logo.png"
-            alt="Figure with align and border"        />
-
-            
-                    <figcaption>
-    <p>Align option combined with extra class</p>
-</figcaption>
-            </figure>
     </section>
     </section>
         <!-- content end -->
+    </div>
+</article>
+                        
+                    </div>
+            </div>
+        </div>
+    </main>
+
+    <div class="modal fade" id="linkReferenceModal" tabindex="-1" aria-labelledby="linkReferenceModalLabel"
+    aria-hidden="true" data-current-filename="index">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="linkReferenceModalLabel">Reference to the headline</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <div class="alert alert-success d-none" id="permalink-alert-success" role="alert"></div>
+                <div class="mb-3">
+                    <div class="permalink-short-wrapper">
+                        <label for="permalink-short" class="col-form-label">Permalink (Shortlink)</label>
+                        <div class="input-group">
+                            <input class="form-control code" id="permalink-short" readonly>
+                            <button type="button" class="btn btn-outline-secondary copy-button" data-target="permalink-short"><i class="far fa-clone"></i></button>
+                        </div>
+                        <p><em>Copy and freely share the link</em></p>
+                    </div>
+                    <label for="permalink-uri" class="col-form-label">URL</label>
+                    <div class="input-group">
+                        <input class="form-control code" id="permalink-uri" readonly>
+                        <button type="button" class="btn btn-outline-secondary copy-button" data-target="permalink-uri"><i class="far fa-clone"></i></button>
+                    </div>
+                </div>
+                <div class="mb-3">
+                    <div class="alert alert-warning alert-permalink-rst" role="alert">This link target has no permanent anchor assigned.The link below can be used, but is prone to change if the page gets moved.
+                    </div>
+                    <label for="permalink-rst" class="col-form-label">Link in reStructuredText (reST)</label>
+                    <div class="input-group">
+                        <textarea class="form-control code" id="permalink-rst" readonly></textarea>
+                        <button type="button" class="btn btn-outline-secondary copy-button" data-target="permalink-rst"><i class="far fa-clone"></i></button>
+                    </div>
+                    <p><em>Copy this link into your TYPO3 manual.</em></p>
+                </div>
+                <div class="mb-3">
+                    <label for="permalink-md" class="col-form-label">Link in Markdown</label>
+                    <div class="input-group">
+                        <textarea class="form-control code" id="permalink-md" readonly></textarea>
+                        <button type="button" class="btn btn-outline-secondary copy-button" data-target="permalink-md"><i class="far fa-clone"></i></button>
+                    </div>
+                </div>
+                <div class="mb-3">
+                    <label for="permalink-html" class="col-form-label">Link in HTML</label>
+                                        <div class="input-group">
+                        <textarea class="form-control code" id="permalink-html" readonly></textarea>
+                        <button type="button" class="btn btn-outline-secondary copy-button" data-target="permalink-html"><i class="far fa-clone"></i></button>
+                    </div>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+            </div>
+        </div>
+    </div>
+</div>    <div class="modal fade" id="generalModal" tabindex="-1" aria-labelledby="linkReferenceModalLabel"
+    aria-hidden="true" data-current-filename="index"
+>
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="generalModalLabel"></h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <div class="alert alert-success d-none" id="general-alert-success" role="alert"></div>
+                <div id="generalModalContent">
+                </div>
+            </div>
+            <div class="modal-footer justify-content-between">
+                <div id="generalModalCustomButtons"></div>
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal"><i class="fa-regular fa-circle-xmark"></i>&nbsp;Close</button>
+            </div>
+        </div>
+    </div>
+</div></div>
+
+
+<footer class="page-footer">
+    <div class="frame frame-ruler-before frame-background-dark">
+        <div class="frame-container">
+            <div class="frame-inner">
+                                <div class="footer-additional">
+                    <p class="text-center">Last rendered: Jan 01, 2023 12:00</p>
+                </div>
+                <div class="footer-meta">
+                    <ul class="footer-meta-navigation">
+                        <li><a href="https://typo3.org/legal-notice" rel="nofollow" target="_blank" title="Legal Notice">Legal Notice</a></li>
+                        <li><a href="https://typo3.org/privacy-policy" rel="nofollow" target="_blank" title="Privacy Policy">Privacy Policy</a></li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </div>
+</footer>
+<script src="_resources/js/popper.min.js"></script>
+<script src="_resources/js/bootstrap.min.js"></script>
+<script src="_resources/js/theme.min.js"></script>
+
+<!--
+ Locally rendered. No tracking embedded.
+-->
+</body>
+</html>

--- a/tests/Integration/tests/images/Float/expected/index.html
+++ b/tests/Integration/tests/images/Float/expected/index.html
@@ -1,123 +1,386 @@
-<!-- content start -->
-                <section class="section" id="document-title">
-            <h1>Document Title<a class="headerlink" href="#document-title" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">&nbsp;<i class="fa-solid fa-link"></i></a></h1>
+<!DOCTYPE html>
+<html class="no-js" lang="en">
+<head>
+    <title>Float Tests
+        documentation</title>
 
-    <p>Lorem Ipsum Dolor.</p>
+    
+<meta charset="utf-8">
+<meta content="width=device-width, initial-scale=1.0" name="viewport">
+<meta content="phpdocumentor/guides" name="generator">
+<meta content="" name="docsearch:name">
+<meta content="" name="docsearch:package_type">
+<meta content="" name="docsearch:release">
+<meta content="" name="docsearch:version">
+<meta content="2023-01-01T12:00:00+00:00" name="docsearch:modified">
+<meta content="2023-01-01T12:00:00+00:00" name="dc.modified">
+<meta content="2023-01-01T12:00:00+00:00" property="article:modified_time">
+    <link href="http://purl.org/dc/elements/1.1/" rel="schema.dc">
+<link href="_resources/css/theme.css" rel="stylesheet">
+<link href="https://docs.typo3.org/search/" rel="search" title="Search">
+<script src="https://cdn.typo3.com/typo3infrastructure/universe/dist/webcomponents-loader.js"></script>
+<script src="https://cdn.typo3.com/typo3infrastructure/universe/dist/typo3-universe.js" type="module"></script>
+                        <link href="#" rel="top" title="Float Tests"/>
+    </head>
+<body>
+<div class="page">
+    <header>
+    <div class="page-topbar">
+        <div class="page-topbar-inner">
+            <typo3-universe active="documentation">
+                <div style="display: block; height: 44px; background-color: #313131;"></div>
+            </typo3-universe>
+        </div>
+    </div>
+    <div class="page-header">
+        <div class="page-header-inner">
+            <div class="d-flex flex-wrap">
+                <div class="logo-wrapper">
+                    <a class="logo" href="https://docs.typo3.org/" title="TYPO3 Documentation">
+                        <img alt="TYPO3 Logo" class="logo-image" src="_resources/img/typo3-logo.svg" width="484" height="130">
+                    </a>
+                </div>
+                <div class="align-self-center order-lg-2 order-last">
+                    
+<div class="toc-header">
+    <div class="toc-title pe-3">
+                            <a class="toc-title-project" href="#">Float Tests</a>
+            </div>
+    </div>                </div>
+                <div class="ms-auto order-lg-3 d-flex">
+                    <div class="menu-search-wrapper">
+                        <button id="toc-toggle" class="btn btn-light d-block d-lg-none" tabindex="0" aria-controls="toc-collapse" aria-expanded="false">
+                            <i class="fas fa-bars"></i> <span class="visually-hidden">Mobile Menu</span>
+                        </button>
+                        <all-documentations-menu data-override-url="_resources/js/menu-proxy.php"></all-documentations-menu>
+                                                <search role="search">
+                            <form action="https://docs.typo3.org/search/search" id="global-search-form" method="get">
+                                <div class="sr-only"><label for="globalsearchinput">TYPO3 documentation...</label></div>
+                                <div class="input-group mb-3 mt-sm-3">
+                                    <select class="form-select search__scope" id="searchscope" name="scope">
+                                        <option value="">Search all</option>
+                                    </select>
+                                    <input autocomplete="off" class="form-control shadow-none" id="globalsearchinput" name="q" placeholder="TYPO3 documentation..." type="text" value="">
+                                    <button class="btn btn-light" type="submit"><i class="fa fa-search"></i>&nbsp;<span class="d-none d-md-inline">Search</span></button>
+                                </div>
+                            </form>
+                            <div id="global-search-root"></div>
+                        </search>
+                        <div class="position-relative d-inline-block">
+                            <button id="options-toggle" class="btn btn-light d-block" type="button" aria-expanded="false">
+                                <i class="fas fa-cog"></i> <span class="visually-hidden">Options</span>
+                            </button>
 
-            <section class="section" id="figure-align-left">
-            <h2>Figure align left<a class="headerlink" href="#figure-align-left" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">&nbsp;<i class="fa-solid fa-link"></i></a></h2>
-            <figure class="float-left">
+                            <div id="options-panel"
+                                 class="shadow p-3"
+                                 role="menu"
+                                 aria-hidden="true">
+                                <h6 class="dropdown-header text-muted text-uppercase small mb-2">Options</h6>
+
+                                                                                                            <a class="dropdown-item d-flex align-items-center gap-2" href="_sources/index.rst.txt" rel="nofollow noopener" target="_blank">
+        <i class="fas fa-code"></i>
+        View source
+    </a>
+    <a class="dropdown-item d-flex align-items-center gap-2" href="https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/WritingDocsOfficial/GithubMethod.html" id="btnHowToEdit" rel="nofollow noopener" target="_blank">
+        <i class="fas fa-info-circle"></i>
+        How to edit
+    </a>
+                                                                                                                <a class="dropdown-item d-flex align-items-center gap-2" href="singlehtml/Index.html" target="_blank" rel="noopener">
+                                            <i class="fas fa-print"></i>
+                                            Full documentation (single file)
+                                        </a>
+                                                                                                </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</header>    <main class="page-main">
+        <div class="page-main-inner">
+            <div class="page-main-navigation">
+                <nav>
+
+                    <div id="toc-collapse">
+                                                <div aria-label="main navigation" class="toc"
+                             role="navigation">
+                                <all-documentations-menu-mobile
+        data-override-url="_resources/js/menu-proxy.php"></all-documentations-menu-mobile>
+    <div aria-label="Main navigation" class="main_menu" role="navigation">
+                <p class="caption">Float Tests</p>
+        
+    </div>
+                        </div>
+                    </div>
+                </nav>
+            </div>
+            <div class="page-main-content">
+                <div class="rst-content">                        <nav aria-label="breadcrumbs navigation" class="breadcrumb-bar" role="navigation">
+        
+<ol class="breadcrumb">
+                <li aria-current="page"  class="breadcrumb-item  active">Float Tests</li>
+        </ol>
+        <div class="breadcrumb-additions"></div>
+    </nav>
+                    
+<article class="document" itemscope="itemscope" itemtype="http://schema.org/Article" role="main">
+    <div itemprop="articleBody">
+        <!-- content start -->
+                <section class="section" id="float-tests">
+            <h1>Float Tests<a class="headerlink" href="#float-tests" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">&nbsp;<i class="fa-solid fa-link"></i></a></h1>
+            <section class="section" id="align-left">
+            <h2>Align Left<a class="headerlink" href="#align-left" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">&nbsp;<i class="fa-solid fa-link"></i></a></h2>
+            <figure class="float-start">
     <img
     src="typo3-logo.png"
-            alt="Left aligned figure"        />
+            alt="Left figure"        />
 
-
+            
                     <figcaption>
-    <p>Caption for left-aligned figure</p>
+    <p>Left aligned figure</p>
 </figcaption>
             </figure>
     </section>
-            <section class="section" id="figure-align-right">
-            <h2>Figure align right<a class="headerlink" href="#figure-align-right" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">&nbsp;<i class="fa-solid fa-link"></i></a></h2>
-            <figure class="float-right">
+            <section class="section" id="align-right">
+            <h2>Align Right<a class="headerlink" href="#align-right" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">&nbsp;<i class="fa-solid fa-link"></i></a></h2>
+            <figure class="float-end">
     <img
     src="typo3-logo.png"
-            alt="Right aligned figure"        />
+            alt="Right figure"        />
 
-
+            
                     <figcaption>
-    <p>Caption for right-aligned figure</p>
+    <p>Right aligned figure</p>
 </figcaption>
             </figure>
     </section>
-            <section class="section" id="figure-align-center">
-            <h2>Figure align center<a class="headerlink" href="#figure-align-center" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">&nbsp;<i class="fa-solid fa-link"></i></a></h2>
+            <section class="section" id="align-center">
+            <h2>Align Center<a class="headerlink" href="#align-center" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">&nbsp;<i class="fa-solid fa-link"></i></a></h2>
             <figure class="align-center">
     <img
     src="typo3-logo.png"
-            alt="Center aligned figure"        />
+            alt="Center figure"        />
 
-
+            
                     <figcaption>
-    <p>Caption for center-aligned figure</p>
+    <p>Center aligned figure</p>
+</figcaption>
+            </figure>
+    </section>
+            <section class="section" id="legacy-figure-class">
+            <h2>Legacy Figure Class<a class="headerlink" href="#legacy-figure-class" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">&nbsp;<i class="fa-solid fa-link"></i></a></h2>
+            <figure class="float-start">
+    <img
+    src="typo3-logo.png"
+            alt="Legacy float-left figure"        />
+
+            
+                    <figcaption>
+    <p>Should rewrite to float-start</p>
+</figcaption>
+            </figure>
+    </section>
+            <section class="section" id="legacy-figure-right">
+            <h2>Legacy Figure Right<a class="headerlink" href="#legacy-figure-right" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">&nbsp;<i class="fa-solid fa-link"></i></a></h2>
+            <figure class="float-end">
+    <img
+    src="typo3-logo.png"
+            alt="Legacy float-right figure"        />
+
+            
+                    <figcaption>
+    <p>Should rewrite to float-end</p>
+</figcaption>
+            </figure>
+    </section>
+            <section class="section" id="legacy-image-left">
+            <h2>Legacy Image Left<a class="headerlink" href="#legacy-image-left" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">&nbsp;<i class="fa-solid fa-link"></i></a></h2>
+            <img
+    src="typo3-logo.png"
+            alt="Legacy float-left image"        class="float-start"/>
+    </section>
+            <section class="section" id="legacy-image-right">
+            <h2>Legacy Image Right<a class="headerlink" href="#legacy-image-right" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">&nbsp;<i class="fa-solid fa-link"></i></a></h2>
+            <img
+    src="typo3-logo.png"
+            alt="Legacy float-right image"        class="float-end"/>
+    </section>
+            <section class="section" id="mixed-legacy-with-extra-class">
+            <h2>Mixed Legacy With Extra Class<a class="headerlink" href="#mixed-legacy-with-extra-class" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">&nbsp;<i class="fa-solid fa-link"></i></a></h2>
+            <figure class="float-start with-shadow">
+    <img
+    src="typo3-logo.png"
+            alt="Mixed class figure"        />
+
+            
+                    <figcaption>
+    <p>Should rewrite float-left but keep with-shadow</p>
+</figcaption>
+            </figure>
+    </section>
+            <section class="section" id="align-plus-legacy-class">
+            <h2>Align Plus Legacy Class<a class="headerlink" href="#align-plus-legacy-class" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">&nbsp;<i class="fa-solid fa-link"></i></a></h2>
+            <figure class="float-start">
+    <img
+    src="typo3-logo.png"
+            alt="Both align and legacy class"        />
+
+            
+                    <figcaption>
+    <p>Should use align, class gets rewritten to float-start</p>
 </figcaption>
             </figure>
     </section>
             <section class="section" id="image-align-left">
-            <h2>Image align left<a class="headerlink" href="#image-align-left" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">&nbsp;<i class="fa-solid fa-link"></i></a></h2>
+            <h2>Image Align Left<a class="headerlink" href="#image-align-left" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">&nbsp;<i class="fa-solid fa-link"></i></a></h2>
             <img
     src="typo3-logo.png"
-            alt="Left aligned image"        class="float-left"/>
+            alt="Image align left"        class="float-start"/>
     </section>
             <section class="section" id="image-align-right">
-            <h2>Image align right<a class="headerlink" href="#image-align-right" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">&nbsp;<i class="fa-solid fa-link"></i></a></h2>
+            <h2>Image Align Right<a class="headerlink" href="#image-align-right" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">&nbsp;<i class="fa-solid fa-link"></i></a></h2>
             <img
     src="typo3-logo.png"
-            alt="Right aligned image"        class="float-right"/>
+            alt="Image align right"        class="float-end"/>
     </section>
-            <section class="section" id="image-align-center">
-            <h2>Image align center<a class="headerlink" href="#image-align-center" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">&nbsp;<i class="fa-solid fa-link"></i></a></h2>
+            <section class="section" id="modern-float-start-no-warning">
+            <h2>Modern Float Start (No Warning)<a class="headerlink" href="#modern-float-start-no-warning" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">&nbsp;<i class="fa-solid fa-link"></i></a></h2>
+            <figure class="float-start">
+    <img
+    src="typo3-logo.png"
+            alt="Modern float-start figure"        />
+
+            
+                    <figcaption>
+    <p>Already uses modern class, no rewriting needed</p>
+</figcaption>
+            </figure>
+    </section>
+            <section class="section" id="modern-float-end-image-no-warning">
+            <h2>Modern Float End Image (No Warning)<a class="headerlink" href="#modern-float-end-image-no-warning" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">&nbsp;<i class="fa-solid fa-link"></i></a></h2>
             <img
     src="typo3-logo.png"
-            alt="Center aligned image"        class="align-center"/>
+            alt="Modern float-end image"        class="float-end"/>
     </section>
-            <section class="section" id="figure-with-float-class">
-            <h2>Figure with float class<a class="headerlink" href="#figure-with-float-class" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">&nbsp;<i class="fa-solid fa-link"></i></a></h2>
-            <figure class="float-left">
-    <img
+            <section class="section" id="substitution-image-left">
+            <h2>Substitution Image Left<a class="headerlink" href="#substitution-image-left" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">&nbsp;<i class="fa-solid fa-link"></i></a></h2>
+            
+    <p>Use the <img
     src="typo3-logo.png"
-            alt="Figure with float-left class"        />
+            alt="Substitution logo"        class="float-start"/> inline text here.</p>
 
-
-                    <figcaption>
-    <p>Float class on figure</p>
-</figcaption>
-            </figure>
-    </section>
-            <section class="section" id="figure-with-float-right-class">
-            <h2>Figure with float-right class<a class="headerlink" href="#figure-with-float-right-class" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">&nbsp;<i class="fa-solid fa-link"></i></a></h2>
-            <figure class="float-right">
-    <img
-    src="typo3-logo.png"
-            alt="Figure with float-right class"        />
-
-
-                    <figcaption>
-    <p>Float-right class on figure</p>
-</figcaption>
-            </figure>
-    </section>
-            <section class="section" id="figure-with-float-class-and-extra-classes">
-            <h2>Figure with float class and extra classes<a class="headerlink" href="#figure-with-float-class-and-extra-classes" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">&nbsp;<i class="fa-solid fa-link"></i></a></h2>
-            <figure class="float-left with-shadow">
-    <img
-    src="typo3-logo.png"
-            alt="Figure with float and shadow"        />
-
-
-                    <figcaption>
-    <p>Float class combined with other classes</p>
-</figcaption>
-            </figure>
-    </section>
-            <section class="section" id="image-with-float-class">
-            <h2>Image with float class<a class="headerlink" href="#image-with-float-class" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">&nbsp;<i class="fa-solid fa-link"></i></a></h2>
-            <img
-    src="typo3-logo.png"
-            alt="Image with float-right class"        class="float-right"/>
-    </section>
-            <section class="section" id="figure-with-align-and-extra-class">
-            <h2>Figure with align and extra class<a class="headerlink" href="#figure-with-align-and-extra-class" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">&nbsp;<i class="fa-solid fa-link"></i></a></h2>
-            <figure class="with-border float-left">
-    <img
-    src="typo3-logo.png"
-            alt="Figure with align and border"        />
-
-
-                    <figcaption>
-    <p>Align option combined with extra class</p>
-</figcaption>
-            </figure>
     </section>
     </section>
         <!-- content end -->
+    </div>
+</article>
+                        
+                    </div>
+            </div>
+        </div>
+    </main>
+
+    <div class="modal fade" id="linkReferenceModal" tabindex="-1" aria-labelledby="linkReferenceModalLabel"
+    aria-hidden="true" data-current-filename="index">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="linkReferenceModalLabel">Reference to the headline</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <div class="alert alert-success d-none" id="permalink-alert-success" role="alert"></div>
+                <div class="mb-3">
+                    <div class="permalink-short-wrapper">
+                        <label for="permalink-short" class="col-form-label">Permalink (Shortlink)</label>
+                        <div class="input-group">
+                            <input class="form-control code" id="permalink-short" readonly>
+                            <button type="button" class="btn btn-outline-secondary copy-button" data-target="permalink-short"><i class="far fa-clone"></i></button>
+                        </div>
+                        <p><em>Copy and freely share the link</em></p>
+                    </div>
+                    <label for="permalink-uri" class="col-form-label">URL</label>
+                    <div class="input-group">
+                        <input class="form-control code" id="permalink-uri" readonly>
+                        <button type="button" class="btn btn-outline-secondary copy-button" data-target="permalink-uri"><i class="far fa-clone"></i></button>
+                    </div>
+                </div>
+                <div class="mb-3">
+                    <div class="alert alert-warning alert-permalink-rst" role="alert">This link target has no permanent anchor assigned.The link below can be used, but is prone to change if the page gets moved.
+                    </div>
+                    <label for="permalink-rst" class="col-form-label">Link in reStructuredText (reST)</label>
+                    <div class="input-group">
+                        <textarea class="form-control code" id="permalink-rst" readonly></textarea>
+                        <button type="button" class="btn btn-outline-secondary copy-button" data-target="permalink-rst"><i class="far fa-clone"></i></button>
+                    </div>
+                    <p><em>Copy this link into your TYPO3 manual.</em></p>
+                </div>
+                <div class="mb-3">
+                    <label for="permalink-md" class="col-form-label">Link in Markdown</label>
+                    <div class="input-group">
+                        <textarea class="form-control code" id="permalink-md" readonly></textarea>
+                        <button type="button" class="btn btn-outline-secondary copy-button" data-target="permalink-md"><i class="far fa-clone"></i></button>
+                    </div>
+                </div>
+                <div class="mb-3">
+                    <label for="permalink-html" class="col-form-label">Link in HTML</label>
+                                        <div class="input-group">
+                        <textarea class="form-control code" id="permalink-html" readonly></textarea>
+                        <button type="button" class="btn btn-outline-secondary copy-button" data-target="permalink-html"><i class="far fa-clone"></i></button>
+                    </div>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+            </div>
+        </div>
+    </div>
+</div>    <div class="modal fade" id="generalModal" tabindex="-1" aria-labelledby="linkReferenceModalLabel"
+    aria-hidden="true" data-current-filename="index"
+>
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="generalModalLabel"></h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <div class="alert alert-success d-none" id="general-alert-success" role="alert"></div>
+                <div id="generalModalContent">
+                </div>
+            </div>
+            <div class="modal-footer justify-content-between">
+                <div id="generalModalCustomButtons"></div>
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal"><i class="fa-regular fa-circle-xmark"></i>&nbsp;Close</button>
+            </div>
+        </div>
+    </div>
+</div></div>
+
+
+<footer class="page-footer">
+    <div class="frame frame-ruler-before frame-background-dark">
+        <div class="frame-container">
+            <div class="frame-inner">
+                                <div class="footer-additional">
+                    <p class="text-center">Last rendered: Jan 01, 2023 12:00</p>
+                </div>
+                <div class="footer-meta">
+                    <ul class="footer-meta-navigation">
+                        <li><a href="https://typo3.org/legal-notice" rel="nofollow" target="_blank" title="Legal Notice">Legal Notice</a></li>
+                        <li><a href="https://typo3.org/privacy-policy" rel="nofollow" target="_blank" title="Privacy Policy">Privacy Policy</a></li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </div>
+</footer>
+<script src="_resources/js/popper.min.js"></script>
+<script src="_resources/js/bootstrap.min.js"></script>
+<script src="_resources/js/theme.min.js"></script>
+
+<!--
+ Locally rendered. No tracking embedded.
+-->
+</body>
+</html>

--- a/tests/Integration/tests/images/Float/expected/logs/warning.log
+++ b/tests/Integration/tests/images/Float/expected/logs/warning.log
@@ -1,0 +1,7 @@
+app.WARNING: Using `:class: float-left` / `:class: float-right` is deprecated. Use `:align: left` / `:align: right` instead. {"rst-file":"index.rst","currentLineNumber":40} []
+app.WARNING: Using `:class: float-left` / `:class: float-right` is deprecated. Use `:align: left` / `:align: right` instead. {"rst-file":"index.rst","currentLineNumber":49} []
+app.WARNING: Using `:class: float-left` / `:class: float-right` is deprecated. Use `:align: left` / `:align: right` instead, or `float-start` / `float-end` for substitution images. {"rst-file":"index.rst","currentLineNumber":55,"currentLine":""} []
+app.WARNING: Using `:class: float-left` / `:class: float-right` is deprecated. Use `:align: left` / `:align: right` instead, or `float-start` / `float-end` for substitution images. {"rst-file":"index.rst","currentLineNumber":62,"currentLine":""} []
+app.WARNING: Using `:class: float-left` / `:class: float-right` is deprecated. Use `:align: left` / `:align: right` instead. {"rst-file":"index.rst","currentLineNumber":72} []
+app.WARNING: Using `:class: float-left` / `:class: float-right` is deprecated. Use `:align: left` / `:align: right` instead. {"rst-file":"index.rst","currentLineNumber":82} []
+app.WARNING: Using `:class: float-left` / `:class: float-right` is deprecated. Use `:align: left` / `:align: right` instead, or `float-start` / `float-end` for substitution images. {"rst-file":"index.rst","currentLineNumber":118,"currentLine":""} []

--- a/tests/Integration/tests/images/Float/input/index.rst
+++ b/tests/Integration/tests/images/Float/input/index.rst
@@ -1,97 +1,120 @@
-==============
-Document Title
-==============
+===========
+Float Tests
+===========
 
-Lorem Ipsum Dolor.
+Align Left
+==========
 
-Figure align left
-=================
+.. figure:: /typo3-logo.png
+   :alt: Left figure
+   :align: left
 
-..  figure:: /typo3-logo.png
-    :alt: Left aligned figure
-    :align: left
+   Left aligned figure
 
-    Caption for left-aligned figure
+Align Right
+===========
 
-Figure align right
-==================
+.. figure:: /typo3-logo.png
+   :alt: Right figure
+   :align: right
 
-..  figure:: /typo3-logo.png
-    :alt: Right aligned figure
-    :align: right
+   Right aligned figure
 
-    Caption for right-aligned figure
+Align Center
+============
 
-Figure align center
+.. figure:: /typo3-logo.png
+   :alt: Center figure
+   :align: center
+
+   Center aligned figure
+
+Legacy Figure Class
 ===================
 
-..  figure:: /typo3-logo.png
-    :alt: Center aligned figure
-    :align: center
+.. figure:: /typo3-logo.png
+   :alt: Legacy float-left figure
+   :class: float-left
 
-    Caption for center-aligned figure
+   Should rewrite to float-start
 
-Image align left
-================
+Legacy Figure Right
+====================
 
-..  image:: /typo3-logo.png
-    :alt: Left aligned image
-    :align: left
+.. figure:: /typo3-logo.png
+   :alt: Legacy float-right figure
+   :class: float-right
 
-Image align right
+   Should rewrite to float-end
+
+Legacy Image Left
 =================
 
-..  image:: /typo3-logo.png
-    :alt: Right aligned image
-    :align: right
+.. image:: /typo3-logo.png
+   :alt: Legacy float-left image
+   :class: float-left
 
-Image align center
+Legacy Image Right
 ==================
 
-..  image:: /typo3-logo.png
-    :alt: Center aligned image
-    :align: center
+.. image:: /typo3-logo.png
+   :alt: Legacy float-right image
+   :class: float-right
 
-Figure with float class
-=======================
+Mixed Legacy With Extra Class
+==============================
 
-..  figure:: /typo3-logo.png
-    :alt: Figure with float-left class
-    :class: float-left
+.. figure:: /typo3-logo.png
+   :alt: Mixed class figure
+   :class: float-left with-shadow
 
-    Float class on figure
+   Should rewrite float-left but keep with-shadow
 
-Figure with float-right class
-=============================
+Align Plus Legacy Class
+========================
 
-..  figure:: /typo3-logo.png
-    :alt: Figure with float-right class
-    :class: float-right
+.. figure:: /typo3-logo.png
+   :alt: Both align and legacy class
+   :align: left
+   :class: float-left
 
-    Float-right class on figure
+   Should use align, class gets rewritten to float-start
 
-Figure with float class and extra classes
-=========================================
+Image Align Left
+================
 
-..  figure:: /typo3-logo.png
-    :alt: Figure with float and shadow
-    :class: float-left with-shadow
+.. image:: /typo3-logo.png
+   :alt: Image align left
+   :align: left
 
-    Float class combined with other classes
+Image Align Right
+=================
 
-Image with float class
-======================
+.. image:: /typo3-logo.png
+   :alt: Image align right
+   :align: right
 
-..  image:: /typo3-logo.png
-    :alt: Image with float-right class
-    :class: float-right
+Modern Float Start (No Warning)
+================================
 
-Figure with align and extra class
-=================================
+.. figure:: /typo3-logo.png
+   :alt: Modern float-start figure
+   :class: float-start
 
-..  figure:: /typo3-logo.png
-    :alt: Figure with align and border
-    :align: left
-    :class: with-border
+   Already uses modern class, no rewriting needed
 
-    Align option combined with extra class
+Modern Float End Image (No Warning)
+=====================================
+
+.. image:: /typo3-logo.png
+   :alt: Modern float-end image
+   :class: float-end
+
+Substitution Image Left
+========================
+
+.. |sub-logo| image:: /typo3-logo.png
+   :alt: Substitution logo
+   :class: float-left
+
+Use the |sub-logo| inline text here.


### PR DESCRIPTION
## Summary

Builds on #1174 (merged). Modernizes legacy float CSS classes to Bootstrap 5 logical properties with backward-compatible deprecation handling.

- Modernize CSS float selectors to Bootstrap 5 logical properties (`float-start`/`float-end`), keeping backward-compatible aliases with grouped selectors to reduce duplication
- Add Twig `alignMap` to translate RST `:align:` values to CSS classes, with deduplication to prevent duplicate classes when both `:align:` and `:class:` resolve to the same value
- Detect and rewrite deprecated `:class: float-left`/`:class: float-right` in both FigureDirective and ImageDirective, emitting deprecation warnings
- Extract shared `RewritesLegacyFloatClasses` trait for detection/rewrite logic (DRY)
- ImageDirective uses **composition** (decorator pattern) instead of forking the upstream `final` class — zero code duplication, upstream changes are inherited automatically
- Add responsive breakpoint for standalone images on small screens

## Implementation notes

- **ImageDirective**: Wraps the upstream `final` class via composition. Intercepts `process()` to rewrite float classes, then delegates to `$this->inner->process()`. No need to duplicate `processNode()` or `resolveLinkTarget()`.
- **FigureDirective**: Existing fork extended with float class detection. Uses `array_filter`/`explode` to strip float classes from the inner `<img>` while preserving non-float classes (e.g. `with-shadow`). A future PR will explore refactoring this to use decoration as well.
- **RewritesLegacyFloatClasses trait**: Shared regex detection (`hasLegacyFloatClass`) and rewrite (`rewriteLegacyFloatClasses`) used by both directives.
- Upstream issue for `final` removal: https://github.com/phpDocumentor/guides/issues/1303

## Test plan

- [x] Integration tests cover: align left/right/center, legacy float-left/right rewriting, mixed classes, simultaneous :align: + :class:, standalone images, modern float-start/float-end pass-through, substitution images
- [x] Deprecation warnings verified for all legacy class usages (7 warnings, no false positives for modern classes)
- [x] Unit tests: 40 tests covering RewritesLegacyFloatClasses trait, ImageDirective, and FigureDirective (100% patch coverage)