### PR TITLE
[TASK] Add PHP 8.5 to CI test matrix

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -22,6 +22,7 @@ jobs:
           - '8.2'
           - '8.3'
           - '8.4'
+          - '8.5'
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- Adds PHP 8.5 (stable since Nov 2025, current: 8.5.3) to the CI test matrix
- Tests unit and integration suites against PHP 8.5
- No dependency or config changes needed (`platform.php: 8.1.27` ensures locked install works)

## Changes

- `.github/workflows/main.yaml`: Added `'8.5'` to `matrix.php` in the `tests` job

## Context

PHP 8.5 has been GA since November 2025. The existing `composer.json` constraint
(`^8.1`) already allows 8.5. The `config.platform.php: 8.1.27` setting ensures
`composer install --locked` succeeds regardless of runtime PHP version.

## Test plan

- [ ] CI runs unit tests on PHP 8.5
- [ ] CI runs integration tests on PHP 8.5
- [ ] Existing PHP 8.1-8.4 jobs unaffected