### PR TITLE
[TASK] Update and SHA-pin all GitHub Actions

### DIFF
--- a/.github/workflows/deploy-azure-assets.yaml
+++ b/.github/workflows/deploy-azure-assets.yaml
@@ -18,7 +18,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Get the version
         id: get-version

--- a/.github/workflows/deploy-azure-assets.yaml
+++ b/.github/workflows/deploy-azure-assets.yaml
@@ -18,7 +18,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Get the version
         id: get-version

--- a/.github/workflows/docker-test.yaml
+++ b/.github/workflows/docker-test.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: "Checkout"
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd" # v6.0.2
 
       - name: "Prepare action (adjust configure-guides-step)"
         ##################################################################

--- a/.github/workflows/docker-test.yaml
+++ b/.github/workflows/docker-test.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: "Checkout"
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0" # v7.0.0
 
       - name: "Prepare action (adjust configure-guides-step)"
         ##################################################################

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -24,7 +24,7 @@ jobs:
           - linux/amd64
           - linux/arm64
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Prepare image name
         run: |
@@ -35,7 +35,7 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -46,24 +46,24 @@ jobs:
             type=semver,pattern={{major}}
 
       - name: Log in to the Container registry
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Build and push
         id: build
         env:
           TYPO3AZUREEDGEURIVERSION: ${{ env.DOCKER_METADATA_OUTPUT_VERSION }}
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}
@@ -81,7 +81,7 @@ jobs:
           touch "/tmp/digests/${digest#sha256:}"
       -
         name: Upload digest
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: digests-${{ env.PLATFORM_NAME }}
           overwrite: true
@@ -101,18 +101,18 @@ jobs:
 
       -
         name: Download digests
-        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           pattern: digests-*
           merge-multiple: true
           path: /tmp/digests
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
       -
         name: Docker meta
         id: meta
-        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -122,7 +122,7 @@ jobs:
             type=raw,value=latest,enable=true
 
       - name: Log in to the Container registry
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -24,7 +24,7 @@ jobs:
           - linux/amd64
           - linux/arm64
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Prepare image name
         run: |
@@ -35,7 +35,7 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -46,24 +46,24 @@ jobs:
             type=semver,pattern={{major}}
 
       - name: Log in to the Container registry
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Build and push
         id: build
         env:
           TYPO3AZUREEDGEURIVERSION: ${{ env.DOCKER_METADATA_OUTPUT_VERSION }}
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}
@@ -81,7 +81,7 @@ jobs:
           touch "/tmp/digests/${digest#sha256:}"
       -
         name: Upload digest
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: digests-${{ env.PLATFORM_NAME }}
           overwrite: true
@@ -101,18 +101,18 @@ jobs:
 
       -
         name: Download digests
-        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: digests-*
           merge-multiple: true
           path: /tmp/digests
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
       -
         name: Docker meta
         id: meta
-        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -122,7 +122,7 @@ jobs:
             type=raw,value=latest,enable=true
 
       - name: Log in to the Container registry
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/pr-auto-approve.yaml
+++ b/.github/workflows/pr-auto-approve.yaml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7
+        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2.5.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/pr-auto-approve.yaml
+++ b/.github/workflows/pr-auto-approve.yaml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/pr-auto-merge.yaml
+++ b/.github/workflows/pr-auto-merge.yaml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7
+        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2.5.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/pr-auto-merge.yaml
+++ b/.github/workflows/pr-auto-merge.yaml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/split-repositories.yaml
+++ b/.github/workflows/split-repositories.yaml
@@ -20,22 +20,22 @@ jobs:
     runs-on: "ubuntu-latest"
     name: "Publish Sub-split"
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd" # v6.0.2
         with:
           fetch-depth: "0"
           persist-credentials: "false"
-      - uses: frankdejonge/use-github-token@15e6289d07c12b3b1603268a628bb74f2e9765f4
+      - uses: "frankdejonge/use-github-token@15e6289d07c12b3b1603268a628bb74f2e9765f4" # 1.1.0
         with:
           authentication: "typo3-documentation-team:${{ secrets.BOT_TOKEN }}"
           user_name: "TYPO3 Documentation Team"
           user_email: "documentation-automation@typo3.com"
       - name: "Cache splitsh-lite"
         id: "splitsh-cache"
-        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306
+        uses: "actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306" # v5.0.3
         with:
           path: "./.splitsh"
           key: "${{ runner.os }}-splitsh-d-101"
-      - uses: frankdejonge/use-subsplit-publish@0001015147267203898034927e8cccad3a7a9aa7
+      - uses: "frankdejonge/use-subsplit-publish@0001015147267203898034927e8cccad3a7a9aa7" # 1.1.0
         with:
           source-branch: "main"
           config-path: "./config.subsplit-publish.json"

--- a/.github/workflows/split-repositories.yaml
+++ b/.github/workflows/split-repositories.yaml
@@ -20,22 +20,22 @@ jobs:
     runs-on: "ubuntu-latest"
     name: "Publish Sub-split"
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0" # v7.0.0
         with:
           fetch-depth: "0"
           persist-credentials: "false"
-      - uses: frankdejonge/use-github-token@15e6289d07c12b3b1603268a628bb74f2e9765f4
+      - uses: "frankdejonge/use-github-token@15e6289d07c12b3b1603268a628bb74f2e9765f4" # 1.1.0
         with:
           authentication: "typo3-documentation-team:${{ secrets.BOT_TOKEN }}"
           user_name: "TYPO3 Documentation Team"
           user_email: "documentation-automation@typo3.com"
       - name: "Cache splitsh-lite"
         id: "splitsh-cache"
-        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306
+        uses: "actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9" # v6.1.0
         with:
           path: "./.splitsh"
           key: "${{ runner.os }}-splitsh-d-101"
-      - uses: frankdejonge/use-subsplit-publish@0001015147267203898034927e8cccad3a7a9aa7
+      - uses: "frankdejonge/use-subsplit-publish@0001015147267203898034927e8cccad3a7a9aa7" # 1.1.0
         with:
           source-branch: "main"
           config-path: "./config.subsplit-publish.json"


### PR DESCRIPTION
## Summary

Updates and SHA-pins all GitHub Actions in non-CI workflow files for supply
chain security.

`main.yaml` is excluded from this PR — it will be migrated to shared reusable
workflows via [#1196](https://github.com/TYPO3-Documentation/render-guides/pull/1196).

### Files changed

- `.github/workflows/docker.yaml` — metadata-action, login-action, setup-qemu, setup-buildx, build-push, upload/download-artifact, checkout
- `.github/workflows/docker-test.yaml` — checkout
- `.github/workflows/deploy-azure-assets.yaml` — checkout
- `.github/workflows/split-repositories.yaml` — checkout, cache, use-github-token, use-subsplit-publish
- `.github/workflows/pr-auto-merge.yaml` — dependabot/fetch-metadata
- `.github/workflows/pr-auto-approve.yaml` — dependabot/fetch-metadata

### Version updates

All versions verified as latest releases via the GitHub API on 2026-07-04.

| Action | Old | New | SHA |
|--------|-----|-----|-----|
| actions/checkout | SHA only (v6.0.2) | v7.0.0 | `9c091bb2` |
| actions/cache | SHA only (v5.0.3) | v6.1.0 | `55cc8345` |
| docker/metadata-action | SHA only | v6.2.0 | `dc802804` |
| docker/login-action | SHA only | v4.4.0 | `af1e73f9` |
| docker/setup-qemu-action | SHA only | v4.2.0 | `96fe6ef7` |
| docker/setup-buildx-action | SHA only | v4.2.0 | `bb05f3f5` |
| docker/build-push-action | SHA only | v7.3.0 | `53b7df96` |
| actions/upload-artifact | SHA only | v7.0.1 | `043fb46d` |
| actions/download-artifact | SHA only | v8.0.1 | `3e5f45b2` |
| dependabot/fetch-metadata | SHA only | v3.1.0 | `25dd0e34` |
| frankdejonge/use-github-token | SHA only | 1.1.0 | `15e6289d` |
| frankdejonge/use-subsplit-publish | SHA only | 1.1.0 | `00010151` |

### Reviewer note on test coverage

Several bumps cross a major version (docker/* actions, upload/download-artifact, fetch-metadata, cache). Their latest release notes show no input/behavior breaking changes affecting our usage, but note that `docker.yaml` (publish path), `split-repositories.yaml` and `deploy-azure-assets.yaml` only run on push/tag events, so PR CI does not exercise them — worth a close look at the first post-merge runs.

## Related

- [#1196](https://github.com/TYPO3-Documentation/render-guides/pull/1196) — Migrates `main.yaml` to shared reusable workflows
