### PR TITLE
[BUGFIX] Resolve double-backslash escape in code text roles

### DIFF
--- a/Documentation-rendertest/Inline-code-and-textroles/Index.rst
+++ b/Documentation-rendertest/Inline-code-and-textroles/Index.rst
@@ -239,6 +239,37 @@ Inline `code` :php:`MyCustomException` :ts:`PAGE` in title
 
 
 
+Escape handling in code text roles
+===================================
+
+Double backslash (``\\``) in code text roles should render as a single
+backslash. This applies to all code-type text roles that use ``$rawContent``.
+
+Source::
+
+   :rst:`a\\b`
+   :shell:`path\\to\\file`
+   :typoscript:`config.no\\cache`
+   :yaml:`key\\value`
+
+Result:
+
+*  :rst:`a\\b`
+*  :shell:`path\\to\\file`
+*  :typoscript:`config.no\\cache`
+*  :yaml:`key\\value`
+
+Plain content without escapes should still work:
+
+*  :rst:`rest code`
+*  :shell:`ls -la`
+
+PHP namespace paths use single backslashes and must be preserved:
+
+*  :php:`\TYPO3\CMS\Core\Utility\GeneralUtility`
+*  :code:`TYPO3\CMS\Core\Cache\Frontend\FrontendInterface`
+
+
 Fully qualified names with backslashes
 ======================================
 

--- a/packages/typo3-docs-theme/src/Nodes/Inline/CodeInlineNode.php
+++ b/packages/typo3-docs-theme/src/Nodes/Inline/CodeInlineNode.php
@@ -13,6 +13,7 @@ final class CodeInlineNode extends InlineNode
      */
     public function __construct(string $value, private string $language, private string $helpText = '', private array $info = [])
     {
+        $value = str_replace('\\\\', '\\', $value);
         parent::__construct(self::TYPE, $value);
     }
 

--- a/tests/Integration/tests/code/code-textrole-escape/expected/index.html
+++ b/tests/Integration/tests/code/code-textrole-escape/expected/index.html
@@ -1,0 +1,67 @@
+<!-- content start -->
+                <section class="section" id="code-text-role-escape-tests">
+            <h1>Code text role escape tests<a class="headerlink" href="#code-text-role-escape-tests" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">&nbsp;<i class="fa-solid fa-link"></i></a></h1>
+
+    <p>Double backslash resolves to single backslash:</p>
+
+    <p><code class="code-inline"
+          translate="no"
+          data-bs-toggle="modal"
+          data-bs-target="#generalModal"
+          data-code="a\b"
+          data-shortdescription="Code written in reStructuredText"
+          data-details="Easy-to-read, what-you-see-is-what-you-get plaintext markup syntax and parser system."
+          data-morelink=""          data-bs-html="true"
+    >
+        a\<wbr>b</code></p>
+
+    <p><code class="code-inline code-inline-long"
+          translate="no"
+          data-bs-toggle="modal"
+          data-bs-target="#generalModal"
+          data-code="path\to\file"
+          data-shortdescription="Code written in Shell Script"
+          data-details="Raw command line interface code on operating-system level."
+          data-morelink=""          data-bs-html="true"
+    >
+        path\<wbr>to\<wbr>file</code></p>
+
+    <p>Plain content without escapes still works:</p>
+
+    <p><code class="code-inline"
+          translate="no"
+          data-bs-toggle="modal"
+          data-bs-target="#generalModal"
+          data-code="rest code"
+          data-shortdescription="Code written in reStructuredText"
+          data-details="Easy-to-read, what-you-see-is-what-you-get plaintext markup syntax and parser system."
+          data-morelink=""          data-bs-html="true"
+    >
+        rest code</code></p>
+
+    <p>Multiple roles with double backslash:</p>
+
+    <p><code class="code-inline code-inline-long"
+          translate="no"
+          data-bs-toggle="modal"
+          data-bs-target="#generalModal"
+          data-code="config.no\cache"
+          data-shortdescription="Code written in TypoScript"
+          data-details="Directive-based configuration language used by TYPO3."
+          data-morelink=""          data-bs-html="true"
+    >
+        config.<wbr>no\<wbr>cache</code></p>
+
+    <p><code class="code-inline"
+          translate="no"
+          data-bs-toggle="modal"
+          data-bs-target="#generalModal"
+          data-code="key\value"
+          data-shortdescription="Code written in YAML"
+          data-details="Yet Another Markup Language, used for key-value configuration."
+          data-morelink=""          data-bs-html="true"
+    >
+        key\<wbr>value</code></p>
+
+    </section>
+        <!-- content end -->

--- a/tests/Integration/tests/code/code-textrole-escape/input/index.rst
+++ b/tests/Integration/tests/code/code-textrole-escape/input/index.rst
@@ -1,0 +1,19 @@
+==========================
+Code text role escape tests
+==========================
+
+Double backslash resolves to single backslash:
+
+:rst:`a\\b`
+
+:shell:`path\\to\\file`
+
+Plain content without escapes still works:
+
+:rst:`rest code`
+
+Multiple roles with double backslash:
+
+:typoscript:`config.no\\cache`
+
+:yaml:`key\\value`


### PR DESCRIPTION
## Summary

Demonstrates a possible fix for #1188 — `:rst:` (and all other code-type text roles) display `\\` literally instead of resolving to `\`.

All 20 code-type text roles pass `$rawContent` to `CodeInlineNode`, which preserves RST escape sequences literally. This means `\\` in the RST source stays as `\\` in the rendered output instead of resolving to `\` as the author intended.

**Approach:** Add `str_replace('\\\\', '\\', $value)` in the `CodeInlineNode` constructor to resolve double-backslash escape sequences.

### Changes

- `CodeInlineNode.php` — one line added in constructor
- New integration test `code-textrole-escape` covering `:rst:`, `:shell:`, `:typoscript:`, `:yaml:` with `\\` and plain content
- Render-test examples added to `Inline-code-and-textroles/Index.rst`

### Scope

This PR addresses **Test B** from the issue (double backslash). Tests A, D, E involve the upstream `InlineLexer` in phpDocumentor/guides consuming `` \` `` as `ESCAPED_SIGN` before text role boundaries are resolved — that requires a separate upstream fix.

## ⚠️ Known limitation — this is a demonstration, not a complete fix

The `str_replace` approach is **blind** — it cannot distinguish between:

- `\\` meaning "RST escaped backslash → display `\`" (the bug we're fixing)
- `\\` meaning "literal double backslash in code that should stay as `\\`"

**PHP code samples that would break:**

| RST source | Before this PR | After this PR | Problem |
|---|---|---|---|
| `:php:`'/\\d+/'`` | `'/\\d+/'` | `'/\d+/'` | Lost the PHP string escape |
| `:php:`"hello\\nworld"`` | `"hello\\nworld"` | `"hello\nworld"` | Looks like a newline now |
| `:php:`preg_match('/\\\\/')`` | `preg_match('/\\\\/')` | `preg_match('/\\/')` | Regex completely wrong |

This is the fundamental tension identified in the issue: `$rawContent` was introduced by [phpDocumentor/guides#533](https://github.com/phpDocumentor/guides/pull/533) to preserve literal backslashes for PHP namespaces (`\TYPO3\CMS\Core`), but that same literalness prevents `\\` from resolving to `\`.

**A proper fix needs to happen upstream** in the parser/lexer layer where `ESCAPED_SIGN` tokens are available — only the parser knows which `\\` came from an intentional RST escape vs which `\` was just a literal backslash character in code.

## Test plan

- [x] `make test-integration ENV=local` — all 113 tests pass
- [x] `make code-style ENV=local` — 0 issues
- [x] `make phpstan ENV=local` — no errors
- [ ] `make rendertest ENV=local` — inspect "Escape handling in code text roles" section
- [ ] Verify `:php:` namespace paths still render correctly (existing `code-php` test)