### PR TITLE
[!] [TASK] Fix SHA commits for GH actions

### DIFF
--- a/.github/workflows/deploy-azure-assets.yaml
+++ b/.github/workflows/deploy-azure-assets.yaml
@@ -18,7 +18,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Get the version
         id: get-version

--- a/.github/workflows/docker-test.yaml
+++ b/.github/workflows/docker-test.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v4"
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: "Prepare action (adjust configure-guides-step)"
         ##################################################################

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -20,7 +20,7 @@ jobs:
           - linux/amd64
           - linux/arm64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Prepare image name
         run: |
@@ -31,7 +31,7 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -42,24 +42,24 @@ jobs:
             type=semver,pattern={{major}}
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
 
       - name: Build and push
         id: build
         env:
           TYPO3AZUREEDGEURIVERSION: ${{ env.DOCKER_METADATA_OUTPUT_VERSION }}
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}
@@ -77,7 +77,7 @@ jobs:
           touch "/tmp/digests/${digest#sha256:}"
       -
         name: Upload digest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
         with:
           name: digests-${{ env.PLATFORM_NAME }}
           overwrite: true
@@ -97,18 +97,18 @@ jobs:
 
       -
         name: Download digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3
         with:
           pattern: digests-*
           merge-multiple: true
           path: /tmp/digests
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
       -
         name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -118,7 +118,7 @@ jobs:
             type=raw,value=latest,enable=true
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -25,17 +25,17 @@ jobs:
           - '8.5'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: "Install PHP"
-        uses: "shivammathur/setup-php@v2"
+        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1
         with:
           coverage: "none"
           php-version: "${{ matrix.php }}"
           extensions: 'inotify, pcntl'
 
       - name: "Install dependencies with Composer"
-        uses: "ramsey/composer-install@v2"
+        uses: ramsey/composer-install@3cf229dc2919194e9e36783941438d17239e8520
         with:
           dependency-versions: "locked"
 
@@ -50,17 +50,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: "Install PHP"
-        uses: "shivammathur/setup-php@v2"
+        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1
         with:
           coverage: "none"
           php-version: "${{ env.DEFAULT_PHP_VERSION }}"
           extensions: 'inotify, pcntl'
 
       - name: "Install dependencies with Composer"
-        uses: "ramsey/composer-install@v2"
+        uses: ramsey/composer-install@3cf229dc2919194e9e36783941438d17239e8520
         with:
           dependency-versions: "locked"
 
@@ -87,17 +87,17 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v4"
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: "Install PHP"
-        uses: "shivammathur/setup-php@v2"
+        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1
         with:
           coverage: "none"
           php-version: "${{ env.DEFAULT_PHP_VERSION }}"
           extensions: 'inotify, pcntl'
 
       - name: "Install dependencies with Composer"
-        uses: "ramsey/composer-install@v2"
+        uses: ramsey/composer-install@3cf229dc2919194e9e36783941438d17239e8520
         with:
           dependency-versions: "locked"
 

--- a/.github/workflows/pr-auto-approve.yaml
+++ b/.github/workflows/pr-auto-approve.yaml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v1
+        uses: dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/split-repositories.yaml
+++ b/.github/workflows/split-repositories.yaml
@@ -20,22 +20,22 @@ jobs:
     runs-on: "ubuntu-latest"
     name: "Publish Sub-split"
     steps:
-      - uses: "actions/checkout@v4"
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: "0"
           persist-credentials: "false"
-      - uses: "frankdejonge/use-github-token@1.0.2"
+      - uses: frankdejonge/use-github-token@15e6289d07c12b3b1603268a628bb74f2e9765f4
         with:
           authentication: "typo3-documentation-team:${{ secrets.BOT_TOKEN }}"
           user_name: "TYPO3 Documentation Team"
           user_email: "documentation-automation@typo3.com"
       - name: "Cache splitsh-lite"
         id: "splitsh-cache"
-        uses: "actions/cache@v4"
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306
         with:
           path: "./.splitsh"
           key: "${{ runner.os }}-splitsh-d-101"
-      - uses: "frankdejonge/use-subsplit-publish@1.0.0"
+      - uses: frankdejonge/use-subsplit-publish@0001015147267203898034927e8cccad3a7a9aa7
         with:
           source-branch: "main"
           config-path: "./config.subsplit-publish.json"


### PR DESCRIPTION
With this patch (thanks to Sebastian Mendel!) we utilize fixed SHA commit IDs for all our action usages.

This allows us to consciously upgrade dependencies and are a lesser subject to dependency chain vulnerabilities.

This can possibly introduce breakage. The bumps in all major versions mainly affect node runtimes. No breaking changes have ben consciously applied, and may require further adjustment.

After all repositories receive a commit like this, the organisation-wide SHA pinning will be enabled.

This is our current "allow-list" for GH actions:

```
TYPO3-Continuous-Integration/*,
TYPO3-Documentation/*,
actions/cache@*,
actions/checkout@*,
actions/download-artifact@*,
actions/setup-python*,
actions/upload-artifact@*,
appleboy/scp-action@*,
appleboy/ssh-action@*,
ddev/github-action-add-on-test@*,
dependabot/*,
distributhor/workflow-webhook@*,
docker/build-push-action*,
docker/login-action@*,
docker/metadata-action@*,
docker/setup-buildx-action@*,
docker/setup-qemu-action@*,
frankdejonge/use-github-token@*,
frankdejonge/use-subsplit-publish@*,
m-kuhn/backport@*,
peter-evans/create-pull-request@*,
ramsey/composer-install@*,
repo-sync/pull-request@*,
shivammathur/setup-php@*,
tomasnorre/typo3-upload-ter@*,
```

And these are all fixed versions:

```
m-kuhn/backport@30b6e83906cc97bad3a02867181d6236becf68f9
repo-sync/pull-request@7e79a9f5dc3ad0ce53138f01df2fad14a04831c5
peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0
tomasnorre/typo3-upload-ter@7982891f20d0b224f67e250e8ea8814d9e5f9671
appleboy/scp-action@ff85246acaad7bdce478db94a363cd2bf7c90345
appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2
TYPO3-Continuous-Integration/TYPO3-CI-Xliff-Lint@ea1db1c5aeafbbc3c092ece90e5ecedf1f09ded9
shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1
actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306
actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3
actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
ddev/github-action-add-on-test@1a55661204342fd16650a5a149395bfb1837d4b9
dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7
distributhor/workflow-webhook@2381f0e9c7b6bf061fb1405bd0804b8706116369
docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294
docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2
docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf
docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a
docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
frankdejonge/use-github-token@15e6289d07c12b3b1603268a628bb74f2e9765f4
frankdejonge/use-subsplit-publish@0001015147267203898034927e8cccad3a7a9aa7
ramsey/composer-install@3cf229dc2919194e9e36783941438d17239e8520
```

**THERE IS ONE EXCEPTION**:

The `TYPO3-Documentation/gh-render-action` always needs to be executed with `main` scoping, so we don't need to create releases for changes.