### PR TITLE
[TASK] Migrate CI to shared reusable workflows

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,131 +1,56 @@
 name: "Main"
 
-on: # yamllint disable-line rule:truthy
+on:
   pull_request: null
   push:
     branches:
       - "main"
 
-env:
-  DEFAULT_PHP_VERSION: "8.2"
-  RUN_ENVIRONMENT: "local"
+permissions: {}
 
 jobs:
   tests:
-    name : Tests
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        php:
-          - '8.2'
-          - '8.3'
-          - '8.4'
-          - '8.5'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-
-      - name: "Install PHP"
-        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1
-        with:
-          coverage: "none"
-          php-version: "${{ matrix.php }}"
-          extensions: 'inotify, pcntl'
-
-      - name: "Get Composer cache directory"
-        id: composer-cache
-        run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
-
-      - name: "Cache Composer dependencies"
-        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: php-${{ matrix.php }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: php-${{ matrix.php }}-composer-
-
-      - name: "Install dependencies with Composer"
-        run: composer install --no-interaction --no-progress --prefer-dist
-
-      - name: "Run unit tests"
-        run: "make test-unit ENV=${{ env.RUN_ENVIRONMENT }}"
-
-      - name: "Run integration tests"
-        run: "make test-integration ENV=${{ env.RUN_ENVIRONMENT }}"
+    uses: TYPO3-Documentation/.github/.github/workflows/reusable-php-tests.yml@main
+    with:
+      php-versions: '["8.2", "8.3", "8.4", "8.5"]'
+      test-unit-command: "make test-unit ENV=local"
+      test-integration-command: "make test-integration ENV=local"
+      php-extensions: "inotify, pcntl"
 
   quality:
-    name: Quality
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+    uses: TYPO3-Documentation/.github/.github/workflows/reusable-php-quality.yml@main
+    with:
+      php-version: "8.2"
+      cs-fixer-command: "make code-style ENV=local"
+      phpstan-command: "make phpstan ENV=local"
+      run-xml-lint: true
+      xml-lint-command: "make test-xml ENV=local"
+      php-extensions: "inotify, pcntl"
 
-      - name: "Install PHP"
-        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1
-        with:
-          coverage: "none"
-          php-version: "${{ env.DEFAULT_PHP_VERSION }}"
-          extensions: 'inotify, pcntl'
+  composer-normalize:
+    uses: TYPO3-Documentation/.github/.github/workflows/reusable-php-command.yml@main
+    with:
+      php-version: "8.2"
+      command: "composer normalize --dry-run"
+      php-extensions: "inotify, pcntl"
 
-      - name: "Get Composer cache directory"
-        id: composer-cache
-        run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
+  test-docs:
+    uses: TYPO3-Documentation/.github/.github/workflows/reusable-php-command.yml@main
+    with:
+      php-version: "8.2"
+      command: "make test-docs ENV=local"
+      php-extensions: "inotify, pcntl"
 
-      - name: "Cache Composer dependencies"
-        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: php-${{ env.DEFAULT_PHP_VERSION }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: php-${{ env.DEFAULT_PHP_VERSION }}-composer-
+  test-rendertest:
+    uses: TYPO3-Documentation/.github/.github/workflows/reusable-php-command.yml@main
+    with:
+      php-version: "8.2"
+      command: "make test-rendertest ENV=local"
+      php-extensions: "inotify, pcntl"
 
-      - name: "Install dependencies with Composer"
-        run: composer install --no-interaction --no-progress --prefer-dist
-
-      - name: "Check for normalized composer.json"
-        run: "composer normalize --dry-run"
-
-      - name: "CGL"
-        run: "make code-style ENV=${{ env.RUN_ENVIRONMENT }}"
-
-      - name: "PHPSTAN"
-        run: "make phpstan ENV=${{ env.RUN_ENVIRONMENT }}"
-
-      - name: "Lint guides.xml configurations"
-        run: "make test-xml ENV=${{ env.RUN_ENVIRONMENT }}"
-
-      - name: "'Documentation' renders without warning'"
-        run: "make test-docs ENV=${{ env.RUN_ENVIRONMENT }}"
-
-      - name: "'Documentation-rendertest' renders without warning'"
-        run: "make test-rendertest ENV=${{ env.RUN_ENVIRONMENT }}"
-
-  monorepo-validate:
-    name: "Validate monorepo structure"
-    runs-on: "ubuntu-latest"
-    steps:
-      - name: "Checkout"
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-
-      - name: "Install PHP"
-        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1
-        with:
-          coverage: "none"
-          php-version: "${{ env.DEFAULT_PHP_VERSION }}"
-          extensions: 'inotify, pcntl'
-
-      - name: "Get Composer cache directory"
-        id: composer-cache
-        run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
-
-      - name: "Cache Composer dependencies"
-        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: php-${{ env.DEFAULT_PHP_VERSION }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: php-${{ env.DEFAULT_PHP_VERSION }}-composer-
-
-      - name: "Install dependencies with Composer"
-        run: composer install --no-interaction --no-progress --prefer-dist
-
-      - name: "Validate monorepo"
-        run: "make test-monorepo ENV=${{ env.RUN_ENVIRONMENT }}"
+  validate-monorepo:
+    uses: TYPO3-Documentation/.github/.github/workflows/reusable-php-command.yml@main
+    with:
+      php-version: "8.2"
+      command: "make test-monorepo ENV=local"
+      php-extensions: "inotify, pcntl"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,103 +1,60 @@
 name: "Main"
 
-on: # yamllint disable-line rule:truthy
+on:
   pull_request: null
   push:
     branches:
       - "main"
 
-env:
-  DEFAULT_PHP_VERSION: "8.2"
-  RUN_ENVIRONMENT: "local"
+permissions:
+  contents: read
 
 jobs:
   tests:
-    name : Tests
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        php:
-          - '8.2'
-          - '8.3'
-          - '8.4'
-          - '8.5'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-
-      - name: "Install PHP"
-        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
-        with:
-          coverage: "none"
-          php-version: "${{ matrix.php }}"
-          extensions: 'inotify, pcntl'
-
-      - name: "Get Composer cache directory"
-        id: composer-cache
-        run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
-
-      - name: "Cache Composer dependencies"
-        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: php-${{ matrix.php }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: php-${{ matrix.php }}-composer-
-
-      - name: "Install dependencies with Composer"
-        run: composer install --no-interaction --no-progress --prefer-dist
-
-      - name: "Run unit tests"
-        run: "make test-unit ENV=${{ env.RUN_ENVIRONMENT }}"
-
-      - name: "Run integration tests"
-        run: "make test-integration ENV=${{ env.RUN_ENVIRONMENT }}"
+    uses: TYPO3-Documentation/.github/.github/workflows/reusable-php-tests.yml@main
+    with:
+      php-versions: '["8.2", "8.3", "8.4", "8.5"]'
+      test-unit-command: "make test-unit ENV=local"
+      test-integration-command: "make test-integration ENV=local"
+      php-extensions: "inotify, pcntl"
 
   quality:
-    name: Quality
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+    uses: TYPO3-Documentation/.github/.github/workflows/reusable-php-quality.yml@main
+    with:
+      php-version: "8.2"
+      cs-fixer-command: "make code-style ENV=local"
+      phpstan-command: "make phpstan ENV=local"
+      run-xml-lint: true
+      xml-lint-command: "make test-xml ENV=local"
+      php-extensions: "inotify, pcntl"
 
-      - name: "Install PHP"
-        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
-        with:
-          coverage: "none"
-          php-version: "${{ env.DEFAULT_PHP_VERSION }}"
-          extensions: 'inotify, pcntl'
+  composer-normalize:
+    uses: TYPO3-Documentation/.github/.github/workflows/reusable-php-command.yml@main
+    with:
+      php-version: "8.2"
+      command: "composer normalize --dry-run"
+      php-extensions: "inotify, pcntl"
 
-      - name: "Get Composer cache directory"
-        id: composer-cache
-        run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
+  test-docs:
+    uses: TYPO3-Documentation/.github/.github/workflows/reusable-php-command.yml@main
+    with:
+      php-version: "8.2"
+      command: "make test-docs ENV=local"
+      php-extensions: "inotify, pcntl"
 
-      - name: "Cache Composer dependencies"
-        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: php-${{ env.DEFAULT_PHP_VERSION }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: php-${{ env.DEFAULT_PHP_VERSION }}-composer-
+  test-rendertest:
+    uses: TYPO3-Documentation/.github/.github/workflows/reusable-php-command.yml@main
+    with:
+      php-version: "8.2"
+      command: "make test-rendertest ENV=local"
+      php-extensions: "inotify, pcntl"
 
-      - name: "Install dependencies with Composer"
-        run: composer install --no-interaction --no-progress --prefer-dist
-
-      - name: "Check for normalized composer.json"
-        run: "composer normalize --dry-run"
-
-      - name: "CGL"
-        run: "make code-style ENV=${{ env.RUN_ENVIRONMENT }}"
-
-      - name: "PHPSTAN"
-        run: "make phpstan ENV=${{ env.RUN_ENVIRONMENT }}"
-
-      - name: "Lint guides.xml configurations"
-        run: "make test-xml ENV=${{ env.RUN_ENVIRONMENT }}"
-
-      - name: "'Documentation' renders without warning'"
-        run: "make test-docs ENV=${{ env.RUN_ENVIRONMENT }}"
-
-      - name: "'Documentation-rendertest' renders without warning'"
-        run: "make test-rendertest ENV=${{ env.RUN_ENVIRONMENT }}"
+  validate-monorepo:
+    uses: TYPO3-Documentation/.github/.github/workflows/reusable-php-command.yml@main
+    with:
+      php-version: "8.2"
+      command: "make test-monorepo ENV=local"
+      php-extensions: "inotify, pcntl"
 
   theme-js-tests:
     name: "typo3-docs-theme JS tests"
@@ -107,7 +64,7 @@ jobs:
         working-directory: packages/typo3-docs-theme
     steps:
       - name: "Checkout"
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: "Install Node"
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -122,33 +79,3 @@ jobs:
       - name: "Run JS unit tests"
         run: npm test
 
-  monorepo-validate:
-    name: "Validate monorepo structure"
-    runs-on: "ubuntu-latest"
-    steps:
-      - name: "Checkout"
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-
-      - name: "Install PHP"
-        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
-        with:
-          coverage: "none"
-          php-version: "${{ env.DEFAULT_PHP_VERSION }}"
-          extensions: 'inotify, pcntl'
-
-      - name: "Get Composer cache directory"
-        id: composer-cache
-        run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
-
-      - name: "Cache Composer dependencies"
-        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: php-${{ env.DEFAULT_PHP_VERSION }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: php-${{ env.DEFAULT_PHP_VERSION }}-composer-
-
-      - name: "Install dependencies with Composer"
-        run: composer install --no-interaction --no-progress --prefer-dist
-
-      - name: "Validate monorepo"
-        run: "make test-monorepo ENV=${{ env.RUN_ENVIRONMENT }}"


### PR DESCRIPTION
## Summary

Replaces the inline CI jobs in `main.yaml` with the shared workflows of [TYPO3-Documentation/.github](https://github.com/TYPO3-Documentation/.github), so action versions and the composer/cache setup are maintained in one place instead of once per repository.

| Job | Before | After |
|-----|--------|-------|
| Tests | inline matrix | `reusable-php-tests.yml` |
| Quality (CS Fixer, PHPStan, XML lint) | inline | `reusable-php-quality.yml` |
| Composer normalize | step inside Quality | `reusable-php-command.yml` |
| Documentation render test | step inside Quality | `reusable-php-command.yml` |
| Render-test validation | step inside Quality | `reusable-php-command.yml` |
| Validate monorepo structure | inline | `reusable-php-command.yml` |
| typo3-docs-theme JS tests | inline | unchanged — Node, not PHP |

Rewritten against current `main` rather than rebased: the original branch predated 59 commits and would have reverted the `merge_group` trigger, the `test-rendertest` and `test-monorepo` jobs and the theme JS job.

## This needs a ruleset change in the same step

A called workflow reports its checks as `<job name> / <inner job name>`, so six of the seven context names change. These are the names GitHub actually produced on this head, read from the check runs of `39a0585e` — not predicted:

| now required | after this change |
|---|---|
| `Tests (8.2)` … `Tests (8.5)` | `Tests / Tests (PHP 8.2)` … `Tests / Tests (PHP 8.5)` |
| `Quality` | `Quality / Quality` |
| `Validate monorepo structure` | `Validate monorepo structure / Run` |
| `typo3-docs-theme JS tests` | unchanged |
| — | `Composer normalize / Run` |
| — | `Documentation renders without warning / Run` |
| — | `Documentation-rendertest renders without warning / Run` |

The last three deserve attention: `composer normalize --dry-run`, `make test-docs` and `make test-rendertest` used to be *steps inside* the required `Quality` check, so they gated merges implicitly. As separate jobs they are only gated if the ruleset lists them. Leaving them out would weaken the gate as a side effect of the migration, so the recommended required set is all ten contexts above.

Merging this without the ruleset change blocks the merge queue: it would keep requiring contexts that no longer report.

## Order of operations

There is no ordering that keeps the gate closed the whole time. Switching the ruleset first blocks every other open PR, whose checks still report under the old names; merging first blocks the queue. The workable sequence is to drop the required contexts for the merge window and set the new ones immediately after.

## Note

The shared workflows currently pin `actions/checkout` v6.0.2, `shivammathur/setup-php` 2.37.1 and `actions/cache` v5.0.3, while this repository's inline jobs are on newer pins. The migration therefore moves those three back a version; they are maintained centrally by Dependabot in `.github` afterwards.

## Related

- Depends on .github#2 (adds `reusable-php-command.yml`) — merged 2026-03-22.
- SHA-pinning of actions in other workflow files is handled separately in #1184.
