### PR TITLE
[BUGFIX] Bump phpdocumentor/guides-* to fix bignums-tip leak in tabs

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1687,16 +1687,16 @@
         },
         {
             "name": "phpdocumentor/filesystem",
-            "version": "1.9.0",
+            "version": "1.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/filesystem.git",
-                "reference": "baf81ce5f6ebf450b798bee74f60d107c21e3a8b"
+                "reference": "1234be43d6604bd5ca0951e5d0e8e61e62b872b0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/filesystem/zipball/baf81ce5f6ebf450b798bee74f60d107c21e3a8b",
-                "reference": "baf81ce5f6ebf450b798bee74f60d107c21e3a8b",
+                "url": "https://api.github.com/repos/phpDocumentor/filesystem/zipball/1234be43d6604bd5ca0951e5d0e8e61e62b872b0",
+                "reference": "1234be43d6604bd5ca0951e5d0e8e61e62b872b0",
                 "shasum": ""
             },
             "require": {
@@ -1725,9 +1725,9 @@
             "homepage": "https://www.phpdoc.org",
             "support": {
                 "issues": "https://github.com/phpDocumentor/filesystem/issues",
-                "source": "https://github.com/phpDocumentor/filesystem/tree/1.9.0"
+                "source": "https://github.com/phpDocumentor/filesystem/tree/1.10.0"
             },
-            "time": "2025-09-10T21:23:28+00:00"
+            "time": "2026-04-13T20:20:50+00:00"
         },
         {
             "name": "phpdocumentor/flyfinder",
@@ -1787,16 +1787,16 @@
         },
         {
             "name": "phpdocumentor/guides",
-            "version": "1.9.6",
+            "version": "1.10.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/guides-core.git",
-                "reference": "3ebb9c4d4ad0c19335a13d0f3932a9d48b461c41"
+                "reference": "f90731c13f0132dac864c21adce866f0f756541a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/guides-core/zipball/3ebb9c4d4ad0c19335a13d0f3932a9d48b461c41",
-                "reference": "3ebb9c4d4ad0c19335a13d0f3932a9d48b461c41",
+                "url": "https://api.github.com/repos/phpDocumentor/guides-core/zipball/f90731c13f0132dac864c21adce866f0f756541a",
+                "reference": "f90731c13f0132dac864c21adce866f0f756541a",
                 "shasum": ""
             },
             "require": {
@@ -1841,9 +1841,9 @@
             "homepage": "https://www.phpdoc.org",
             "support": {
                 "issues": "https://github.com/phpDocumentor/guides-core/issues",
-                "source": "https://github.com/phpDocumentor/guides-core/tree/1.9.6"
+                "source": "https://github.com/phpDocumentor/guides-core/tree/1.10.1"
             },
-            "time": "2026-01-23T12:31:23+00:00"
+            "time": "2026-05-08T14:29:08+00:00"
         },
         {
             "name": "phpdocumentor/guides-cli",
@@ -1995,16 +1995,16 @@
         },
         {
             "name": "phpdocumentor/guides-restructured-text",
-            "version": "1.9.6",
+            "version": "1.10.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/guides-restructured-text.git",
-                "reference": "5b381632eb32b9f255348a938bafdcfe322ab8d0"
+                "reference": "382bb6f6ae20cb289999bbbd5b8d42a50032bb44"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/guides-restructured-text/zipball/5b381632eb32b9f255348a938bafdcfe322ab8d0",
-                "reference": "5b381632eb32b9f255348a938bafdcfe322ab8d0",
+                "url": "https://api.github.com/repos/phpDocumentor/guides-restructured-text/zipball/382bb6f6ae20cb289999bbbd5b8d42a50032bb44",
+                "reference": "382bb6f6ae20cb289999bbbd5b8d42a50032bb44",
                 "shasum": ""
             },
             "require": {
@@ -2032,28 +2032,29 @@
             "description": "Adds reStructuredText Markup support to the phpDocumentor's Guides library.",
             "homepage": "https://www.phpdoc.org",
             "support": {
-                "source": "https://github.com/phpDocumentor/guides-restructured-text/tree/1.9.6"
+                "source": "https://github.com/phpDocumentor/guides-restructured-text/tree/1.10.1"
             },
-            "time": "2026-02-27T16:00:14+00:00"
+            "time": "2026-05-05T21:54:11+00:00"
         },
         {
             "name": "phpdocumentor/guides-theme-bootstrap",
-            "version": "1.9.6",
+            "version": "1.9.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/guides-theme-bootstrap.git",
-                "reference": "ac4e5f2afc10eb31de916b9d3f6bee2ef90d82ec"
+                "reference": "370ecfadd3be4218922f99baea65f8d66fddd986"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/guides-theme-bootstrap/zipball/ac4e5f2afc10eb31de916b9d3f6bee2ef90d82ec",
-                "reference": "ac4e5f2afc10eb31de916b9d3f6bee2ef90d82ec",
+                "url": "https://api.github.com/repos/phpDocumentor/guides-theme-bootstrap/zipball/370ecfadd3be4218922f99baea65f8d66fddd986",
+                "reference": "370ecfadd3be4218922f99baea65f8d66fddd986",
                 "shasum": ""
             },
             "require": {
+                "doctrine/deprecations": "^1.1",
                 "php": "^8.1",
                 "phpdocumentor/guides": "^1.0 || ^2.0",
-                "phpdocumentor/guides-restructured-text": "^1.0 || ^2.0"
+                "phpdocumentor/guides-restructured-text": "^1.10 || ^2.0"
             },
             "type": "library",
             "extra": {
@@ -2073,9 +2074,9 @@
             "description": "A theme for phpdocumentor/guides based on Bootstrap",
             "homepage": "https://www.phpdoc.org",
             "support": {
-                "source": "https://github.com/phpDocumentor/guides-theme-bootstrap/tree/1.9.6"
+                "source": "https://github.com/phpDocumentor/guides-theme-bootstrap/tree/1.9.7"
             },
-            "time": "2026-02-23T20:35:06+00:00"
+            "time": "2026-03-18T20:40:56+00:00"
         },
         {
             "name": "phpdocumentor/guides-theme-rst",

--- a/packages/typo3-docs-theme/src/Nodes/GroupTabNode.php
+++ b/packages/typo3-docs-theme/src/Nodes/GroupTabNode.php
@@ -2,7 +2,7 @@
 
 namespace T3Docs\Typo3DocsTheme\Nodes;
 
-use phpDocumentor\Guides\Bootstrap\Nodes\AbstractTabNode;
+use phpDocumentor\Guides\RestructuredText\Nodes\AbstractTabNode;
 use phpDocumentor\Guides\Nodes\InlineCompoundNode;
 use phpDocumentor\Guides\Nodes\Node;
 

--- a/tests/Integration/tests/bignum/bignum-in-tabs/expected/index.html
+++ b/tests/Integration/tests/bignum/bignum-in-tabs/expected/index.html
@@ -1,0 +1,273 @@
+<!DOCTYPE html>
+<html class="no-js" lang="en">
+<head>
+    <title>Tabs containing rst-class sibling list (issue 1236)
+        documentation</title>
+
+    
+<meta charset="utf-8">
+<meta content="width=device-width, initial-scale=1.0" name="viewport">
+<meta content="phpdocumentor/guides" name="generator">
+<meta content="" name="docsearch:name">
+<meta content="" name="docsearch:package_type">
+<meta content="" name="docsearch:release">
+<meta content="" name="docsearch:version">
+<meta content="2026-05-09T09:03:18+00:00" name="docsearch:modified">
+<meta content="2026-05-09T09:03:18+00:00" name="dc.modified">
+<meta content="2026-05-09T09:03:18+00:00" property="article:modified_time">
+    <link href="http://purl.org/dc/elements/1.1/" rel="schema.dc">
+<link href="_resources/css/theme.css" rel="stylesheet">
+<link href="https://docs.typo3.org/search/" rel="search" title="Search">
+<script src="https://cdn.typo3.com/typo3infrastructure/universe/dist/webcomponents-loader.js"></script>
+<script src="https://cdn.typo3.com/typo3infrastructure/universe/dist/typo3-universe.js" type="module"></script>
+                        <link href="#" rel="top" title="Tabs containing rst-class sibling list (issue 1236)"/>
+    </head>
+<body>
+<div class="page">
+    <header>
+    <div class="page-topbar">
+        <div class="page-topbar-inner">
+            <typo3-universe active="documentation">
+                <div style="display: block; height: 44px; background-color: #313131;"></div>
+            </typo3-universe>
+        </div>
+    </div>
+    <div class="page-header">
+        <div class="page-header-inner">
+            <div class="d-flex flex-wrap">
+                <div class="logo-wrapper">
+                    <a class="logo" href="https://docs.typo3.org/" title="TYPO3 Documentation">
+                        <img alt="TYPO3 Logo" class="logo-image" src="_resources/img/typo3-logo.svg" width="484" height="130">
+                    </a>
+                </div>
+                <div class="align-self-center order-lg-2 order-last">
+                    
+<div class="toc-header">
+    <div class="toc-title pe-3">
+                            <a class="toc-title-project" href="#">Tabs containing rst-class sibling list (issue 1236)</a>
+            </div>
+    </div>                </div>
+                <div class="ms-auto order-lg-3 d-flex">
+                    <div class="menu-search-wrapper">
+                        <button id="toc-toggle" class="btn btn-light d-block d-lg-none" tabindex="0" aria-controls="toc-collapse" aria-expanded="false">
+                            <i class="fas fa-bars"></i> <span class="visually-hidden">Mobile Menu</span>
+                        </button>
+                        <all-documentations-menu data-override-url="_resources/js/menu-proxy.php"></all-documentations-menu>
+                                                <search role="search">
+                            <form action="https://docs.typo3.org/search/search" id="global-search-form" method="get">
+                                <div class="sr-only"><label for="globalsearchinput">TYPO3 documentation...</label></div>
+                                <div class="input-group mb-3 mt-sm-3">
+                                    <select class="form-select search__scope" id="searchscope" name="scope">
+                                        <option value="">Search all</option>
+                                    </select>
+                                    <input autocomplete="off" class="form-control shadow-none" id="globalsearchinput" name="q" placeholder="TYPO3 documentation..." type="text" value="">
+                                    <button class="btn btn-light" type="submit"><i class="fa fa-search"></i>&nbsp;<span class="d-none d-md-inline">Search</span></button>
+                                </div>
+                            </form>
+                            <div id="global-search-root"></div>
+                        </search>
+                        <div class="position-relative d-inline-block">
+                            <button id="options-toggle" class="btn btn-light d-block" type="button" aria-expanded="false">
+                                <i class="fas fa-cog"></i> <span class="visually-hidden">Options</span>
+                            </button>
+
+                            <div id="options-panel"
+                                 class="shadow p-3"
+                                 role="menu"
+                                 aria-hidden="true">
+                                <h6 class="dropdown-header text-muted text-uppercase small mb-2">Options</h6>
+
+                                                                                                            <a class="dropdown-item d-flex align-items-center gap-2" href="_sources/index.rst.txt" rel="nofollow noopener" target="_blank">
+        <i class="fas fa-code"></i>
+        View source
+    </a>
+    <a class="dropdown-item d-flex align-items-center gap-2" href="https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/WritingDocsOfficial/GithubMethod.html" id="btnHowToEdit" rel="nofollow noopener" target="_blank">
+        <i class="fas fa-info-circle"></i>
+        How to edit
+    </a>
+                                                                                                                <a class="dropdown-item d-flex align-items-center gap-2" href="singlehtml/Index.html" target="_blank" rel="noopener">
+                                            <i class="fas fa-print"></i>
+                                            Full documentation (single file)
+                                        </a>
+                                                                                                </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</header>    <main class="page-main">
+        <div class="page-main-inner">
+            <div class="page-main-navigation">
+                <nav>
+
+                    <div id="toc-collapse">
+                                                <div aria-label="main navigation" class="toc"
+                             role="navigation">
+                                <all-documentations-menu-mobile
+        data-override-url="_resources/js/menu-proxy.php"></all-documentations-menu-mobile>
+    <div aria-label="Main navigation" class="main_menu" role="navigation">
+                <p class="caption">Tabs containing rst-class sibling list (issue 1236)</p>
+        
+    </div>
+                        </div>
+                    </div>
+                </nav>
+            </div>
+            <div class="page-main-content">
+                <div class="rst-content">                        <nav aria-label="breadcrumbs navigation" class="breadcrumb-bar" role="navigation">
+        
+<ol class="breadcrumb">
+                <li aria-current="page"  class="breadcrumb-item  active">Tabs containing rst-class sibling list (issue 1236)</li>
+        </ol>
+        <div class="breadcrumb-additions"></div>
+    </nav>
+                    
+<article class="document" itemscope="itemscope" itemtype="http://schema.org/Article" role="main">
+    <div itemprop="articleBody">
+        <!-- content start -->
+                <section class="section" id="tabs-containing-rst-class-sibling-list-issue-1236">
+            <h1>Tabs containing rst-class sibling list (issue 1236)<a class="headerlink" href="#tabs-containing-rst-class-sibling-list-issue-1236" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">&nbsp;<i class="fa-solid fa-link"></i></a></h1>
+            
+    <p>The <code>bignums-tip</code> rst-class must apply to the <code>&lt;ol&gt;</code> and must NOT leak
+its own class name as text into the rendered tab pane.</p>
+
+            <div class="tabs">
+    <ul class="nav nav-tabs" id="tab-tabs-1" role="tablist">
+        <li class="nav-item" role="presentation">
+    <button class="nav-link active"
+            id="extension-manager-tab-tabs-1" data-bs-toggle="tab" data-bs-target="#extension-manager-tabs-1"
+            type="button" role="tab" aria-controls="extension-manager-tabs-1"
+            aria-selected="true">
+        Extension Manager
+    </button>
+</li>
+    </ul>
+    <div class="tab-content" id="tab-content-tabs-1">
+        <div class="tab-pane fade show active" id="extension-manager-tabs-1" role="tabpanel" aria-labelledby="extension-manager-tab-tabs-1">
+    
+    
+<ol class="bignums-tip" type="1">
+    <li>Switch to the module <span class="guilabel">System &gt; Extensions</span>.</li>
+    <li>Switch to <span class="guilabel">Get Extensions</span>.</li>
+    <li>Search for the extension key <span class="guilabel">example_extension</span>.</li>
+    <li>Import the extension from the repository.</li>
+</ol>
+
+</div>
+    </div>
+</div>
+    </section>
+        <!-- content end -->
+    </div>
+</article>
+                        
+                    </div>
+            </div>
+        </div>
+    </main>
+
+    <div class="modal fade" id="linkReferenceModal" tabindex="-1" aria-labelledby="linkReferenceModalLabel"
+    aria-hidden="true" data-current-filename="index">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="linkReferenceModalLabel">Reference to the headline</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <div class="alert alert-success d-none" id="permalink-alert-success" role="alert"></div>
+                <div class="mb-3">
+                    <div class="permalink-short-wrapper">
+                        <label for="permalink-short" class="col-form-label">Permalink (Shortlink)</label>
+                        <div class="input-group">
+                            <input class="form-control code" id="permalink-short" readonly>
+                            <button type="button" class="btn btn-outline-secondary copy-button" data-target="permalink-short"><i class="far fa-clone"></i></button>
+                        </div>
+                        <p><em>Copy and freely share the link</em></p>
+                    </div>
+                    <label for="permalink-uri" class="col-form-label">URL</label>
+                    <div class="input-group">
+                        <input class="form-control code" id="permalink-uri" readonly>
+                        <button type="button" class="btn btn-outline-secondary copy-button" data-target="permalink-uri"><i class="far fa-clone"></i></button>
+                    </div>
+                </div>
+                <div class="mb-3">
+                    <div class="alert alert-warning alert-permalink-rst" role="alert">This link target has no permanent anchor assigned.The link below can be used, but is prone to change if the page gets moved.
+                    </div>
+                    <label for="permalink-rst" class="col-form-label">Link in reStructuredText (reST)</label>
+                    <div class="input-group">
+                        <textarea class="form-control code" id="permalink-rst" readonly></textarea>
+                        <button type="button" class="btn btn-outline-secondary copy-button" data-target="permalink-rst"><i class="far fa-clone"></i></button>
+                    </div>
+                    <p><em>Copy this link into your TYPO3 manual.</em></p>
+                </div>
+                <div class="mb-3">
+                    <label for="permalink-md" class="col-form-label">Link in Markdown</label>
+                    <div class="input-group">
+                        <textarea class="form-control code" id="permalink-md" readonly></textarea>
+                        <button type="button" class="btn btn-outline-secondary copy-button" data-target="permalink-md"><i class="far fa-clone"></i></button>
+                    </div>
+                </div>
+                <div class="mb-3">
+                    <label for="permalink-html" class="col-form-label">Link in HTML</label>
+                                        <div class="input-group">
+                        <textarea class="form-control code" id="permalink-html" readonly></textarea>
+                        <button type="button" class="btn btn-outline-secondary copy-button" data-target="permalink-html"><i class="far fa-clone"></i></button>
+                    </div>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+            </div>
+        </div>
+    </div>
+</div>    <div class="modal fade" id="generalModal" tabindex="-1" aria-labelledby="linkReferenceModalLabel"
+    aria-hidden="true" data-current-filename="index"
+>
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="generalModalLabel"></h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <div class="alert alert-success d-none" id="general-alert-success" role="alert"></div>
+                <div id="generalModalContent">
+                </div>
+            </div>
+            <div class="modal-footer justify-content-between">
+                <div id="generalModalCustomButtons"></div>
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal"><i class="fa-regular fa-circle-xmark"></i>&nbsp;Close</button>
+            </div>
+        </div>
+    </div>
+</div></div>
+
+
+<footer class="page-footer">
+    <div class="frame frame-ruler-before frame-background-dark">
+        <div class="frame-container">
+            <div class="frame-inner">
+                                <div class="footer-additional">
+                    <p class="text-center">Last rendered: May 09, 2026 09:03</p>
+                </div>
+                <div class="footer-meta">
+                    <ul class="footer-meta-navigation">
+                        <li><a href="https://typo3.org/legal-notice" rel="nofollow" target="_blank" title="Legal Notice">Legal Notice</a></li>
+                        <li><a href="https://typo3.org/privacy-policy" rel="nofollow" target="_blank" title="Privacy Policy">Privacy Policy</a></li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </div>
+</footer>
+<script src="_resources/js/popper.min.js"></script>
+<script src="_resources/js/bootstrap.min.js"></script>
+<script src="_resources/js/theme.min.js"></script>
+
+<!--
+ Locally rendered. No tracking embedded.
+-->
+</body>
+</html>

--- a/tests/Integration/tests/bignum/bignum-in-tabs/input/index.rst
+++ b/tests/Integration/tests/bignum/bignum-in-tabs/input/index.rst
@@ -1,0 +1,17 @@
+=========================================================
+Tabs containing rst-class sibling list (issue 1236)
+=========================================================
+
+The ``bignums-tip`` rst-class must apply to the ``<ol>`` and must NOT leak
+its own class name as text into the rendered tab pane.
+
+..  tabs::
+
+    ..  group-tab:: Extension Manager
+
+        ..  rst-class:: bignums-tip
+
+        #.  Switch to the module :guilabel:`System > Extensions`.
+        #.  Switch to :guilabel:`Get Extensions`.
+        #.  Search for the extension key :guilabel:`example_extension`.
+        #.  Import the extension from the repository.


### PR DESCRIPTION
## Summary

Bumps phpdocumentor monorepo subsplit packages so the `bignums-tip` text leak in tabs (#1236) is fixed:

- `phpdocumentor/guides` 1.9.6 → 1.10.1
- `phpdocumentor/guides-restructured-text` 1.9.6 → 1.10.1
- `phpdocumentor/guides-theme-bootstrap` 1.9.6 → 1.9.7
- `phpdocumentor/filesystem` 1.9.0 → 1.10.0

Resolves #1236.

## Why this fixes #1236

The `bignums-tip` rst-class leak inside tabs was caused by a dual-storage bug in `phpDocumentor\Guides\Bootstrap\Nodes\TabsNode`: tab children were kept in two parallel arrays (a private `$tabs` cache plus the `$value` array inherited from `CompoundNode`). The `ClassNodeTransformer` correctly removed orphan `ClassNode`s from `$value`, but the bootstrap-theme Twig template iterated the stale `$tabs` cache, which still referenced the pre-transform tab and emitted its `ClassNode`'s value (`bignums-tip`) as plain text.

The fix landed incidentally via [phpDocumentor/guides#1316 / 1bdb18c7](https://github.com/phpDocumentor/guides/commit/1bdb18c7), which moved the Tabs/Tab directives out of `guides-theme-bootstrap` into `guides-restructured-text`. The Bootstrap classes are now deprecation shims that delegate to `RestructuredText\Nodes\TabsNode`, whose `getTabs()` is derived from `getChildren()` — no stale cache, no leak.

## Why this couldn't be merged earlier

`guides-theme-bootstrap:1.9.7` declared `phpdocumentor/guides-restructured-text:^1.10 || ^2.0`, but no `1.10.x` of `guides-restructured-text` had been published on Packagist yet — the constraint was unresolvable for any consumer with the default `minimum-stability: stable`. I filed [phpDocumentor/guides#1341](https://github.com/phpDocumentor/guides/issues/1341); @jaapio tagged `1.10.1` on 2026-05-05 and the release is now installable.

## Test plan

- [x] `composer update phpdocumentor/*` resolves cleanly with the existing constraints in `composer.json` (no constraint changes needed)
- [x] `make test-integration` — 114 tests, 1140 assertions, OK (1 new test added)
- [x] `make test-unit` — 83 tests, 183 assertions, OK
- [x] `make test-xml` — all `guides.xml` fixtures validate
- [x] `make test-docs` — project docs render successfully
- [x] `make test-rendertest` — render test corpus renders successfully (incl. ru_RU, fr_FR, de_DE localizations)
- [x] `make phpstan` — `[OK] No errors`
- [x] Reproducer from #1236 rendered against upgraded packages — produces `<ol class="bignums-tip">` with no literal text leak
- [x] Same reproducer rendered against pre-upgrade packages — still leaks `bignums-tip` (regression test would catch it)

## New regression fixture

`tests/Integration/tests/bignum/bignum-in-tabs/` — mirrors the reproducer from #1236 (rst-class sibling to a list inside a `tabs::` directive) and asserts the rendered tab pane contains `<ol class="bignums-tip">` without leaking the literal class name as text. The fixture lives under `bignum/` rather than `tabs/` because the existing `tabs/` test harness already has a top-level `input/` directory and the data provider only recurses into directories without one.

## Downstream PHPStan fix included

[phpDocumentor/guides#1316](https://github.com/phpDocumentor/guides/pull/1316) made `phpDocumentor\Guides\Bootstrap\Nodes\AbstractTabNode` a `class_alias()` shim. The local `T3Docs\Typo3DocsTheme\Nodes\GroupTabNode` extends that class, and PHPStan can't follow runtime aliases — so the bump initially caused two `Quality` job failures (`return.type` and `staticMethod.notFound`).

Fix is a one-line import switch to the new home: `phpDocumentor\Guides\RestructuredText\Nodes\AbstractTabNode`. Runtime behaviour is identical (the alias makes the inheritance chain the same either way), and the deprecation notice the shim would otherwise emit on file load is silenced as a side effect.

## Related

- #1236 — the issue this PR resolves
- [phpDocumentor/guides#1316](https://github.com/phpDocumentor/guides/pull/1316) / [commit 1bdb18c7](https://github.com/phpDocumentor/guides/commit/1bdb18c7) — upstream move of Tabs/Tab into `guides-restructured-text` (the incidental fix)
- [phpDocumentor/guides#1341](https://github.com/phpDocumentor/guides/issues/1341) — packaging issue blocking the upgrade until 2026-05-08

A detailed per-PR review of all upstream changes between `1.9.6...1.10.1` (with risk assessment and pointers for deeper review) is in the [comment thread below](https://github.com/TYPO3-Documentation/render-guides/pull/1243#issuecomment-4412169222).

## Notes for review

- No `composer.json` constraint changes were required — the existing `^1.9.4` / `^1.9` / `^1.7` constraints all resolve to the new versions. The only code change is the one-line `GroupTabNode` import switch documented above.
- The bump pulls in `phpdocumentor/guides:1.10.1` (a minor) — the changes between 1.9.6 and 1.10.1 are dominated by the Tabs/Tab move (#1316) plus deprecation shims; full integration suite passes without changes to any other expected fixtures.