### PR TITLE
[TASK] Migrate HyperLinkNode/ReferenceNode constructor calls to array children form

### DIFF
--- a/packages/typo3-docs-theme/src/Compiler/NodeTransformers/RedirectsNodeTransformer.php
+++ b/packages/typo3-docs-theme/src/Compiler/NodeTransformers/RedirectsNodeTransformer.php
@@ -16,6 +16,7 @@ namespace T3Docs\Typo3DocsTheme\Compiler\NodeTransformers;
 use phpDocumentor\Guides\Compiler\CompilerContextInterface;
 use phpDocumentor\Guides\Compiler\NodeTransformer;
 use phpDocumentor\Guides\Nodes\Inline\CrossReferenceNode;
+use phpDocumentor\Guides\Nodes\Inline\PlainTextInlineNode;
 use phpDocumentor\Guides\Nodes\Inline\ReferenceNode;
 use phpDocumentor\Guides\Nodes\Node;
 use phpDocumentor\Guides\Nodes\PrefixedLinkTargetNode;
@@ -51,7 +52,8 @@ final class RedirectsNodeTransformer implements NodeTransformer
                 $prefix = $node->getPrefix();
             }
             assert(is_string($node->getValue()));
-            return new ReferenceNode('guide-' . $node->getTargetReference(), $node->getValue(), $node->getInterlinkDomain(), $node->getInterlinkGroup(), $prefix);
+            $value = $node->getValue();
+            return new ReferenceNode('guide-' . $node->getTargetReference(), $value === '' ? [] : [new PlainTextInlineNode($value)], $node->getInterlinkDomain(), $node->getInterlinkGroup(), $prefix);
         }
         return $node;
     }

--- a/packages/typo3-docs-theme/src/Compiler/NodeTransformers/RedirectsNodeTransformer.php
+++ b/packages/typo3-docs-theme/src/Compiler/NodeTransformers/RedirectsNodeTransformer.php
@@ -16,8 +16,8 @@ namespace T3Docs\Typo3DocsTheme\Compiler\NodeTransformers;
 use phpDocumentor\Guides\Compiler\CompilerContextInterface;
 use phpDocumentor\Guides\Compiler\NodeTransformer;
 use phpDocumentor\Guides\Nodes\Inline\CrossReferenceNode;
-use phpDocumentor\Guides\Nodes\Inline\PlainTextInlineNode;
 use phpDocumentor\Guides\Nodes\Inline\ReferenceNode;
+use phpDocumentor\Guides\Nodes\InlineCompoundNode;
 use phpDocumentor\Guides\Nodes\Node;
 use phpDocumentor\Guides\Nodes\PrefixedLinkTargetNode;
 use T3Docs\Typo3DocsTheme\Inventory\Typo3VersionService;
@@ -51,9 +51,8 @@ final class RedirectsNodeTransformer implements NodeTransformer
             if ($node instanceof PrefixedLinkTargetNode) {
                 $prefix = $node->getPrefix();
             }
-            assert(is_string($node->getValue()));
-            $value = $node->getValue();
-            return new ReferenceNode('guide-' . $node->getTargetReference(), $value === '' ? [] : [new PlainTextInlineNode($value)], $node->getInterlinkDomain(), $node->getInterlinkGroup(), $prefix);
+            assert($node instanceof InlineCompoundNode);
+            return new ReferenceNode('guide-' . $node->getTargetReference(), $node->getChildren(), $node->getInterlinkDomain(), $node->getInterlinkGroup(), $prefix);
         }
         return $node;
     }

--- a/packages/typo3-docs-theme/src/Compiler/NodeTransformers/RemoveInterlinkSelfReferencesFromCrossReferenceNodeTransformer.php
+++ b/packages/typo3-docs-theme/src/Compiler/NodeTransformers/RemoveInterlinkSelfReferencesFromCrossReferenceNodeTransformer.php
@@ -17,7 +17,6 @@ use phpDocumentor\Guides\Compiler\CompilerContextInterface;
 use phpDocumentor\Guides\Compiler\NodeTransformer;
 use phpDocumentor\Guides\Nodes\Inline\CrossReferenceNode;
 use phpDocumentor\Guides\Nodes\Inline\DocReferenceNode;
-use phpDocumentor\Guides\Nodes\Inline\PlainTextInlineNode;
 use phpDocumentor\Guides\Nodes\Inline\ReferenceNode;
 use phpDocumentor\Guides\Nodes\Node;
 use T3Docs\Typo3DocsTheme\Settings\Typo3DocsThemeSettings;
@@ -48,10 +47,9 @@ final class RemoveInterlinkSelfReferencesFromCrossReferenceNodeTransformer imple
         }
         // Remove interlink references to the own current document
         if ($node instanceof ReferenceNode) {
-            $value = $node->getValue();
             $newRef = new ReferenceNode(
                 $node->getTargetReference(),
-                $value === '' ? [] : [new PlainTextInlineNode($value)],
+                $node->getChildren(),
                 '',
                 $node->getLinkType(),
                 $node->getPrefix()
@@ -61,7 +59,7 @@ final class RemoveInterlinkSelfReferencesFromCrossReferenceNodeTransformer imple
         if ($node instanceof DocReferenceNode) {
             $newDocRef = new DocReferenceNode(
                 $node->getTargetReference(),
-                $node->getValue(),
+                $node->getChildren(),
             );
             return $newDocRef;
         }

--- a/packages/typo3-docs-theme/src/Compiler/NodeTransformers/RemoveInterlinkSelfReferencesFromCrossReferenceNodeTransformer.php
+++ b/packages/typo3-docs-theme/src/Compiler/NodeTransformers/RemoveInterlinkSelfReferencesFromCrossReferenceNodeTransformer.php
@@ -17,6 +17,7 @@ use phpDocumentor\Guides\Compiler\CompilerContextInterface;
 use phpDocumentor\Guides\Compiler\NodeTransformer;
 use phpDocumentor\Guides\Nodes\Inline\CrossReferenceNode;
 use phpDocumentor\Guides\Nodes\Inline\DocReferenceNode;
+use phpDocumentor\Guides\Nodes\Inline\PlainTextInlineNode;
 use phpDocumentor\Guides\Nodes\Inline\ReferenceNode;
 use phpDocumentor\Guides\Nodes\Node;
 use T3Docs\Typo3DocsTheme\Settings\Typo3DocsThemeSettings;
@@ -47,9 +48,10 @@ final class RemoveInterlinkSelfReferencesFromCrossReferenceNodeTransformer imple
         }
         // Remove interlink references to the own current document
         if ($node instanceof ReferenceNode) {
+            $value = $node->getValue();
             $newRef = new ReferenceNode(
                 $node->getTargetReference(),
-                $node->getValue(),
+                $value === '' ? [] : [new PlainTextInlineNode($value)],
                 '',
                 $node->getLinkType(),
                 $node->getPrefix()

--- a/packages/typo3-docs-theme/src/Compiler/NodeTransformers/ReplacePermalinksNodeTransformer.php
+++ b/packages/typo3-docs-theme/src/Compiler/NodeTransformers/ReplacePermalinksNodeTransformer.php
@@ -16,6 +16,7 @@ namespace T3Docs\Typo3DocsTheme\Compiler\NodeTransformers;
 use phpDocumentor\Guides\Compiler\CompilerContextInterface;
 use phpDocumentor\Guides\Compiler\NodeTransformer;
 use phpDocumentor\Guides\Nodes\Inline\HyperLinkNode;
+use phpDocumentor\Guides\Nodes\Inline\PlainTextInlineNode;
 use phpDocumentor\Guides\Nodes\Inline\ReferenceNode;
 use phpDocumentor\Guides\Nodes\Node;
 
@@ -54,7 +55,7 @@ final class ReplacePermalinksNodeTransformer implements NodeTransformer
         if ($version !== null && $interlink !== null) {
             $interlink = $interlink . '/' . $version;
         }
-        $node = new ReferenceNode($url, $value, $interlink ?? '');
+        $node = new ReferenceNode($url, $value === '' ? [] : [new PlainTextInlineNode($value)], $interlink ?? '');
         return $node;
     }
 

--- a/packages/typo3-docs-theme/src/Compiler/NodeTransformers/ReplacePermalinksNodeTransformer.php
+++ b/packages/typo3-docs-theme/src/Compiler/NodeTransformers/ReplacePermalinksNodeTransformer.php
@@ -16,7 +16,6 @@ namespace T3Docs\Typo3DocsTheme\Compiler\NodeTransformers;
 use phpDocumentor\Guides\Compiler\CompilerContextInterface;
 use phpDocumentor\Guides\Compiler\NodeTransformer;
 use phpDocumentor\Guides\Nodes\Inline\HyperLinkNode;
-use phpDocumentor\Guides\Nodes\Inline\PlainTextInlineNode;
 use phpDocumentor\Guides\Nodes\Inline\ReferenceNode;
 use phpDocumentor\Guides\Nodes\Node;
 
@@ -39,10 +38,9 @@ final class ReplacePermalinksNodeTransformer implements NodeTransformer
         if (!str_starts_with($node->getTargetReference(), 'https://docs.typo3.org/permalink/')) {
             return $node;
         }
-        $value = $node->getValue();
-        if ($value === $node->getTargetReference()) {
-            $value = '';
-        }
+        // When the link's visible label equals its URL (auto-linkified plain URL),
+        // drop the children so the resolver fills in the canonical title.
+        $children = $node->toString() === $node->getTargetReference() ? [] : $node->getChildren();
         $url = str_replace('https://docs.typo3.org/permalink/', '', ($node->getTargetReference()));
         $version = null;
         $interlink = null;
@@ -55,7 +53,7 @@ final class ReplacePermalinksNodeTransformer implements NodeTransformer
         if ($version !== null && $interlink !== null) {
             $interlink = $interlink . '/' . $version;
         }
-        $node = new ReferenceNode($url, $value === '' ? [] : [new PlainTextInlineNode($value)], $interlink ?? '');
+        $node = new ReferenceNode($url, $children, $interlink ?? '');
         return $node;
     }
 

--- a/packages/typo3-docs-theme/src/Nodes/Inline/FileInlineNode.php
+++ b/packages/typo3-docs-theme/src/Nodes/Inline/FileInlineNode.php
@@ -18,7 +18,7 @@ final class FileInlineNode extends AbstractLinkInlineNode implements CrossRefere
         private string $interlinkDomain,
         private string $linkType
     ) {
-        parent::__construct(self::TYPE, $fileLink, $fileLabel, [new PlainTextInlineNode($fileLabel)]);
+        parent::__construct(self::TYPE, $fileLink, [new PlainTextInlineNode($fileLabel)]);
     }
 
     public function getFileLink(): string

--- a/packages/typo3-docs-theme/src/TextRoles/ApiClassTextRole.php
+++ b/packages/typo3-docs-theme/src/TextRoles/ApiClassTextRole.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace T3Docs\Typo3DocsTheme\TextRoles;
 
 use phpDocumentor\Guides\Nodes\Inline\AbstractLinkInlineNode;
+use phpDocumentor\Guides\Nodes\Inline\PlainTextInlineNode;
 use phpDocumentor\Guides\Nodes\Inline\ReferenceNode;
 use phpDocumentor\Guides\ReferenceResolvers\AnchorNormalizer;
 use phpDocumentor\Guides\RestructuredText\Parser\Interlink\InterlinkParser;
@@ -54,6 +55,7 @@ final class ApiClassTextRole extends AbstractReferenceTextRole
             $interlink = 'api';
         }
 
-        return new ReferenceNode($reference, $referenceName ?? '', $interlink, self::TYPE, $prefix);
+        $label = $referenceName ?? '';
+        return new ReferenceNode($reference, $label === '' ? [] : [new PlainTextInlineNode($label)], $interlink, self::TYPE, $prefix);
     }
 }

--- a/packages/typo3-docs-theme/src/TextRoles/ApiClassTextRole.php
+++ b/packages/typo3-docs-theme/src/TextRoles/ApiClassTextRole.php
@@ -55,7 +55,6 @@ final class ApiClassTextRole extends AbstractReferenceTextRole
             $interlink = 'api';
         }
 
-        $label = $referenceName ?? '';
-        return new ReferenceNode($reference, $label === '' ? [] : [new PlainTextInlineNode($label)], $interlink, self::TYPE, $prefix);
+        return new ReferenceNode($reference, $referenceName ? [new PlainTextInlineNode($referenceName)] : [], $interlink, self::TYPE, $prefix);
     }
 }

--- a/packages/typo3-docs-theme/src/TextRoles/CustomLinkTextRole.php
+++ b/packages/typo3-docs-theme/src/TextRoles/CustomLinkTextRole.php
@@ -57,8 +57,7 @@ abstract class CustomLinkTextRole implements TextRole
             $id = $this->anchorReducer->reduceAnchor($referenceTarget);
         }
 
-        $label = $referenceName ?? '';
-        return new ReferenceNode($id, $label === '' ? [] : [new PlainTextInlineNode($label)], $interlinkDomain, 'php:' . $this->getName());
+        return new ReferenceNode($id, $referenceName ? [new PlainTextInlineNode($referenceName)] : [], $interlinkDomain, 'php:' . $this->getName());
     }
 
     /** @return array{text:?string,uri:string} */

--- a/packages/typo3-docs-theme/src/TextRoles/CustomLinkTextRole.php
+++ b/packages/typo3-docs-theme/src/TextRoles/CustomLinkTextRole.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace T3Docs\Typo3DocsTheme\TextRoles;
 
 use phpDocumentor\Guides\Nodes\Inline\AbstractLinkInlineNode;
+use phpDocumentor\Guides\Nodes\Inline\PlainTextInlineNode;
 use phpDocumentor\Guides\Nodes\Inline\ReferenceNode;
 use phpDocumentor\Guides\ReferenceResolvers\AnchorNormalizer;
 use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
@@ -56,7 +57,8 @@ abstract class CustomLinkTextRole implements TextRole
             $id = $this->anchorReducer->reduceAnchor($referenceTarget);
         }
 
-        return new ReferenceNode($id, $referenceName ?? '', $interlinkDomain, 'php:' . $this->getName());
+        $label = $referenceName ?? '';
+        return new ReferenceNode($id, $label === '' ? [] : [new PlainTextInlineNode($label)], $interlinkDomain, 'php:' . $this->getName());
     }
 
     /** @return array{text:?string,uri:string} */

--- a/packages/typo3-docs-theme/src/TextRoles/FileTextRole.php
+++ b/packages/typo3-docs-theme/src/TextRoles/FileTextRole.php
@@ -20,11 +20,11 @@ final class FileTextRole extends CustomLinkTextRole
 
     protected function createNode(DocumentParserContext $documentParserContext, string $referenceTarget, string|null $referenceName, string $role): AbstractLinkInlineNode
     {
-        return $this->createNodeWithInterlink($documentParserContext, $referenceTarget, '', $referenceName);
+        return $this->createNodeWithInterlink($documentParserContext, $referenceTarget, '', $referenceName ?? $referenceTarget);
     }
 
-    private function createNodeWithInterlink(DocumentParserContext $documentParserContext, string $referenceTarget, string $interlinkDomain, string|null $referenceName): AbstractLinkInlineNode
+    private function createNodeWithInterlink(DocumentParserContext $documentParserContext, string $referenceTarget, string $interlinkDomain, string $fileLabel): AbstractLinkInlineNode
     {
-        return new FileInlineNode($referenceTarget, $referenceName ?? $referenceTarget, $interlinkDomain, 'typo3:file');
+        return new FileInlineNode($referenceTarget, $fileLabel, $interlinkDomain, 'typo3:file');
     }
 }

--- a/packages/typo3-docs-theme/src/TextRoles/IssueReferenceTextRole.php
+++ b/packages/typo3-docs-theme/src/TextRoles/IssueReferenceTextRole.php
@@ -6,6 +6,7 @@ namespace T3Docs\Typo3DocsTheme\TextRoles;
 
 use phpDocumentor\Guides\Nodes\Inline\AbstractLinkInlineNode;
 use phpDocumentor\Guides\Nodes\Inline\HyperLinkNode;
+use phpDocumentor\Guides\Nodes\Inline\PlainTextInlineNode;
 use phpDocumentor\Guides\RestructuredText\TextRoles\AbstractReferenceTextRole;
 use Psr\Log\LoggerInterface;
 
@@ -37,8 +38,10 @@ final class IssueReferenceTextRole extends AbstractReferenceTextRole
     {
         if ((int)$referenceTarget <= 0) {
             $this->logger->warning(sprintf('Expected a positive integer as issue number. Found %s', $referenceTarget));
-            return new HyperLinkNode($referenceName ?? 'Forge', self::FORGE_URL);
+            $label = $referenceName ?? 'Forge';
+            return new HyperLinkNode($label === '' ? [] : [new PlainTextInlineNode($label)], self::FORGE_URL);
         }
-        return new HyperLinkNode($referenceName ?? sprintf(self::FORGE_DEFAULT_LABEL, $referenceTarget), sprintf(self::FORGE_ISSUE_URL, $referenceTarget));
+        $label = $referenceName ?? sprintf(self::FORGE_DEFAULT_LABEL, $referenceTarget);
+        return new HyperLinkNode($label === '' ? [] : [new PlainTextInlineNode($label)], sprintf(self::FORGE_ISSUE_URL, $referenceTarget));
     }
 }

--- a/packages/typo3-docs-theme/src/TextRoles/IssueReferenceTextRole.php
+++ b/packages/typo3-docs-theme/src/TextRoles/IssueReferenceTextRole.php
@@ -39,9 +39,9 @@ final class IssueReferenceTextRole extends AbstractReferenceTextRole
         if ((int)$referenceTarget <= 0) {
             $this->logger->warning(sprintf('Expected a positive integer as issue number. Found %s', $referenceTarget));
             $label = $referenceName ?? 'Forge';
-            return new HyperLinkNode($label === '' ? [] : [new PlainTextInlineNode($label)], self::FORGE_URL);
+            return new HyperLinkNode([new PlainTextInlineNode($label)], self::FORGE_URL);
         }
         $label = $referenceName ?? sprintf(self::FORGE_DEFAULT_LABEL, $referenceTarget);
-        return new HyperLinkNode($label === '' ? [] : [new PlainTextInlineNode($label)], sprintf(self::FORGE_ISSUE_URL, $referenceTarget));
+        return new HyperLinkNode([new PlainTextInlineNode($label)], sprintf(self::FORGE_ISSUE_URL, $referenceTarget));
     }
 }

--- a/packages/typo3-docs-theme/src/TextRoles/T3extTextRole.php
+++ b/packages/typo3-docs-theme/src/TextRoles/T3extTextRole.php
@@ -3,6 +3,7 @@
 namespace T3Docs\Typo3DocsTheme\TextRoles;
 
 use phpDocumentor\Guides\Nodes\Inline\HyperLinkNode;
+use phpDocumentor\Guides\Nodes\Inline\PlainTextInlineNode;
 use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
 use phpDocumentor\Guides\RestructuredText\Parser\References\EmbeddedReferenceParser;
 use phpDocumentor\Guides\RestructuredText\TextRoles\TextRole;
@@ -46,6 +47,6 @@ final class T3extTextRole implements TextRole
         }
         $terLink = sprintf('https://extensions.typo3.org/extension/%s', $extKey);
         $extName = $referenceName ?? 'EXT:' . $extKey;
-        return new HyperLinkNode($extName, $terLink);
+        return new HyperLinkNode($extName === '' ? [] : [new PlainTextInlineNode($extName)], $terLink);
     }
 }

--- a/packages/typo3-docs-theme/src/TextRoles/T3extTextRole.php
+++ b/packages/typo3-docs-theme/src/TextRoles/T3extTextRole.php
@@ -47,6 +47,6 @@ final class T3extTextRole implements TextRole
         }
         $terLink = sprintf('https://extensions.typo3.org/extension/%s', $extKey);
         $extName = $referenceName ?? 'EXT:' . $extKey;
-        return new HyperLinkNode($extName === '' ? [] : [new PlainTextInlineNode($extName)], $terLink);
+        return new HyperLinkNode([new PlainTextInlineNode($extName)], $terLink);
     }
 }

--- a/packages/typo3-docs-theme/src/TextRoles/T3srcTextRole.php
+++ b/packages/typo3-docs-theme/src/TextRoles/T3srcTextRole.php
@@ -3,6 +3,7 @@
 namespace T3Docs\Typo3DocsTheme\TextRoles;
 
 use phpDocumentor\Guides\Nodes\Inline\HyperLinkNode;
+use phpDocumentor\Guides\Nodes\Inline\PlainTextInlineNode;
 use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
 use phpDocumentor\Guides\RestructuredText\Parser\References\EmbeddedReferenceParser;
 use phpDocumentor\Guides\RestructuredText\TextRoles\TextRole;
@@ -55,6 +56,6 @@ final class T3srcTextRole implements TextRole
         }
         $gitHubLink = sprintf('https://github.com/typo3/typo3/blob/%s/%s', $typo3Version, $fileLink);
         $fileName = $referenceName ?? str_replace('typo3/sysext/', 'EXT:', $fileLink) . ' (GitHub)';
-        return new HyperLinkNode($fileName, $gitHubLink);
+        return new HyperLinkNode($fileName === '' ? [] : [new PlainTextInlineNode($fileName)], $gitHubLink);
     }
 }

--- a/packages/typo3-docs-theme/src/TextRoles/T3srcTextRole.php
+++ b/packages/typo3-docs-theme/src/TextRoles/T3srcTextRole.php
@@ -56,6 +56,6 @@ final class T3srcTextRole implements TextRole
         }
         $gitHubLink = sprintf('https://github.com/typo3/typo3/blob/%s/%s', $typo3Version, $fileLink);
         $fileName = $referenceName ?? str_replace('typo3/sysext/', 'EXT:', $fileLink) . ' (GitHub)';
-        return new HyperLinkNode($fileName === '' ? [] : [new PlainTextInlineNode($fileName)], $gitHubLink);
+        return new HyperLinkNode([new PlainTextInlineNode($fileName)], $gitHubLink);
     }
 }

--- a/packages/typo3-docs-theme/src/TextRoles/ViewhelperArgumentTextRole.php
+++ b/packages/typo3-docs-theme/src/TextRoles/ViewhelperArgumentTextRole.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace T3Docs\Typo3DocsTheme\TextRoles;
 
+use phpDocumentor\Guides\Nodes\Inline\InlineNodeInterface;
 use phpDocumentor\Guides\Nodes\Inline\PlainTextInlineNode;
 use phpDocumentor\Guides\Nodes\Inline\ReferenceNode;
 use phpDocumentor\Guides\ReferenceResolvers\AnchorNormalizer;
@@ -22,17 +23,19 @@ final class ViewhelperArgumentTextRole extends CustomLinkTextRole
 
     protected function createNode(DocumentParserContext $documentParserContext, string $referenceTarget, string|null $referenceName, string $role): ReferenceNode
     {
+        $children = $referenceName ? [new PlainTextInlineNode($referenceName)] : [];
         if (preg_match(self::INTERLINK_NAME_REGEX, $referenceTarget, $matches)) {
-            return $this->createNodeWithInterlink($documentParserContext, $matches[2], $matches[1], $referenceName);
+            return $this->createNodeWithInterlink($documentParserContext, $matches[2], $matches[1], $children);
         }
-        return $this->createNodeWithInterlink($documentParserContext, $referenceTarget, '', $referenceName);
+        return $this->createNodeWithInterlink($documentParserContext, $referenceTarget, '', $children);
     }
 
-    private function createNodeWithInterlink(DocumentParserContext $documentParserContext, string $referenceTarget, string $interlinkDomain, string|null $referenceName): ReferenceNode
+    /** @param list<InlineNodeInterface> $children */
+    private function createNodeWithInterlink(DocumentParserContext $documentParserContext, string $referenceTarget, string $interlinkDomain, array $children): ReferenceNode
     {
         $id = $this->anchorNormalizer->reduceAnchor($referenceTarget);
 
-        return new ReferenceNode($id, $referenceName ? [new PlainTextInlineNode($referenceName)] : [], $interlinkDomain, 'typo3:' . $this->getName());
+        return new ReferenceNode($id, $children, $interlinkDomain, 'typo3:' . $this->getName());
     }
 
     public function getName(): string

--- a/packages/typo3-docs-theme/src/TextRoles/ViewhelperArgumentTextRole.php
+++ b/packages/typo3-docs-theme/src/TextRoles/ViewhelperArgumentTextRole.php
@@ -32,8 +32,7 @@ final class ViewhelperArgumentTextRole extends CustomLinkTextRole
     {
         $id = $this->anchorNormalizer->reduceAnchor($referenceTarget);
 
-        $label = $referenceName ?? '';
-        return new ReferenceNode($id, $label === '' ? [] : [new PlainTextInlineNode($label)], $interlinkDomain, 'typo3:' . $this->getName());
+        return new ReferenceNode($id, $referenceName ? [new PlainTextInlineNode($referenceName)] : [], $interlinkDomain, 'typo3:' . $this->getName());
     }
 
     public function getName(): string

--- a/packages/typo3-docs-theme/src/TextRoles/ViewhelperArgumentTextRole.php
+++ b/packages/typo3-docs-theme/src/TextRoles/ViewhelperArgumentTextRole.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace T3Docs\Typo3DocsTheme\TextRoles;
 
+use phpDocumentor\Guides\Nodes\Inline\PlainTextInlineNode;
 use phpDocumentor\Guides\Nodes\Inline\ReferenceNode;
 use phpDocumentor\Guides\ReferenceResolvers\AnchorNormalizer;
 use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
@@ -31,7 +32,8 @@ final class ViewhelperArgumentTextRole extends CustomLinkTextRole
     {
         $id = $this->anchorNormalizer->reduceAnchor($referenceTarget);
 
-        return new ReferenceNode($id, $referenceName ?? '', $interlinkDomain, 'typo3:' . $this->getName());
+        $label = $referenceName ?? '';
+        return new ReferenceNode($id, $label === '' ? [] : [new PlainTextInlineNode($label)], $interlinkDomain, 'typo3:' . $this->getName());
     }
 
     public function getName(): string

--- a/packages/typo3-docs-theme/src/TextRoles/ViewhelperTextRole.php
+++ b/packages/typo3-docs-theme/src/TextRoles/ViewhelperTextRole.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace T3Docs\Typo3DocsTheme\TextRoles;
 
+use phpDocumentor\Guides\Nodes\Inline\InlineNodeInterface;
 use phpDocumentor\Guides\Nodes\Inline\PlainTextInlineNode;
 use phpDocumentor\Guides\Nodes\Inline\ReferenceNode;
 use phpDocumentor\Guides\ReferenceResolvers\AnchorNormalizer;
@@ -26,17 +27,19 @@ final class ViewhelperTextRole extends CustomLinkTextRole
 
     protected function createNode(DocumentParserContext $documentParserContext, string $referenceTarget, string|null $referenceName, string $role): ReferenceNode
     {
+        $children = $referenceName ? [new PlainTextInlineNode($referenceName)] : [];
         if (preg_match(self::INTERLINK_NAME_REGEX, $referenceTarget, $matches)) {
-            return $this->createNodeWithInterlink($documentParserContext, $matches[2], $matches[1], $referenceName);
+            return $this->createNodeWithInterlink($documentParserContext, $matches[2], $matches[1], $children);
         }
-        return $this->createNodeWithInterlink($documentParserContext, $referenceTarget, '', $referenceName);
+        return $this->createNodeWithInterlink($documentParserContext, $referenceTarget, '', $children);
     }
 
-    private function createNodeWithInterlink(DocumentParserContext $documentParserContext, string $referenceTarget, string $interlinkDomain, string|null $referenceName): ReferenceNode
+    /** @param list<InlineNodeInterface> $children */
+    private function createNodeWithInterlink(DocumentParserContext $documentParserContext, string $referenceTarget, string $interlinkDomain, array $children): ReferenceNode
     {
         $id = $this->anchorNormalizer->reduceAnchor($referenceTarget);
 
-        return new ReferenceNode($id, $referenceName ? [new PlainTextInlineNode($referenceName)] : [], $interlinkDomain, 'typo3:' . $this->getName());
+        return new ReferenceNode($id, $children, $interlinkDomain, 'typo3:' . $this->getName());
     }
 
     public function getName(): string

--- a/packages/typo3-docs-theme/src/TextRoles/ViewhelperTextRole.php
+++ b/packages/typo3-docs-theme/src/TextRoles/ViewhelperTextRole.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace T3Docs\Typo3DocsTheme\TextRoles;
 
+use phpDocumentor\Guides\Nodes\Inline\PlainTextInlineNode;
 use phpDocumentor\Guides\Nodes\Inline\ReferenceNode;
 use phpDocumentor\Guides\ReferenceResolvers\AnchorNormalizer;
 use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
@@ -35,7 +36,8 @@ final class ViewhelperTextRole extends CustomLinkTextRole
     {
         $id = $this->anchorNormalizer->reduceAnchor($referenceTarget);
 
-        return new ReferenceNode($id, $referenceName ?? '', $interlinkDomain, 'typo3:' . $this->getName());
+        $label = $referenceName ?? '';
+        return new ReferenceNode($id, $label === '' ? [] : [new PlainTextInlineNode($label)], $interlinkDomain, 'typo3:' . $this->getName());
     }
 
     public function getName(): string

--- a/packages/typo3-docs-theme/src/TextRoles/ViewhelperTextRole.php
+++ b/packages/typo3-docs-theme/src/TextRoles/ViewhelperTextRole.php
@@ -36,8 +36,7 @@ final class ViewhelperTextRole extends CustomLinkTextRole
     {
         $id = $this->anchorNormalizer->reduceAnchor($referenceTarget);
 
-        $label = $referenceName ?? '';
-        return new ReferenceNode($id, $label === '' ? [] : [new PlainTextInlineNode($label)], $interlinkDomain, 'typo3:' . $this->getName());
+        return new ReferenceNode($id, $referenceName ? [new PlainTextInlineNode($referenceName)] : [], $interlinkDomain, 'typo3:' . $this->getName());
     }
 
     public function getName(): string

--- a/packages/typo3-docs-theme/tests/unit/Inventory/Typo3InventoryRepositoryTest.php
+++ b/packages/typo3-docs-theme/tests/unit/Inventory/Typo3InventoryRepositoryTest.php
@@ -82,7 +82,7 @@ final class Typo3InventoryRepositoryTest extends TestCase
     public function versionInventoryCreatesVersionedUrl(string $inventoryKey, string $expected): void
     {
         $messages = new Messages();
-        $node = new ReferenceNode('someReference', '', $inventoryKey);
+        $node = new ReferenceNode('someReference', [], $inventoryKey);
         self::assertEquals($expected, $this->subject->previewUrl($inventoryKey));
         self::assertCount(0, $messages->getWarnings());
     }


### PR DESCRIPTION
## Summary

Upstream [phpDocumentor/guides#1161](https://github.com/phpDocumentor/guides/issues/1161) deprecated the string-form first argument of `HyperLinkNode::__construct()` and the string-form second argument of `ReferenceNode::__construct()` in favor of an array of `InlineNodeInterface` instances. The BC bridge still works but emits a `Doctrine\Deprecations` trigger on every call. Pre-existing tech debt — not introduced by any recent bump.

This PR removes every deprecated call site (constructor + `BCInlineNodeBehavior::getValue()`) in the theme, then carries the upstream data model (children as `list<InlineNodeInterface>`) through the local code so private helpers and node ctors stop passing flat strings around. Independent of #1243 — branched from `origin/main`.

## Commits

1. **[`665aa4b6`](https://github.com/TYPO3-Documentation/render-guides/pull/1244/commits/665aa4b678f53d9638f2c4e4be67003c1db901b5) Mechanical migration to array-form constructors.** Each call site passes either `[]` or `[new PlainTextInlineNode($value)]` — mirroring the BC bridge's internal wrapping. Behavior-preserving.

2. **[`233d9004`](https://github.com/TYPO3-Documentation/render-guides/pull/1244/commits/233d900439a91f97cea5b88a6ab74de44d24e15a) Adopt upstream style + `getChildren()` passthrough.**
   - **TextRoles:** switch to upstream's compact truthy form `$x ? [new PlainTextInlineNode($x)] : []` (as in upstream `ReferenceTextRole`, `ApiClassTextRole`, `ReferenceRule`, Markdown `LinkParser`). Where the source has a guaranteed-non-empty fallback, the ternary is dropped entirely.
   - **NodeTransformers:** stop calling deprecated `BCInlineNodeBehavior::getValue()` to flatten an inline tree just to rewrap it. Pass `$node->getChildren()` through directly. Bit-identical for plain-text content (entire TYPO3 corpus); preserves inline structure (emphasis, code, nested refs) for any future content. Removes the **last remaining `BCInlineNodeBehavior::getValue()` call sites** in the codebase.

3. **[`b4f2ba88`](https://github.com/TYPO3-Documentation/render-guides/pull/1244/commits/b4f2ba88bf4804958562d96cf208e4235df7977b) Push the children-array form through private helpers and `FileInlineNode`'s parent ctor.**
   - **Three TextRoles** (`ViewhelperTextRole`, `ViewhelperArgumentTextRole`, `FileTextRole`) had private `createNodeWithInterlink` helpers that still took `string|null $referenceName` and did the wrap-as-`PlainTextInlineNode` dance internally. Wrap once at the upstream-imposed `createNode` boundary instead, so the private helpers operate on the upstream data model directly (`array $children` typed `list<InlineNodeInterface>` for the two Viewhelper roles; non-nullable `string $fileLabel` for `FileTextRole`, since `FileInlineNode`'s public surface is intentionally out of scope).
   - **`FileInlineNode::__construct`** silenced a hidden #1161 deprecation trigger: it called the 4-arg BC form `parent::__construct(type, ref, string, array)` — the BC bridge sees a string as 3rd positional and fires the deprecation regardless of the array as 4th positional. Switch to the 3-arg form `(type, ref, array)`.

## Test plan

All run locally with `PHP_BIN=php` on host PHP 8.5 after each commit:

- [x] `make phpstan` → `[OK] No errors`
- [x] `make test-unit` → `OK (83 tests, 183 assertions)`
- [x] `make test-integration` → `Tests: 113, Assertions: 1131, Deprecations: 3, Skipped: 2` (the 3 deprecations are pre-existing PHP 8.5 `curl_close` warnings in vendor code, identical to `origin/main`)
- [x] `make test-rendertest` → completed, no fixture diffs (53 + 35 + 4 + 4 SINGLEPAGE files)
- [x] `make test-docs` → completed (14 SINGLEPAGE files)

No expected-fixture HTML changed across any of the three commits, confirming the migration is behavior-preserving.
