### PR TITLE
Auto-rebuild & auto-merge theme-asset Dependabot PRs (+ verify check)

### DIFF
--- a/.github/workflows/check-built-assets.yaml
+++ b/.github/workflows/check-built-assets.yaml
@@ -1,0 +1,116 @@
+# Contract workflow: fail a PR whose committed theme assets diverge from a
+# fresh build.
+#
+# This is the actual gate — mark it as a required status check in branch
+# protection. It runs on EVERY pull request (no paths filter) so that the
+# required check always reports a status: a required check that is skipped by
+# a paths filter never reports on unrelated PRs, which leaves them blocked
+# forever ("Expected — waiting for status"). PRs that don't touch the theme
+# package short-circuit to success without building.
+#
+# The companion dependabot-rebuild-assets.yaml is the convenience layer that
+# keeps Dependabot PRs from tripping this check.
+
+name: "Check built assets"
+
+on: # yamllint disable-line rule:truthy
+  pull_request:
+
+permissions: {}
+
+jobs:
+  verify:
+    name: "verify"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: "Harden runner"
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: block
+          disable-sudo: true
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
+            registry.npmjs.org:443
+
+      - name: "Checkout"
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      # Skip the (relatively expensive) build for PRs that don't touch the
+      # theme package. The job still completes successfully, so the required
+      # "verify" status is reported on every PR.
+      - name: "Detect theme-package changes"
+        id: scope
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          if git diff --name-only "$BASE_SHA" HEAD -- packages/typo3-docs-theme/ | grep -q .; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No changes under packages/typo3-docs-theme/ — asset check not applicable."
+          fi
+
+      - name: "Install Node"
+        if: steps.scope.outputs.changed == 'true'
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: "packages/typo3-docs-theme/package.json"
+          cache: "npm"
+          cache-dependency-path: "packages/typo3-docs-theme/package-lock.json"
+
+      - name: "Install npm dependencies (no install scripts)"
+        if: steps.scope.outputs.changed == 'true'
+        working-directory: packages/typo3-docs-theme
+        run: "npm ci --ignore-scripts"
+
+      - name: "Build assets"
+        if: steps.scope.outputs.changed == 'true'
+        working-directory: packages/typo3-docs-theme
+        run: "npm run build"
+
+      - name: "Fail if generated assets differ from committed output"
+        if: steps.scope.outputs.changed == 'true'
+        run: |
+          ASSET_PATHS=(
+            packages/typo3-docs-theme/assets
+            packages/typo3-docs-theme/resources/public
+          )
+
+          # Two failure modes to detect:
+          #   1. Tracked files changed (git diff)
+          #   2. New untracked files were generated under the asset trees
+          #      (git diff alone would miss these)
+          modified="$(git diff --name-only -- "${ASSET_PATHS[@]}")"
+          untracked="$(git ls-files --others --exclude-standard -- "${ASSET_PATHS[@]}")"
+
+          if [ -z "$modified" ] && [ -z "$untracked" ]; then
+            exit 0
+          fi
+
+          # Full diagnostics go to the log; the ::error:: annotation is a
+          # single concise line so the PR Files-changed view doesn't get
+          # cluttered with one annotation per echo.
+          echo "Files out of sync with current build:"
+          if [ -n "$modified" ]; then
+            printf '%s\n' "$modified" | sed 's/^/  modified: /'
+          fi
+          if [ -n "$untracked" ]; then
+            printf '%s\n' "$untracked" | sed 's/^/  untracked: /'
+          fi
+          echo ""
+          echo "Reproduce locally:"
+          echo "  cd packages/typo3-docs-theme && npm ci && npm run build"
+          echo "  git add assets resources/public && git commit"
+          echo ""
+          echo "See Documentation/Developer/ThemeCustomization.rst for context."
+          echo "::error::Generated assets are out of date. Run 'npm ci && npm run build' in packages/typo3-docs-theme/ and commit the regenerated assets. See run log for affected files."
+          exit 1

--- a/.github/workflows/check-built-assets.yaml
+++ b/.github/workflows/check-built-assets.yaml
@@ -8,6 +8,15 @@
 # forever ("Expected — waiting for status"). PRs that don't touch the theme
 # package short-circuit to success without building.
 #
+# The push trigger is not redundant with the pull_request one: security
+# advisory fixes are merged out of a temporary private fork and arrive on
+# "main" as direct commits without ever being a pull request here, so the
+# pull_request trigger alone cannot see them. That is how the 0.40.0 assets
+# came to be published without the fixes they were tagged for.
+#
+# merge_group is required because "main" uses a merge queue: without it,
+# queued merges never receive this required status check and time out.
+#
 # The companion dependabot-rebuild-assets.yaml is the convenience layer that
 # keeps Dependabot PRs from tripping this check.
 
@@ -15,6 +24,10 @@ name: "Check built assets"
 
 on: # yamllint disable-line rule:truthy
   pull_request:
+  push:
+    branches:
+      - "main"
+  merge_group:
 
 permissions: {}
 
@@ -44,15 +57,27 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
-      # Skip the (relatively expensive) build for PRs that don't touch the
-      # theme package. The job still completes successfully, so the required
-      # "verify" status is reported on every PR.
+      # Skip the (relatively expensive) build when the theme package was not
+      # touched. The job still completes successfully, so the required
+      # "verify" status is reported on every pull request and every queued
+      # merge.
+      #
+      # A push to "main" is always verified in full: it is the trigger that
+      # catches commits which never were a pull request here, and a fork
+      # merge leaves no reliable base to diff against.
+      #
+      # The base sha is read from the event payload rather than interpolated
+      # into the script.
       - name: "Detect theme-package changes"
         id: scope
-        env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
-          if git diff --name-only "$BASE_SHA" HEAD -- packages/typo3-docs-theme/ | grep -q .; then
+          filter='.pull_request.base.sha // .merge_group.base_sha // ""'
+          base="$(jq -r "$filter" "$GITHUB_EVENT_PATH")"
+
+          if [ -z "$base" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "Event '$GITHUB_EVENT_NAME' has no base — full verify."
+          elif git diff --name-only "$base" HEAD -- packages/typo3-docs-theme/ | grep -q .; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "changed=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/check-built-assets.yaml
+++ b/.github/workflows/check-built-assets.yaml
@@ -39,18 +39,6 @@ jobs:
       contents: read
 
     steps:
-      - name: "Harden runner"
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
-        with:
-          egress-policy: block
-          disable-sudo: true
-          allowed-endpoints: >
-            api.github.com:443
-            github.com:443
-            objects.githubusercontent.com:443
-            release-assets.githubusercontent.com:443
-            registry.npmjs.org:443
-
       - name: "Checkout"
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/dependabot-rebuild-assets.yaml
+++ b/.github/workflows/dependabot-rebuild-assets.yaml
@@ -1,0 +1,218 @@
+# Convenience workflow: on a Dependabot PR that bumps an npm dependency under
+# packages/typo3-docs-theme/, rebuild the committed assets and commit them
+# back to the Dependabot branch, then enable auto-merge.
+#
+# This is NOT the contract — check-built-assets.yaml is. If this workflow
+# fails, that check still catches the resulting stale assets and blocks the PR.
+#
+# Trigger: pull_request_target matches the local convention in
+# .github/workflows/pr-auto-merge.yaml ("due to permission issues with the
+# pull_request target"). Because pull_request_target runs in the base-repo
+# context, several guards keep it safe:
+#
+#   - if: github.actor == 'dependabot[bot]'
+#   - checkout pinned to the PR head SHA, so if Dependabot force-pushes
+#     between the trigger and the checkout we still build the exact commit
+#     the PR opened with
+#   - lockfile-only diff guard: refuse to build if the PR changed anything
+#     other than package.json / package-lock.json
+#   - npm ci --ignore-scripts; harden-runner egress in block mode
+#   - the App token is minted AFTER the build, so the untrusted build cannot
+#     read it; persist-credentials: false keeps it off disk
+#
+# The rebuilt files are committed via the GitHub API (createCommitOnBranch)
+# with a short-lived GitHub App token, never `git push`. API commits are
+# signed server-side by GitHub (Verified), and an App-token commit re-triggers
+# the asset check on the new commit, so the merged commit is itself checked.
+
+name: "Rebuild assets for Dependabot"
+
+on: # yamllint disable-line rule:truthy
+  pull_request_target:
+    paths:
+      - "packages/typo3-docs-theme/package.json"
+      - "packages/typo3-docs-theme/package-lock.json"
+
+# GITHUB_TOKEN stays read-only — it is used only by dependabot/fetch-metadata.
+# All writes go through the GitHub App token, whose scope comes from the App.
+permissions: {}
+
+jobs:
+  build-and-commit:
+    name: "build-and-commit"
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: "Harden runner"
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: block
+          disable-sudo: true
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
+            registry.npmjs.org:443
+
+      - name: "Checkout Dependabot branch"
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: "Verify PR diff is lockfile-only"
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          # A legitimate Dependabot npm PR only touches package.json and
+          # package-lock.json. Anything else means the branch was tampered
+          # with — fail closed before we execute vite/grunt config.
+          ALLOWED=(
+            packages/typo3-docs-theme/package.json
+            packages/typo3-docs-theme/package-lock.json
+          )
+
+          changed="$(git diff --name-only "$BASE_SHA"...HEAD)"
+          unexpected=""
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            match=0
+            for a in "${ALLOWED[@]}"; do
+              [ "$f" = "$a" ] && match=1 && break
+            done
+            [ $match -eq 0 ] && unexpected="${unexpected}${f}"$'\n'
+          done <<< "$changed"
+
+          if [ -n "$unexpected" ]; then
+            echo "::error::Dependabot PR touches files outside the npm lockfile set. Refusing to build."
+            printf '%s' "$unexpected"
+            exit 1
+          fi
+
+      - name: "Install Node"
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: "packages/typo3-docs-theme/package.json"
+          cache: "npm"
+          cache-dependency-path: "packages/typo3-docs-theme/package-lock.json"
+
+      - name: "Install npm dependencies (no install scripts)"
+        working-directory: packages/typo3-docs-theme
+        run: "npm ci --ignore-scripts"
+
+      - name: "Build assets"
+        working-directory: packages/typo3-docs-theme
+        run: "npm run build"
+
+      # Inspect the asset trees in shell so git output never crosses into JS.
+      # Reject unexpected new files, then record changed/deleted paths
+      # NUL-delimited (-z, --no-renames) so filenames with odd characters
+      # can't skew parsing.
+      - name: "Prepare commit inputs"
+        id: prepare
+        run: |
+          ASSET_PATHS=(
+            packages/typo3-docs-theme/assets
+            packages/typo3-docs-theme/resources/public
+          )
+
+          untracked="$(git ls-files --others --exclude-standard -- "${ASSET_PATHS[@]}")"
+          if [ -n "$untracked" ]; then
+            echo "::error::Build produced unexpected untracked files in the asset trees. Refusing to commit."
+            printf '%s\n' "$untracked"
+            exit 1
+          fi
+
+          git diff -z --name-only --no-renames --diff-filter=d -- "${ASSET_PATHS[@]}" > "$RUNNER_TEMP/asset-upserts"
+          git diff -z --name-only --no-renames --diff-filter=D -- "${ASSET_PATHS[@]}" > "$RUNNER_TEMP/asset-deletes"
+          echo "head_oid=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      # Mint the App token here — AFTER the untrusted build — so a compromised
+      # build dependency cannot read it. The push as the App (not GITHUB_TOKEN)
+      # is what re-triggers the asset check on the rebuild commit.
+      - name: "Mint App token"
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      # Commit via the GitHub API so the commit is GitHub-signed (Verified).
+      # The commit is authored by the App (the token holder) — GitHub only
+      # signs commits it attributes to the token holder.
+      - name: "Commit rebuilt assets as a verified commit (if changed)"
+        uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
+        env:
+          EXPECTED_HEAD_OID: ${{ steps.prepare.outputs.head_oid }}
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const fs = require('fs');
+            const readPaths = (name) =>
+              fs.readFileSync(`${process.env.RUNNER_TEMP}/${name}`)
+                .toString('utf8')
+                .split('\0')
+                .filter(Boolean);
+
+            const upserts = readPaths('asset-upserts');   // added or modified
+            const deletes = readPaths('asset-deletes');
+
+            if (upserts.length === 0 && deletes.length === 0) {
+              core.info('No generated asset changes.');
+              return;
+            }
+
+            const fileChanges = {
+              additions: upserts.map((path) => ({
+                path,
+                contents: fs.readFileSync(path).toString('base64'),
+              })),
+            };
+            if (deletes.length) {
+              fileChanges.deletions = deletes.map((path) => ({ path }));
+            }
+
+            const result = await github.graphql(
+              `mutation($input: CreateCommitOnBranchInput!) {
+                 createCommitOnBranch(input: $input) { commit { oid url } }
+               }`,
+              {
+                input: {
+                  branch: {
+                    repositoryNameWithOwner: context.payload.repository.full_name,
+                    branchName: context.payload.pull_request.head.ref,
+                  },
+                  expectedHeadOid: process.env.EXPECTED_HEAD_OID,
+                  message: { headline: '[TASK] Rebuild theme assets after dependency update' },
+                  fileChanges,
+                },
+              }
+            );
+
+            const commit = result.createCommitOnBranch.commit;
+            core.info(`Created verified rebuild commit ${commit.oid}`);
+            core.info(commit.url);
+
+      # Enable auto-merge AFTER the rebuild commit is in place. pr-auto-merge.yaml
+      # excludes these PRs (it would otherwise squash-merge before the rebuild
+      # lands). A broken build or a tripped guard fails an earlier step and never
+      # reaches this, so a bad upgrade stays open for manual review.
+      - name: "Dependabot metadata"
+        id: metadata
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: "Enable auto-merge for patch/minor updates"
+        if: |
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: gh pr merge --squash --auto "${{ github.event.pull_request.number }}" -R "${{ github.repository }}"

--- a/.github/workflows/dependabot-rebuild-assets.yaml
+++ b/.github/workflows/dependabot-rebuild-assets.yaml
@@ -16,9 +16,14 @@
 #     the PR opened with
 #   - lockfile-only diff guard: refuse to build if the PR changed anything
 #     other than package.json / package-lock.json
-#   - npm ci --ignore-scripts; harden-runner egress in block mode
+#   - npm ci --ignore-scripts
 #   - the App token is minted AFTER the build, so the untrusted build cannot
 #     read it; persist-credentials: false keeps it off disk
+#
+# Egress filtering via step-security/harden-runner is not available here: the
+# repository restricts workflows to an allowlist of actions and harden-runner
+# is not on it. Adding it there would let both workflows in this branch pin
+# their network access.
 #
 # The rebuilt files are committed via the GitHub API (createCommitOnBranch)
 # with a short-lived GitHub App token, never `git push`. API commits are
@@ -46,18 +51,6 @@ jobs:
       contents: read
 
     steps:
-      - name: "Harden runner"
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
-        with:
-          egress-policy: block
-          disable-sudo: true
-          allowed-endpoints: >
-            api.github.com:443
-            github.com:443
-            objects.githubusercontent.com:443
-            release-assets.githubusercontent.com:443
-            registry.npmjs.org:443
-
       - name: "Checkout Dependabot branch"
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/pr-auto-merge.yaml
+++ b/.github/workflows/pr-auto-merge.yaml
@@ -19,12 +19,26 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
+      # Theme-package PRs are intentionally excluded from auto-merge.
+      # The dependabot-rebuild-assets workflow needs to rebuild and push
+      # regenerated assets to the PR branch before the PR can merge; if
+      # auto-merge fires here at PR-open time it squashes BEFORE the
+      # rebuild commit lands, leaving stale assets on main. Theme PRs
+      # require a manual review/merge once the rebuild commit shows up.
       - name: Enable auto-merge
-        if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        if: |
+          (steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+           steps.metadata.outputs.update-type == 'version-update:semver-minor') &&
+          !contains(steps.metadata.outputs.directory, 'typo3-docs-theme')
         run: gh pr merge -R "${{ github.repository }}" --squash --auto "${{ github.event.pull_request.number }}"
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+      - name: Note skipped auto-merge for theme PRs
+        if: contains(steps.metadata.outputs.directory, 'typo3-docs-theme')
+        run: |
+          echo "::notice::Auto-merge intentionally skipped for theme PRs. The dependabot-rebuild-assets workflow rebuilds and pushes regenerated assets to this branch; merge manually once that commit lands and all checks are green."

--- a/Documentation/Developer/ThemeCustomization.rst
+++ b/Documentation/Developer/ThemeCustomization.rst
@@ -70,8 +70,17 @@ Or use the custom ddev commands:
 The generated assets are copied directly into :file:`Documentation-GENERATED-temp/_resources`
 and source maps are not removed. Upon inspection in the browsers web developer
 tools you can therefore see in which source scss file certain styles were
-defined. Before committing you must run :shell:`npm run build` so that you can
-commit the generated asset files into the theme.
+defined. Before committing you must run :shell:`cd packages/typo3-docs-theme && npm ci && npm run build`
+and commit the regenerated asset files in
+:file:`packages/typo3-docs-theme/assets/` and
+:file:`packages/typo3-docs-theme/resources/public/`.
+
+CI enforces this via the ``check-built-assets`` workflow: every pull request
+that touches :file:`packages/typo3-docs-theme/` is rebuilt and fails if the
+committed assets diverge from a fresh build. For Dependabot pull requests the
+``dependabot-rebuild-assets`` workflow performs the rebuild and pushes the
+result back to the Dependabot branch automatically, so no manual rebuild is
+required there.
 
 
 ..  _Bootstrap: https://getbootstrap.com/


### PR DESCRIPTION
## Problem

`packages/typo3-docs-theme/` commits its **built** frontend assets (`assets/js/`, `resources/public/`). They drift out of sync when a contributor forgets to rebuild, or when Dependabot bumps a build dependency — Dependabot can't rebuild the assets (this is what made the manual follow-up #1264 necessary).

## Changes

1. **`check-built-assets.yaml`** — required check `verify`: on every PR, rebuilds the theme and fails if the committed assets don't match a fresh build. PRs not touching the theme short-circuit to success, so the check can be required without blocking unrelated PRs. Also runs on push to `main` and in the merge queue.
2. **`dependabot-rebuild-assets.yaml`** — on a Dependabot theme bump: rebuilds the assets, commits them back as a GitHub-signed (Verified) commit via a GitHub App, then enables auto-merge for patch/minor updates.
3. **`pr-auto-merge.yaml`** — excludes theme PRs from the generic Dependabot auto-merge; the workflow above handles them after the rebuild commit lands.
4. Docs pointer in `Documentation/Developer/ThemeCustomization.rst`.

## Required repository settings

- [ ] GitHub App with **Contents: write** + **Pull requests: write**, exposed as secrets `APP_ID` / `APP_PRIVATE_KEY` (same names as `reusable-backport.yml`).
- [ ] **Allow auto-merge** enabled.
- [ ] Branch protection requiring the **`verify`** check.

## Security

`dependabot-rebuild-assets.yaml` uses `pull_request_target` (same convention as `pr-auto-merge.yaml`). Guards: actor gated to `dependabot[bot]`; checkout pinned to the PR head SHA; lockfile-only diff guard; `npm ci --ignore-scripts`; read-only `GITHUB_TOKEN`; App token minted only **after** the build; commit created via `createCommitOnBranch`, so it is Verified and re-triggers `verify`.

Residual risk (accepted): patch/minor theme bumps merge without a human in the loop, so a compromised dependency's build-time code runs and its output merges. For a manual checkpoint, drop the "Enable auto-merge" step.

## Validation

Proven end-to-end on a fork: non-theme PR → `verify` skips green; stale assets → `verify` blocks; Dependabot bump → Verified rebuild commit → `verify` re-runs → auto-merge with correct assets on `main`.
