### PR TITLE
[BUGFIX] Strip leading backslash from :php-short: output

### DIFF
--- a/packages/typo3-docs-theme/src/TextRoles/PhpTextRole.php
+++ b/packages/typo3-docs-theme/src/TextRoles/PhpTextRole.php
@@ -46,7 +46,8 @@ final class PhpTextRole implements TextRole
             $apiInfo = $this->typo3ApiService->getClassInfo($rawContent);
             $name = $rawContent;
             if ($role === 'php-short') {
-                $name = $fqn[2] ?? $rawContent;
+                $shortName = $fqn[2] ?? '';
+                $name = ltrim($shortName !== '' ? $shortName : $rawContent, '\\');
             }
             return $this->getClassCodeNode($rawContent, $apiInfo, $role, $name, $type);
         }

--- a/tests/Integration/tests/code/code-php-short/expected/index.html
+++ b/tests/Integration/tests/code/code-php-short/expected/index.html
@@ -1,0 +1,31 @@
+        <!-- content start -->
+                <section class="section" id="php-short">
+            <h1>PHP Short<a class="headerlink" href="#php-short" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">&nbsp;<i class="fa-solid fa-link"></i></a></h1>
+            
+
+<ul>
+    <li><code class="code-inline"
+          translate="no"
+          data-bs-toggle="modal"
+          data-bs-target="#generalModal"
+          data-code="FooBar"
+          data-shortdescription="PHP class or interface"
+          data-details="PHP classes in this namespace are commonly used as examples. Replace with your own vendor and namespace on implementation. "
+          data-morelink=""          data-bs-html="true"
+    >
+        Foo<wbr>Bar</code></li>
+    <li><code class="code-inline"
+          translate="no"
+          data-bs-toggle="modal"
+          data-bs-target="#generalModal"
+          data-code="Something"
+          data-shortdescription="PHP class or interface"
+          data-details="This is a fully-qualified class or interface name,
+            try searching for \Foo\Bar\Something in the internet."
+          data-morelink=""          data-bs-html="true"
+    >
+        Something</code></li>
+</ul>
+
+    </section>
+        <!-- content end -->

--- a/tests/Integration/tests/code/code-php-short/input/index.rst
+++ b/tests/Integration/tests/code/code-php-short/input/index.rst
@@ -1,0 +1,6 @@
+=========
+PHP Short
+=========
+
+*   :php-short:`\MyVendor\MyExtension\FooBar`
+*   :php-short:`\Foo\Bar\Something`


### PR DESCRIPTION
## Problem

The `:php-short:` text role renders class names with a leading backslash for classes that are **not** resolved via the TYPO3 API — e.g. `\LoggerInterface` instead of `LoggerInterface`, `\Something` instead of `Something`. As noted in #1155, a leading backslash changes the meaning (it would refer to a root-namespace class), so the output is incorrect.

<img width="1560" height="248" alt="rg1294-before-fix" src="https://github.com/user-attachments/assets/34a608c6-5c36-4c29-9460-0924d56a953f" />

## Cause

In `PhpTextRole::processNode()` the short name was taken from `$fqn[2]`, the last match of the repeated capture group in `CLASS_NAME_PATTERN_REGEX`. That group matches `\Segment`, so the captured value keeps the leading namespace separator. When the class is found in the API, the `apiInfo['short']` value overrides it — which is why the bug only surfaced in the fallback branches (PSR, Fluid, MyVendor, generic).

## Fix

Strip the leading backslash from the short name (falling back to the full name when there is no inner segment). One-line change in the role plus a regression test.

<img width="1560" height="248" alt="rg1294-after-fix" src="https://github.com/user-attachments/assets/bf00231d-d104-453e-b165-7439a9ac9c1e" />

## Test

Adds integration test case `tests/Integration/tests/code/code-php-short` covering the fallback rendering. Without the fix the rendered output is `\FooBar` / `\Foo<wbr>Bar`; with it, `FooBar` / `Foo<wbr>Bar`.

Verified locally: integration + unit suites pass, PHPStan clean, php-cs-fixer clean.

Fixes #1155
