### PR TITLE
[BUGFIX] Collapse empty property, constant and enum case cards

### DIFF
--- a/packages/typo3-docs-theme/assets/sass/components/directives/_phpdomain.scss
+++ b/packages/typo3-docs-theme/assets/sass/components/directives/_phpdomain.scss
@@ -7,4 +7,29 @@
     dl.php {
         @extend .property-card;
     }
+
+    // A public property, class constant or enum case is often just a signature
+    // with no body, which otherwise renders as an empty Bootstrap-style panel
+    // below the header (see #1078). When the body is empty, hide it (dd:empty)
+    // and collapse the card to a single header bar (:has) by also removing the
+    // header margin and card padding. Members that do have a body keep their
+    // normal spacing, and so does the gap between members. The two rules are
+    // kept separate so a browser without :has() still hides the empty body.
+
+    dl.php.property,
+    dl.php.const,
+    dl.php.case {
+
+        & > dd:empty {
+            display: none;
+        }
+
+        &:has(> dd:empty) {
+            padding-bottom: 0;
+
+            & > dt {
+                margin-bottom: 0;
+            }
+        }
+    }
 }

--- a/packages/typo3-docs-theme/resources/public/css/theme.css
+++ b/packages/typo3-docs-theme/resources/public/css/theme.css
@@ -26546,6 +26546,22 @@ dl.field-list > dt:after {
     margin: 0;
   }
 }
+.rst-content dl.php.property > dd:empty,
+.rst-content dl.php.const > dd:empty,
+.rst-content dl.php.case > dd:empty {
+  display: none;
+}
+.rst-content dl.php.property:has(> dd:empty),
+.rst-content dl.php.const:has(> dd:empty),
+.rst-content dl.php.case:has(> dd:empty) {
+  padding-bottom: 0;
+}
+.rst-content dl.php.property:has(> dd:empty) > dt,
+.rst-content dl.php.const:has(> dd:empty) > dt,
+.rst-content dl.php.case:has(> dd:empty) > dt {
+  margin-bottom: 0;
+}
+
 .sidebar {
   margin: 0;
   margin-bottom: 1rem;


### PR DESCRIPTION
## Problem

A public class member documented with `php:attr`/`php:property`, `php:const` or enum `php:case` that has no body (just the signature, e.g. `public formPersistenceIdentifier` or an enum case) renders as a Bootstrap-style panel with an **empty white body** beneath the gray signature header, so it looks like content is missing. This is the issue reported in #1078; `const` and enum `case` share the same template structure and the same symptom.

The empty body comes from the card still wrapping an empty `<dd>` and keeping its header margin and bottom padding even when there is nothing to show below the header.

## Fix

Scoped to `dl.php.property`, `dl.php.const` and `dl.php.case`:

- hide an empty body (`dd:empty`); and
- for that empty case only (`:has(> dd:empty)`), drop the card's bottom padding and the header's bottom margin,

so a body-less member collapses to a single solid header bar — the styling the reporter (@ineswillenbrock) settled on in #1078 ("I'd have to remove both to get a reasonable styling like this"):

![reporter's proposed target](https://raw.githubusercontent.com/CybotTM/render-guides/f9646ae532241edad03ff94fa438ea16c63c3392/issue-1078/reporter-target.png)

Members that **do** have a body, the spacing between members, and classes, enums, methods, globals, confvals and commands are all untouched. (Methods and globals emit a `<dd>` with surrounding whitespace, so `:empty` deliberately does not match them and they are left as-is.)

This is a CSS-only change in the TYPO3 docs theme — the SCSS source plus the rebuilt `theme.css`. `:has()` is already used elsewhere in the theme; `stylelint` and the theme JS tests pass. The `dd:empty` hide is kept as a separate rule from the `:has()` block, so a browser without `:has()` support still hides the empty body and merely keeps the card's ~4.8 px bottom padding (a near-flat header rather than the full panel).

## Before / After

### Properties (the reporter's example)

A class with a documented method, one documented property, and two empty properties.

**Before** — empty properties render as panels with an empty white body:

![before](https://raw.githubusercontent.com/CybotTM/render-guides/f9646ae532241edad03ff94fa438ea16c63c3392/issue-1078/before.png)

**After** — empty properties collapse to a compact header bar; the method, the documented property and the spacing between members are unchanged:

![after](https://raw.githubusercontent.com/CybotTM/render-guides/f9646ae532241edad03ff94fa438ea16c63c3392/issue-1078/after.png)

### Constants and enum cases (same root cause)

An enum with empty cases and a class with an empty constant, property and method.

**Before:**

![siblings before](https://raw.githubusercontent.com/CybotTM/render-guides/f9646ae532241edad03ff94fa438ea16c63c3392/issue-1078/siblings-before.png)

**After** — `const`, enum `case` and the property collapse to solid bars; the enum, the class and the method (whitespace `<dd>`) keep their bodies:

![siblings after](https://raw.githubusercontent.com/CybotTM/render-guides/f9646ae532241edad03ff94fa438ea16c63c3392/issue-1078/siblings-after.png)

Resolves #1078
