### PR TITLE
[FEATURE] Open inline-code information-modal via dedicated button

### DIFF
--- a/packages/typo3-docs-theme/assets/sass/components/_code.scss
+++ b/packages/typo3-docs-theme/assets/sass/components/_code.scss
@@ -115,9 +115,22 @@ a.code-block-edit {
     font-family: $font-family-monospace;
     border-radius: $border-radius;
     border: 2px solid $white;
-    background: $gray-100;
+    background-color: $gray-100;
     padding: 0.25em 0.5em;
     line-height: 27px;
+
+    &:has(button) {
+        padding-right: 0;
+    }
+
+    button {
+        background-color: $gray-100;
+        border-color: $gray-100;
+        margin-top: -0.2em;
+        padding: 0.2em;
+        min-height: unset !important;
+        box-shadow: unset !important;
+    }
 }
 
 .code-inline-long {

--- a/packages/typo3-docs-theme/resources/public/css/theme.css
+++ b/packages/typo3-docs-theme/resources/public/css/theme.css
@@ -24385,9 +24385,20 @@ a.code-block-edit .fa-check:before {
   font-family: "Source Code Pro", monospace;
   border-radius: 0.375rem;
   border: 2px solid #ffffff;
-  background: rgb(247.35, 247.35, 247.35);
+  background-color: rgb(247.35, 247.35, 247.35);
   padding: 0.25em 0.5em;
   line-height: 27px;
+}
+.code-inline:has(button) {
+  padding-right: 0;
+}
+.code-inline button {
+  background-color: rgb(247.35, 247.35, 247.35);
+  border-color: rgb(247.35, 247.35, 247.35);
+  margin-top: -0.2em;
+  padding: 0.2em;
+  min-height: unset !important;
+  box-shadow: unset !important;
 }
 
 /** uses "popover" for all code roles that have tooltips **/

--- a/packages/typo3-docs-theme/resources/template/inline/textroles/code.html.twig
+++ b/packages/typo3-docs-theme/resources/template/inline/textroles/code.html.twig
@@ -1,20 +1,22 @@
 {% apply spaceless %}
     <code class="code-inline{% if node.value|length > 10 %} code-inline-long{% endif %}"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="{{ node.value }}"
-          data-shortdescription="{{ node.language|raw }}"
-          data-details="{{ node.helpText|raw }}"
-          data-morelink="{{  node.info.url }}"
-          {%- if node.info.fqn %}
-              data-fqn="{{ node.info.fqn }}"
-          {%- endif %}
-          data-bs-html="true"
     >
         {{ replaceLineBreakOpportunityTags(node.value) }}
-        {%- if node.info.url %}
-            <span class="text-secondary"><i class="fa-regular fa-circle-question"></i></span>
-        {%- endif -%}
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="{{ node.value }}"
+                data-shortdescription="{{ node.language|raw }}"
+                data-details="{{ node.helpText|raw }}"
+                {%- if node.info.url %}
+                    data-morelink="{{  node.info.url }}"
+                {%- endif -%}
+                {%- if node.info.fqn %}
+                    data-fqn="{{ node.info.fqn }}"
+                {%- endif %}
+                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button>
     </code>
 {% endapply %}

--- a/tests/Integration/tests-full/changelog/expected/Changelog/12.0/Breaking-87616-RemovedHookForAlteringPageLinks.html
+++ b/tests/Integration/tests-full/changelog/expected/Changelog/12.0/Breaking-87616-RemovedHookForAlteringPageLinks.html
@@ -206,40 +206,46 @@
             
     <p>The hook <code class="code-inline code-inline-long"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="$GLOBALS[&#039;TYPO3_CONF_VARS&#039;][&#039;SC_OPTIONS&#039;][&#039;typolinkProcessing&#039;][&#039;typolinkModifyParameterForPageLinks&#039;]"
-          data-shortdescription="Global PHP configuration"
-          data-details="The main configuration is achieved via a set of global
+    >
+        $GLOBALS<wbr>[&#039;TYPO3_<wbr>CONF_<wbr>VARS&#039;]<wbr>[&#039;SC_<wbr>OPTIONS&#039;]<wbr>[&#039;typolink<wbr>Processing&#039;]<wbr>[&#039;typolink<wbr>Modify<wbr>Parameter<wbr>For<wbr>Page<wbr>Links&#039;]
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="$GLOBALS[&#039;TYPO3_CONF_VARS&#039;][&#039;SC_OPTIONS&#039;][&#039;typolinkProcessing&#039;][&#039;typolinkModifyParameterForPageLinks&#039;]"
+                data-shortdescription="Global PHP configuration"
+                data-details="The main configuration is achieved via a set of global
                 settings stored in a global array called $GLOBALS['TYPO3_CONF_VARS'].
                 They are commonly set in config/system/settings.php, config/system/additional.php,
-                or the ext_localconf.php file of an extension. "
-          data-morelink="https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/Configuration/Typo3ConfVars/Index.html"          data-bs-html="true"
-    >
-        $GLOBALS<wbr>[&#039;TYPO3_<wbr>CONF_<wbr>VARS&#039;]<wbr>[&#039;SC_<wbr>OPTIONS&#039;]<wbr>[&#039;typolink<wbr>Processing&#039;]<wbr>[&#039;typolink<wbr>Modify<wbr>Parameter<wbr>For<wbr>Page<wbr>Links&#039;]            <span class="text-secondary"><i class="fa-regular fa-circle-question"></i></span></code>
+                or the ext_localconf.php file of an extension. "                    data-morelink="https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/Configuration/Typo3ConfVars/Index.html"                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
 has been removed in favor of a new PSR-14 event <code class="code-inline code-inline-long"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="\TYPO3\CMS\Frontend\Event\ModifyPageLinkConfigurationEvent"
-          data-shortdescription="PHP class"
-          data-details="<code>final class ModifyPageLinkConfigurationEvent</code><br><em>A generic PSR 14 Event to allow modifying the incoming (and resolved) page when building a &quot;page link&quot;.</em>"
-          data-morelink="https://api.typo3.org/main/classes/TYPO3-CMS-Frontend-Event-ModifyPageLinkConfigurationEvent.html"              data-fqn="\TYPO3\CMS\Frontend\Event\ModifyPageLinkConfigurationEvent"          data-bs-html="true"
     >
-        \TYPO3\<wbr>CMS\<wbr>Frontend\<wbr>Event\<wbr>Modify<wbr>Page<wbr>Link<wbr>Configuration<wbr>Event            <span class="text-secondary"><i class="fa-regular fa-circle-question"></i></span></code>.</p>
+        \TYPO3\<wbr>CMS\<wbr>Frontend\<wbr>Event\<wbr>Modify<wbr>Page<wbr>Link<wbr>Configuration<wbr>Event
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="\TYPO3\CMS\Frontend\Event\ModifyPageLinkConfigurationEvent"
+                data-shortdescription="PHP class"
+                data-details="<code>final class ModifyPageLinkConfigurationEvent</code><br><em>A generic PSR 14 Event to allow modifying the incoming (and resolved) page when building a &quot;page link&quot;.</em>"                    data-morelink="https://api.typo3.org/main/classes/TYPO3-CMS-Frontend-Event-ModifyPageLinkConfigurationEvent.html"                    data-fqn="\TYPO3\CMS\Frontend\Event\ModifyPageLinkConfigurationEvent"                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>.</p>
 
             
     <p>The event is called after TYPO3 has already prepared some functionality
 within the <code class="code-inline code-inline-long"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="PageLinkBuilder"
-          data-shortdescription="Code written in PHP"
-          data-details="Dynamic server-side scripting language."
-          data-morelink=""          data-bs-html="true"
     >
-        Page<wbr>Link<wbr>Builder</code>. This therefore allows to modify more
+        Page<wbr>Link<wbr>Builder
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="PageLinkBuilder"
+                data-shortdescription="Code written in PHP"
+                data-details="Dynamic server-side scripting language."                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>. This therefore allows to modify more
 properties, if needed.</p>
 
     </section>

--- a/tests/Integration/tests-full/edit-on-github/edit-on-github-per-page/expected/page1.html
+++ b/tests/Integration/tests-full/edit-on-github/edit-on-github-per-page/expected/page1.html
@@ -166,14 +166,16 @@
             
     <p>Render the avatar markup, including the <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="&lt;img&gt;"
-          data-shortdescription="Code written in HTML"
-          data-details="HyperText Markup Language."
-          data-morelink=""          data-bs-html="true"
     >
-        &lt;img&gt;</code> tag, for a given backend user.</p>
+        &lt;img&gt;
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="&lt;img&gt;"
+                data-shortdescription="Code written in HTML"
+                data-details="HyperText Markup Language."                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code> tag, for a given backend user.</p>
 
     </section>
         <!-- content end -->

--- a/tests/Integration/tests/code-inline/expected/index.html
+++ b/tests/Integration/tests/code-inline/expected/index.html
@@ -4,38 +4,44 @@
 
     <p><code class="code-inline code-inline-long"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="echo &#039;Hello&#039;"
-          data-shortdescription="Code written in Shell Script"
-          data-details="Raw command line interface code on operating-system level."
-          data-morelink=""          data-bs-html="true"
     >
-        echo &#039;Hello&#039;</code></p>
+        echo &#039;Hello&#039;
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="echo &#039;Hello&#039;"
+                data-shortdescription="Code written in Shell Script"
+                data-details="Raw command line interface code on operating-system level."                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code></p>
 
 
     <p><code class="code-inline code-inline-long"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="body { background: red; }"
-          data-shortdescription="Code written in CSS"
-          data-details="CSS (Cascading Style Sheets) is used to style the appearance of HTML elements on a web page."
-          data-morelink=""          data-bs-html="true"
     >
-        body <wbr>{ background: red; }</code></p>
+        body <wbr>{ background: red; }
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="body { background: red; }"
+                data-shortdescription="Code written in CSS"
+                data-details="CSS (Cascading Style Sheets) is used to style the appearance of HTML elements on a web page."                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code></p>
 
 
     <p><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="$var = 1;"
-          data-shortdescription="Code written in PHP"
-          data-details="Dynamic server-side scripting language."
-          data-morelink=""          data-bs-html="true"
     >
-        $var = 1;</code></p>
+        $var = 1;
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="$var = 1;"
+                data-shortdescription="Code written in PHP"
+                data-details="Dynamic server-side scripting language."                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code></p>
 
     </section>
         <!-- content end -->

--- a/tests/Integration/tests/code/code-php/expected/index.html
+++ b/tests/Integration/tests/code/code-php/expected/index.html
@@ -4,15 +4,17 @@
 
     <p><code class="code-inline code-inline-long"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="\T3Docs\Typo3DocsTheme\TextRoles\PhpTextRole"
-          data-shortdescription="PHP class or interface"
-          data-details="This is a fully-qualified class or interface name,
-            try searching for \T3Docs\Typo3DocsTheme\TextRoles\PhpTextRole in the internet."
-          data-morelink=""          data-bs-html="true"
     >
-        \T3Docs\<wbr>Typo3Docs<wbr>Theme\<wbr>Text<wbr>Roles\<wbr>Php<wbr>Text<wbr>Role</code>.</p>
+        \T3Docs\<wbr>Typo3Docs<wbr>Theme\<wbr>Text<wbr>Roles\<wbr>Php<wbr>Text<wbr>Role
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="\T3Docs\Typo3DocsTheme\TextRoles\PhpTextRole"
+                data-shortdescription="PHP class or interface"
+                data-details="This is a fully-qualified class or interface name,
+            try searching for \T3Docs\Typo3DocsTheme\TextRoles\PhpTextRole in the internet."                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>.</p>
 
     </section>
         <!-- content end -->

--- a/tests/Integration/tests/site-set-category/expected/index.html
+++ b/tests/Integration/tests/site-set-category/expected/index.html
@@ -39,14 +39,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Path of Fluid Templates for all defined content elements
@@ -58,14 +60,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Path of Fluid Partials for all defined content elements
@@ -77,14 +81,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Path of Fluid Layouts for all defined content elements
@@ -106,14 +112,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="int"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        int</code>
+        int
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="int"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Default Header type
@@ -125,14 +133,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     List of accepted tables
@@ -144,14 +154,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     List of allowed HTML tags when rendering RTE content
@@ -163,14 +175,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Default settings for browser-native image lazy loading
@@ -182,14 +196,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Default settings for an image decoding hint to the browser
@@ -201,14 +217,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="int"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        int</code>
+        int
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="int"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Max Image/Media Width
@@ -220,14 +238,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="int"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        int</code>
+        int
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="int"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Max Image/Media Width (Text)
@@ -239,14 +259,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="int"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        int</code>
+        int
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="int"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Advanced, Column space
@@ -258,14 +280,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="int"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        int</code>
+        int
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="int"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Advanced, Row space
@@ -277,14 +301,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="int"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        int</code>
+        int
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="int"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Advanced, Margin to text
@@ -296,14 +322,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="color"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        color</code>
+        color
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="color"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Media element border, color
@@ -315,14 +343,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="int"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        int</code>
+        int
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="int"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Media element border, thickness
@@ -334,14 +364,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="int"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        int</code>
+        int
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="int"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Media element border, padding
@@ -353,14 +385,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Click-enlarge Media Width
@@ -372,14 +406,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Click-enlarge Media Height
@@ -391,14 +427,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="bool"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        bool</code>
+        bool
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="bool"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Advanced, New window
@@ -410,14 +448,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="bool"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        bool</code>
+        bool
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="bool"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Lightbox click-enlarge rendering
@@ -429,14 +469,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Lightbox CSS class
@@ -448,14 +490,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Lightbox rel=&quot;&quot; attribute
@@ -467,14 +511,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Target for external links
@@ -486,14 +532,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Parts to keep when building links
@@ -592,14 +640,16 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Path of Fluid Templates for all defined content elements
@@ -641,14 +691,16 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Path of Fluid Partials for all defined content elements
@@ -690,14 +742,16 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Path of Fluid Layouts for all defined content elements
@@ -773,26 +827,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="int"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        int</code>
+        int
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="int"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="2"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        2</code>
+        2
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="2"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Default Header type
@@ -836,26 +894,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline code-inline-long"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="&quot;tt_content&quot;"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        &quot;tt_<wbr>content&quot;</code>
+        &quot;tt_<wbr>content&quot;
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="&quot;tt_content&quot;"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">List of accepted tables
@@ -897,26 +959,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline code-inline-long"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="&quot;a, abbr, acronym, address, article, aside, b, bdo, big, blockquote, br, caption, center, cite, code, col, colgroup, dd, del, dfn, dl, div, dt, em, figure, font, footer, header, h1, h2, h3, h4, h5, h6, hr, i, img, ins, kbd, label, li, link, mark, meta, nav, ol, p, pre, q, s, samp, sdfield, section, small, span, strike, strong, style, sub, sup, table, thead, tbody, tfoot, td, th, tr, title, tt, u, ul, var&quot;"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        &quot;a, abbr, acronym, address, article, aside, b, bdo, big, blockquote, br, caption, center, cite, code, col, colgroup, dd, del, dfn, dl, div, dt, em, figure, font, footer, header, h1, h2, h3, h4, h5, h6, hr, i, img, ins, kbd, label, li, link, mark, meta, nav, ol, p, pre, q, s, samp, sdfield, section, small, span, strike, strong, style, sub, sup, table, thead, tbody, tfoot, td, th, tr, title, tt, u, ul, var&quot;</code>
+        &quot;a, abbr, acronym, address, article, aside, b, bdo, big, blockquote, br, caption, center, cite, code, col, colgroup, dd, del, dfn, dl, div, dt, em, figure, font, footer, header, h1, h2, h3, h4, h5, h6, hr, i, img, ins, kbd, label, li, link, mark, meta, nav, ol, p, pre, q, s, samp, sdfield, section, small, span, strike, strong, style, sub, sup, table, thead, tbody, tfoot, td, th, tr, title, tt, u, ul, var&quot;
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="&quot;a, abbr, acronym, address, article, aside, b, bdo, big, blockquote, br, caption, center, cite, code, col, colgroup, dd, del, dfn, dl, div, dt, em, figure, font, footer, header, h1, h2, h3, h4, h5, h6, hr, i, img, ins, kbd, label, li, link, mark, meta, nav, ol, p, pre, q, s, samp, sdfield, section, small, span, strike, strong, style, sub, sup, table, thead, tbody, tfoot, td, th, tr, title, tt, u, ul, var&quot;"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">List of allowed HTML tags when rendering RTE content
@@ -958,26 +1024,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="&quot;lazy&quot;"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        &quot;lazy&quot;</code>
+        &quot;lazy&quot;
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="&quot;lazy&quot;"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Default settings for browser-native image lazy loading
@@ -1028,14 +1098,16 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Default settings for an image decoding hint to the browser
@@ -1086,26 +1158,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="int"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        int</code>
+        int
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="int"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="600"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        600</code>
+        600
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="600"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Max Image/Media Width
@@ -1149,26 +1225,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="int"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        int</code>
+        int
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="int"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="300"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        300</code>
+        300
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="300"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Max Image/Media Width (Text)
@@ -1212,26 +1292,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="int"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        int</code>
+        int
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="int"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="10"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        10</code>
+        10
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="10"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Advanced, Column space
@@ -1275,26 +1359,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="int"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        int</code>
+        int
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="int"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="10"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        10</code>
+        10
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="10"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Advanced, Row space
@@ -1338,26 +1426,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="int"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        int</code>
+        int
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="int"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="10"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        10</code>
+        10
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="10"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Advanced, Margin to text
@@ -1401,26 +1493,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="color"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        color</code>
+        color
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="color"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="&quot;#000000&quot;"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        &quot;#000000&quot;</code>
+        &quot;#000000&quot;
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="&quot;#000000&quot;"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Media element border, color
@@ -1464,26 +1560,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="int"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        int</code>
+        int
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="int"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="2"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        2</code>
+        2
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="2"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Media element border, thickness
@@ -1527,26 +1627,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="int"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        int</code>
+        int
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="int"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="0"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        0</code>
+        0
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="0"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Media element border, padding
@@ -1590,26 +1694,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="&quot;800m&quot;"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        &quot;800m&quot;</code>
+        &quot;800m&quot;
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="&quot;800m&quot;"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Click-enlarge Media Width
@@ -1653,26 +1761,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="&quot;600m&quot;"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        &quot;600m&quot;</code>
+        &quot;600m&quot;
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="&quot;600m&quot;"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Click-enlarge Media Height
@@ -1716,26 +1828,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="bool"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        bool</code>
+        bool
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="bool"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="false"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        false</code>
+        false
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="false"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Advanced, New window
@@ -1779,26 +1895,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="bool"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        bool</code>
+        bool
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="bool"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="false"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        false</code>
+        false
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="false"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Lightbox click-enlarge rendering
@@ -1842,26 +1962,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="&quot;lightbox&quot;"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        &quot;lightbox&quot;</code>
+        &quot;lightbox&quot;
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="&quot;lightbox&quot;"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Lightbox CSS class
@@ -1905,26 +2029,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline code-inline-long"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="&quot;lightbox[{field:uid}]&quot;"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        &quot;lightbox<wbr>[<wbr>{field:<wbr>uid}]&quot;</code>
+        &quot;lightbox<wbr>[<wbr>{field:<wbr>uid}]&quot;
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="&quot;lightbox[{field:uid}]&quot;"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Lightbox rel=&quot;&quot; attribute
@@ -1968,26 +2096,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="&quot;_blank&quot;"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        &quot;_<wbr>blank&quot;</code>
+        &quot;_<wbr>blank&quot;
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="&quot;_blank&quot;"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Target for external links
@@ -2029,26 +2161,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="&quot;path&quot;"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        &quot;path&quot;</code>
+        &quot;path&quot;
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="&quot;path&quot;"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Parts to keep when building links

--- a/tests/Integration/tests/site-set-ext-syntax/expected/index.html
+++ b/tests/Integration/tests/site-set-ext-syntax/expected/index.html
@@ -29,14 +29,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="int"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        int</code>
+        int
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="int"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Default Header type
@@ -48,14 +50,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     List of accepted tables
@@ -67,14 +71,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     List of allowed HTML tags when rendering RTE content
@@ -86,14 +92,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Default settings for browser-native image lazy loading
@@ -105,14 +113,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Default settings for an image decoding hint to the browser
@@ -124,14 +134,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="int"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        int</code>
+        int
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="int"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Max Image/Media Width
@@ -143,14 +155,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="int"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        int</code>
+        int
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="int"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Max Image/Media Width (Text)
@@ -162,14 +176,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="int"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        int</code>
+        int
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="int"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Advanced, Column space
@@ -181,14 +197,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="int"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        int</code>
+        int
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="int"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Advanced, Row space
@@ -200,14 +218,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="int"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        int</code>
+        int
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="int"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Advanced, Margin to text
@@ -219,14 +239,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="color"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        color</code>
+        color
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="color"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Media element border, color
@@ -238,14 +260,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="int"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        int</code>
+        int
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="int"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Media element border, thickness
@@ -257,14 +281,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="int"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        int</code>
+        int
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="int"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Media element border, padding
@@ -276,14 +302,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Click-enlarge Media Width
@@ -295,14 +323,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Click-enlarge Media Height
@@ -314,14 +344,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="bool"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        bool</code>
+        bool
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="bool"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Advanced, New window
@@ -333,14 +365,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="bool"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        bool</code>
+        bool
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="bool"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Lightbox click-enlarge rendering
@@ -352,14 +386,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Lightbox CSS class
@@ -371,14 +407,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Lightbox rel=&quot;&quot; attribute
@@ -390,14 +428,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Target for external links
@@ -409,14 +449,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Parts to keep when building links
@@ -428,14 +470,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Path of Fluid Templates for all defined content elements
@@ -447,14 +491,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Path of Fluid Partials for all defined content elements
@@ -466,14 +512,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Path of Fluid Layouts for all defined content elements
@@ -538,26 +586,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="int"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        int</code>
+        int
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="int"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="2"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        2</code>
+        2
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="2"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Default Header type
@@ -598,26 +650,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline code-inline-long"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="&quot;tt_content&quot;"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        &quot;tt_<wbr>content&quot;</code>
+        &quot;tt_<wbr>content&quot;
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="&quot;tt_content&quot;"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">List of accepted tables
@@ -657,26 +713,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline code-inline-long"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="&quot;a, abbr, acronym, address, article, aside, b, bdo, big, blockquote, br, caption, center, cite, code, col, colgroup, dd, del, dfn, dl, div, dt, em, figure, font, footer, header, h1, h2, h3, h4, h5, h6, hr, i, img, ins, kbd, label, li, link, meta, nav, ol, p, pre, q, s, samp, sdfield, section, small, span, strike, strong, style, sub, sup, table, thead, tbody, tfoot, td, th, tr, title, tt, u, ul, var&quot;"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        &quot;a, abbr, acronym, address, article, aside, b, bdo, big, blockquote, br, caption, center, cite, code, col, colgroup, dd, del, dfn, dl, div, dt, em, figure, font, footer, header, h1, h2, h3, h4, h5, h6, hr, i, img, ins, kbd, label, li, link, meta, nav, ol, p, pre, q, s, samp, sdfield, section, small, span, strike, strong, style, sub, sup, table, thead, tbody, tfoot, td, th, tr, title, tt, u, ul, var&quot;</code>
+        &quot;a, abbr, acronym, address, article, aside, b, bdo, big, blockquote, br, caption, center, cite, code, col, colgroup, dd, del, dfn, dl, div, dt, em, figure, font, footer, header, h1, h2, h3, h4, h5, h6, hr, i, img, ins, kbd, label, li, link, meta, nav, ol, p, pre, q, s, samp, sdfield, section, small, span, strike, strong, style, sub, sup, table, thead, tbody, tfoot, td, th, tr, title, tt, u, ul, var&quot;
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="&quot;a, abbr, acronym, address, article, aside, b, bdo, big, blockquote, br, caption, center, cite, code, col, colgroup, dd, del, dfn, dl, div, dt, em, figure, font, footer, header, h1, h2, h3, h4, h5, h6, hr, i, img, ins, kbd, label, li, link, meta, nav, ol, p, pre, q, s, samp, sdfield, section, small, span, strike, strong, style, sub, sup, table, thead, tbody, tfoot, td, th, tr, title, tt, u, ul, var&quot;"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">List of allowed HTML tags when rendering RTE content
@@ -716,26 +776,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="&quot;lazy&quot;"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        &quot;lazy&quot;</code>
+        &quot;lazy&quot;
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="&quot;lazy&quot;"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Default settings for browser-native image lazy loading
@@ -783,14 +847,16 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Default settings for an image decoding hint to the browser
@@ -838,26 +904,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="int"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        int</code>
+        int
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="int"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="600"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        600</code>
+        600
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="600"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Max Image/Media Width
@@ -898,26 +968,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="int"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        int</code>
+        int
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="int"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="300"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        300</code>
+        300
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="300"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Max Image/Media Width (Text)
@@ -958,26 +1032,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="int"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        int</code>
+        int
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="int"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="10"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        10</code>
+        10
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="10"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Advanced, Column space
@@ -1018,26 +1096,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="int"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        int</code>
+        int
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="int"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="10"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        10</code>
+        10
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="10"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Advanced, Row space
@@ -1078,26 +1160,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="int"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        int</code>
+        int
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="int"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="10"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        10</code>
+        10
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="10"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Advanced, Margin to text
@@ -1138,26 +1224,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="color"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        color</code>
+        color
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="color"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="&quot;#000000&quot;"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        &quot;#000000&quot;</code>
+        &quot;#000000&quot;
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="&quot;#000000&quot;"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Media element border, color
@@ -1198,26 +1288,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="int"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        int</code>
+        int
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="int"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="2"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        2</code>
+        2
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="2"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Media element border, thickness
@@ -1258,26 +1352,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="int"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        int</code>
+        int
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="int"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="0"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        0</code>
+        0
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="0"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Media element border, padding
@@ -1318,26 +1416,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="&quot;800m&quot;"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        &quot;800m&quot;</code>
+        &quot;800m&quot;
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="&quot;800m&quot;"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Click-enlarge Media Width
@@ -1378,26 +1480,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="&quot;600m&quot;"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        &quot;600m&quot;</code>
+        &quot;600m&quot;
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="&quot;600m&quot;"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Click-enlarge Media Height
@@ -1438,26 +1544,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="bool"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        bool</code>
+        bool
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="bool"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="false"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        false</code>
+        false
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="false"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Advanced, New window
@@ -1498,26 +1608,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="bool"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        bool</code>
+        bool
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="bool"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="false"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        false</code>
+        false
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="false"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Lightbox click-enlarge rendering
@@ -1558,26 +1672,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="&quot;lightbox&quot;"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        &quot;lightbox&quot;</code>
+        &quot;lightbox&quot;
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="&quot;lightbox&quot;"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Lightbox CSS class
@@ -1618,26 +1736,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline code-inline-long"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="&quot;lightbox[{field:uid}]&quot;"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        &quot;lightbox<wbr>[<wbr>{field:<wbr>uid}]&quot;</code>
+        &quot;lightbox<wbr>[<wbr>{field:<wbr>uid}]&quot;
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="&quot;lightbox[{field:uid}]&quot;"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Lightbox rel=&quot;&quot; attribute
@@ -1678,26 +1800,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="&quot;_blank&quot;"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        &quot;_<wbr>blank&quot;</code>
+        &quot;_<wbr>blank&quot;
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="&quot;_blank&quot;"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Target for external links
@@ -1737,26 +1863,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="&quot;path&quot;"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        &quot;path&quot;</code>
+        &quot;path&quot;
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="&quot;path&quot;"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Parts to keep when building links
@@ -1797,14 +1927,16 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Path of Fluid Templates for all defined content elements
@@ -1844,14 +1976,16 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Path of Fluid Partials for all defined content elements
@@ -1891,14 +2025,16 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Path of Fluid Layouts for all defined content elements

--- a/tests/Integration/tests/site-set-labels-autoload/expected/index.html
+++ b/tests/Integration/tests/site-set-labels-autoload/expected/index.html
@@ -29,14 +29,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     User Storage Page
@@ -48,14 +50,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Recursive
@@ -67,14 +71,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="bool"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        bool</code>
+        bool
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="bool"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Display Password Recovery Link
@@ -86,14 +92,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="bool"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        bool</code>
+        bool
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="bool"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Display Remember Login Option
@@ -105,14 +113,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="bool"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        bool</code>
+        bool
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="bool"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Disable redirect after successful login, but display logout-form
@@ -124,14 +134,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Email Sender Address
@@ -143,14 +155,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Email Sender Name
@@ -162,14 +176,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Reply-to email Address
@@ -181,14 +197,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Date format
@@ -200,14 +218,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Layout root path
@@ -219,14 +239,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Template root path
@@ -238,14 +260,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Partial root path
@@ -257,14 +281,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Template name for emails.
@@ -276,14 +302,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Redirect Mode
@@ -295,14 +323,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="bool"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        bool</code>
+        bool
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="bool"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Use First Supported Mode from Selection
@@ -314,14 +344,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="int"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        int</code>
+        int
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="int"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     After Successful Login Redirect to Page
@@ -333,14 +365,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="int"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        int</code>
+        int
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="int"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     After Failed Login Redirect to Page
@@ -352,14 +386,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="int"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        int</code>
+        int
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="int"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     After Logout Redirect to Page
@@ -371,14 +407,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="bool"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        bool</code>
+        bool
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="bool"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Disable Redirect
@@ -390,14 +428,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="int"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        int</code>
+        int
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="int"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Time in hours how long the link for forgot password is valid
@@ -409,14 +449,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Allowed Referrer-Redirect-Domains
@@ -428,14 +470,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="bool"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        bool</code>
+        bool
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="bool"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Expose existing users
@@ -447,14 +491,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Path to template root (frontend)
@@ -466,14 +512,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Path to template partials (frontend)
@@ -485,14 +533,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Path to template layouts (frontend)
@@ -557,26 +607,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="&quot;0&quot;"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        &quot;0&quot;</code>
+        &quot;0&quot;
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="&quot;0&quot;"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">User Storage Page
@@ -617,26 +671,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="&quot;0&quot;"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        &quot;0&quot;</code>
+        &quot;0&quot;
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="&quot;0&quot;"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Recursive
@@ -687,26 +745,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="bool"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        bool</code>
+        bool
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="bool"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="false"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        false</code>
+        false
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="false"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Display Password Recovery Link
@@ -747,26 +809,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="bool"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        bool</code>
+        bool
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="bool"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="false"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        false</code>
+        false
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="false"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Display Remember Login Option
@@ -807,26 +873,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="bool"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        bool</code>
+        bool
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="bool"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="false"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        false</code>
+        false
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="false"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Disable redirect after successful login, but display logout-form
@@ -867,14 +937,16 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Email Sender Address
@@ -915,14 +987,16 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Email Sender Name
@@ -963,14 +1037,16 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Reply-to email Address
@@ -1011,26 +1087,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline code-inline-long"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="&quot;Y-m-d H:i&quot;"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        &quot;Y-<wbr>m-<wbr>d H:<wbr>i&quot;</code>
+        &quot;Y-<wbr>m-<wbr>d H:<wbr>i&quot;
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="&quot;Y-m-d H:i&quot;"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Date format
@@ -1071,14 +1151,16 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Layout root path
@@ -1119,26 +1201,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline code-inline-long"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="&quot;EXT:felogin/Resources/Private/Email/Templates/&quot;"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        &quot;EXT:<wbr>felogin/<wbr>Resources/<wbr>Private/<wbr>Email/<wbr>Templates/&quot;</code>
+        &quot;EXT:<wbr>felogin/<wbr>Resources/<wbr>Private/<wbr>Email/<wbr>Templates/&quot;
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="&quot;EXT:felogin/Resources/Private/Email/Templates/&quot;"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Template root path
@@ -1179,14 +1265,16 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Partial root path
@@ -1227,26 +1315,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline code-inline-long"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="&quot;PasswordRecovery&quot;"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        &quot;Password<wbr>Recovery&quot;</code>
+        &quot;Password<wbr>Recovery&quot;
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="&quot;PasswordRecovery&quot;"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Template name for emails.
@@ -1287,14 +1379,16 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Redirect Mode
@@ -1335,26 +1429,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="bool"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        bool</code>
+        bool
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="bool"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="false"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        false</code>
+        false
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="false"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Use First Supported Mode from Selection
@@ -1395,26 +1493,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="int"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        int</code>
+        int
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="int"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="0"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        0</code>
+        0
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="0"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">After Successful Login Redirect to Page
@@ -1455,26 +1557,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="int"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        int</code>
+        int
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="int"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="0"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        0</code>
+        0
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="0"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">After Failed Login Redirect to Page
@@ -1515,26 +1621,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="int"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        int</code>
+        int
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="int"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="0"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        0</code>
+        0
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="0"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">After Logout Redirect to Page
@@ -1575,26 +1685,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="bool"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        bool</code>
+        bool
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="bool"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="false"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        false</code>
+        false
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="false"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Disable Redirect
@@ -1635,26 +1749,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="int"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        int</code>
+        int
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="int"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="12"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        12</code>
+        12
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="12"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Time in hours how long the link for forgot password is valid
@@ -1695,14 +1813,16 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Allowed Referrer-Redirect-Domains
@@ -1743,26 +1863,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="bool"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        bool</code>
+        bool
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="bool"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="false"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        false</code>
+        false
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="false"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Expose existing users
@@ -1803,14 +1927,16 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Path to template root (frontend)
@@ -1851,14 +1977,16 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Path to template partials (frontend)
@@ -1899,14 +2027,16 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Path to template layouts (frontend)

--- a/tests/Integration/tests/site-set-labels/expected/index.html
+++ b/tests/Integration/tests/site-set-labels/expected/index.html
@@ -29,14 +29,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     User Storage Page
@@ -48,14 +50,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Recursive
@@ -67,14 +71,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="bool"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        bool</code>
+        bool
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="bool"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Display Password Recovery Link
@@ -86,14 +92,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="bool"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        bool</code>
+        bool
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="bool"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Display Remember Login Option
@@ -105,14 +113,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="bool"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        bool</code>
+        bool
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="bool"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Disable redirect after successful login, but display logout-form
@@ -124,14 +134,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Email Sender Address
@@ -143,14 +155,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Email Sender Name
@@ -162,14 +176,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Reply-to email Address
@@ -181,14 +197,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Date format
@@ -200,14 +218,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Layout root path
@@ -219,14 +239,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Template root path
@@ -238,14 +260,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Partial root path
@@ -257,14 +281,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Template name for emails.
@@ -276,14 +302,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Redirect Mode
@@ -295,14 +323,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="bool"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        bool</code>
+        bool
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="bool"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Use First Supported Mode from Selection
@@ -314,14 +344,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="int"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        int</code>
+        int
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="int"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     After Successful Login Redirect to Page
@@ -333,14 +365,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="int"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        int</code>
+        int
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="int"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     After Failed Login Redirect to Page
@@ -352,14 +386,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="int"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        int</code>
+        int
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="int"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     After Logout Redirect to Page
@@ -371,14 +407,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="bool"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        bool</code>
+        bool
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="bool"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Disable Redirect
@@ -390,14 +428,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="int"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        int</code>
+        int
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="int"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Time in hours how long the link for forgot password is valid
@@ -409,14 +449,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Allowed Referrer-Redirect-Domains
@@ -428,14 +470,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="bool"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        bool</code>
+        bool
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="bool"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Expose existing users
@@ -447,14 +491,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Path to template root (frontend)
@@ -466,14 +512,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Path to template partials (frontend)
@@ -485,14 +533,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Path to template layouts (frontend)
@@ -557,26 +607,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="&quot;0&quot;"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        &quot;0&quot;</code>
+        &quot;0&quot;
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="&quot;0&quot;"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">User Storage Page
@@ -617,26 +671,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="&quot;0&quot;"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        &quot;0&quot;</code>
+        &quot;0&quot;
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="&quot;0&quot;"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Recursive
@@ -687,26 +745,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="bool"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        bool</code>
+        bool
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="bool"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="false"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        false</code>
+        false
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="false"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Display Password Recovery Link
@@ -747,26 +809,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="bool"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        bool</code>
+        bool
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="bool"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="false"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        false</code>
+        false
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="false"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Display Remember Login Option
@@ -807,26 +873,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="bool"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        bool</code>
+        bool
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="bool"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="false"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        false</code>
+        false
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="false"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Disable redirect after successful login, but display logout-form
@@ -867,14 +937,16 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Email Sender Address
@@ -915,14 +987,16 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Email Sender Name
@@ -963,14 +1037,16 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Reply-to email Address
@@ -1011,26 +1087,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline code-inline-long"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="&quot;Y-m-d H:i&quot;"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        &quot;Y-<wbr>m-<wbr>d H:<wbr>i&quot;</code>
+        &quot;Y-<wbr>m-<wbr>d H:<wbr>i&quot;
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="&quot;Y-m-d H:i&quot;"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Date format
@@ -1071,14 +1151,16 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Layout root path
@@ -1119,26 +1201,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline code-inline-long"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="&quot;EXT:felogin/Resources/Private/Email/Templates/&quot;"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        &quot;EXT:<wbr>felogin/<wbr>Resources/<wbr>Private/<wbr>Email/<wbr>Templates/&quot;</code>
+        &quot;EXT:<wbr>felogin/<wbr>Resources/<wbr>Private/<wbr>Email/<wbr>Templates/&quot;
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="&quot;EXT:felogin/Resources/Private/Email/Templates/&quot;"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Template root path
@@ -1179,14 +1265,16 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Partial root path
@@ -1227,26 +1315,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline code-inline-long"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="&quot;PasswordRecovery&quot;"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        &quot;Password<wbr>Recovery&quot;</code>
+        &quot;Password<wbr>Recovery&quot;
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="&quot;PasswordRecovery&quot;"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Template name for emails.
@@ -1287,14 +1379,16 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Redirect Mode
@@ -1335,26 +1429,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="bool"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        bool</code>
+        bool
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="bool"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="false"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        false</code>
+        false
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="false"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Use First Supported Mode from Selection
@@ -1395,26 +1493,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="int"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        int</code>
+        int
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="int"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="0"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        0</code>
+        0
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="0"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">After Successful Login Redirect to Page
@@ -1455,26 +1557,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="int"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        int</code>
+        int
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="int"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="0"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        0</code>
+        0
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="0"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">After Failed Login Redirect to Page
@@ -1515,26 +1621,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="int"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        int</code>
+        int
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="int"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="0"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        0</code>
+        0
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="0"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">After Logout Redirect to Page
@@ -1575,26 +1685,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="bool"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        bool</code>
+        bool
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="bool"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="false"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        false</code>
+        false
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="false"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Disable Redirect
@@ -1635,26 +1749,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="int"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        int</code>
+        int
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="int"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="12"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        12</code>
+        12
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="12"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Time in hours how long the link for forgot password is valid
@@ -1695,14 +1813,16 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Allowed Referrer-Redirect-Domains
@@ -1743,26 +1863,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="bool"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        bool</code>
+        bool
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="bool"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="false"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        false</code>
+        false
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="false"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Expose existing users
@@ -1803,14 +1927,16 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Path to template root (frontend)
@@ -1851,14 +1977,16 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Path to template partials (frontend)
@@ -1899,14 +2027,16 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Path to template layouts (frontend)

--- a/tests/Integration/tests/site-set/expected/index.html
+++ b/tests/Integration/tests/site-set/expected/index.html
@@ -29,14 +29,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     User Storage Page
@@ -48,14 +50,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Recursive
@@ -67,14 +71,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="bool"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        bool</code>
+        bool
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="bool"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Display Password Recovery Link
@@ -86,14 +92,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="bool"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        bool</code>
+        bool
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="bool"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Display Remember Login Option
@@ -105,14 +113,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="bool"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        bool</code>
+        bool
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="bool"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Disable redirect after successful login, but display logout-form
@@ -124,14 +134,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Email Sender Address
@@ -143,14 +155,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Email Sender Name
@@ -162,14 +176,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Reply-to email Address
@@ -181,14 +197,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Date format
@@ -200,14 +218,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Layout root path
@@ -219,14 +239,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Template root path
@@ -238,14 +260,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Partial root path
@@ -257,14 +281,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Template name for emails.
@@ -276,14 +302,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Redirect Mode
@@ -295,14 +323,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="bool"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        bool</code>
+        bool
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="bool"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Use First Supported Mode from Selection
@@ -314,14 +344,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="int"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        int</code>
+        int
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="int"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     After Successful Login Redirect to Page
@@ -333,14 +365,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="int"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        int</code>
+        int
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="int"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     After Failed Login Redirect to Page
@@ -352,14 +386,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="int"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        int</code>
+        int
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="int"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     After Logout Redirect to Page
@@ -371,14 +407,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="bool"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        bool</code>
+        bool
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="bool"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Disable Redirect
@@ -390,14 +428,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="int"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        int</code>
+        int
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="int"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Time in hours how long the link for forgot password is valid
@@ -409,14 +449,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Allowed Referrer-Redirect-Domains
@@ -428,14 +470,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="bool"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        bool</code>
+        bool
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="bool"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Expose existing users
@@ -447,14 +491,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Path to template root (frontend)
@@ -466,14 +512,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Path to template partials (frontend)
@@ -485,14 +533,16 @@
                     <td>
                             <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </td>
                     <td>
                                     Path to template layouts (frontend)
@@ -557,26 +607,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="&quot;0&quot;"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        &quot;0&quot;</code>
+        &quot;0&quot;
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="&quot;0&quot;"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">User Storage Page
@@ -617,26 +671,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="&quot;0&quot;"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        &quot;0&quot;</code>
+        &quot;0&quot;
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="&quot;0&quot;"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Recursive
@@ -687,26 +745,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="bool"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        bool</code>
+        bool
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="bool"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="false"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        false</code>
+        false
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="false"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Display Password Recovery Link
@@ -747,26 +809,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="bool"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        bool</code>
+        bool
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="bool"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="false"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        false</code>
+        false
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="false"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Display Remember Login Option
@@ -807,26 +873,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="bool"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        bool</code>
+        bool
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="bool"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="false"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        false</code>
+        false
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="false"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Disable redirect after successful login, but display logout-form
@@ -867,14 +937,16 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Email Sender Address
@@ -915,14 +987,16 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Email Sender Name
@@ -963,14 +1037,16 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Reply-to email Address
@@ -1011,26 +1087,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline code-inline-long"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="&quot;Y-m-d H:i&quot;"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        &quot;Y-<wbr>m-<wbr>d H:<wbr>i&quot;</code>
+        &quot;Y-<wbr>m-<wbr>d H:<wbr>i&quot;
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="&quot;Y-m-d H:i&quot;"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Date format
@@ -1071,14 +1151,16 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Layout root path
@@ -1119,26 +1201,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline code-inline-long"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="&quot;EXT:felogin/Resources/Private/Email/Templates/&quot;"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        &quot;EXT:<wbr>felogin/<wbr>Resources/<wbr>Private/<wbr>Email/<wbr>Templates/&quot;</code>
+        &quot;EXT:<wbr>felogin/<wbr>Resources/<wbr>Private/<wbr>Email/<wbr>Templates/&quot;
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="&quot;EXT:felogin/Resources/Private/Email/Templates/&quot;"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Template root path
@@ -1179,14 +1265,16 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Partial root path
@@ -1227,26 +1315,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline code-inline-long"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="&quot;PasswordRecovery&quot;"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        &quot;Password<wbr>Recovery&quot;</code>
+        &quot;Password<wbr>Recovery&quot;
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="&quot;PasswordRecovery&quot;"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Template name for emails.
@@ -1287,14 +1379,16 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Redirect Mode
@@ -1335,26 +1429,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="bool"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        bool</code>
+        bool
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="bool"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="false"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        false</code>
+        false
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="false"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Use First Supported Mode from Selection
@@ -1395,26 +1493,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="int"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        int</code>
+        int
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="int"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="0"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        0</code>
+        0
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="0"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">After Successful Login Redirect to Page
@@ -1455,26 +1557,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="int"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        int</code>
+        int
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="int"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="0"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        0</code>
+        0
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="0"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">After Failed Login Redirect to Page
@@ -1515,26 +1621,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="int"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        int</code>
+        int
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="int"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="0"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        0</code>
+        0
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="0"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">After Logout Redirect to Page
@@ -1575,26 +1685,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="bool"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        bool</code>
+        bool
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="bool"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="false"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        false</code>
+        false
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="false"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Disable Redirect
@@ -1635,26 +1749,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="int"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        int</code>
+        int
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="int"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="12"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        12</code>
+        12
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="12"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Time in hours how long the link for forgot password is valid
@@ -1695,14 +1813,16 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Allowed Referrer-Redirect-Domains
@@ -1743,26 +1863,30 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="bool"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        bool</code>
+        bool
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="bool"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                             <dt class="field-odd">Default</dt>
                         <dd class="field-odd"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="false"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        false</code>
+        false
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="false"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Expose existing users
@@ -1803,14 +1927,16 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Path to template root (frontend)
@@ -1851,14 +1977,16 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Path to template partials (frontend)
@@ -1899,14 +2027,16 @@
                                             <dt class="field-even">Type</dt>
                         <dd class="field-even"><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="string"
-          data-shortdescription=""
-          data-details=""
-          data-morelink=""          data-bs-html="true"
     >
-        string</code>
+        string
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="string"
+                data-shortdescription=""
+                data-details=""                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code>
                         </dd>
                                                 <dt class="field-even">Label</dt>
                             <dd class="field-even">Path to template layouts (frontend)

--- a/tests/Integration/tests/typo3-file/expected/index.html
+++ b/tests/Integration/tests/typo3-file/expected/index.html
@@ -184,17 +184,19 @@ included for all pages.</p>
                     <dd class="field-odd">
     <p><code class="code-inline code-inline-long"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="$GLOBALS[&#039;TYPO3_CONF_VARS&#039;][&#039;BE&#039;][&#039;lockBackendFile&#039;]"
-          data-shortdescription="Global PHP configuration"
-          data-details="The main configuration is achieved via a set of global
+    >
+        $GLOBALS<wbr>[&#039;TYPO3_<wbr>CONF_<wbr>VARS&#039;]<wbr>[&#039;BE&#039;]<wbr>[&#039;lock<wbr>Backend<wbr>File&#039;]
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="$GLOBALS[&#039;TYPO3_CONF_VARS&#039;][&#039;BE&#039;][&#039;lockBackendFile&#039;]"
+                data-shortdescription="Global PHP configuration"
+                data-details="The main configuration is achieved via a set of global
                 settings stored in a global array called $GLOBALS['TYPO3_CONF_VARS'].
                 They are commonly set in config/system/settings.php, config/system/additional.php,
-                or the ext_localconf.php file of an extension. "
-          data-morelink="https://docs.typo3.org/m/typo3/reference-coreapi/14.3/en-us/Configuration/Typo3ConfVars/Index.html"          data-bs-html="true"
-    >
-        $GLOBALS<wbr>[&#039;TYPO3_<wbr>CONF_<wbr>VARS&#039;]<wbr>[&#039;BE&#039;]<wbr>[&#039;lock<wbr>Backend<wbr>File&#039;]            <span class="text-secondary"><i class="fa-regular fa-circle-question"></i></span></code></p>
+                or the ext_localconf.php file of an extension. "                    data-morelink="https://docs.typo3.org/m/typo3/reference-coreapi/14.3/en-us/Configuration/Typo3ConfVars/Index.html"                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code></p>
 </dd>
                                     <dt class="field-odd">Command</dt>
                     <dd class="field-odd">

--- a/tests/Integration/tests/viewhelper/viewhelper-all/expected/index.html
+++ b/tests/Integration/tests/viewhelper/viewhelper-all/expected/index.html
@@ -21,14 +21,16 @@ the last item contains the remaining unsplit string.</p>
 
     <p>This ViewHelper mimicks PHP&#039;s <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="explode()"
-          data-shortdescription="Code written in PHP"
-          data-details="Dynamic server-side scripting language."
-          data-morelink=""          data-bs-html="true"
     >
-        explode<wbr>()</code> function.</p>
+        explode<wbr>()
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="explode()"
+                data-shortdescription="Code written in PHP"
+                data-details="Dynamic server-side scripting language."                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code> function.</p>
 
     <p>The following examples store the result in a variable because an array cannot
 be outputted directly in a template.</p>
@@ -240,14 +242,16 @@ the last item contains the remaining unsplit string.</p>
 
     <p>This ViewHelper mimicks PHP&#039;s <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="explode()"
-          data-shortdescription="Code written in PHP"
-          data-details="Dynamic server-side scripting language."
-          data-morelink=""          data-bs-html="true"
     >
-        explode<wbr>()</code> function.</p>
+        explode<wbr>()
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="explode()"
+                data-shortdescription="Code written in PHP"
+                data-details="Dynamic server-side scripting language."                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code> function.</p>
 
     <p>The following examples store the result in a variable because an array cannot
 be outputted directly in a template.</p>

--- a/tests/Integration/tests/viewhelper/viewhelper-parts/expected/index.html
+++ b/tests/Integration/tests/viewhelper/viewhelper-parts/expected/index.html
@@ -33,14 +33,16 @@ the last item contains the remaining unsplit string.</p>
 
     <p>This ViewHelper mimicks PHP&#039;s <code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="explode()"
-          data-shortdescription="Code written in PHP"
-          data-details="Dynamic server-side scripting language."
-          data-morelink=""          data-bs-html="true"
     >
-        explode<wbr>()</code> function.</p>
+        explode<wbr>()
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="explode()"
+                data-shortdescription="Code written in PHP"
+                data-details="Dynamic server-side scripting language."                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code> function.</p>
 
     <p>The following examples store the result in a variable because an array cannot
 be outputted directly in a template.</p>


### PR DESCRIPTION
[FEATURE] Open inline-code information-modal via dedicated button

This allows for normal selection of the inline-code without
opening the information-modal.

Using a HTML button together with aria-label allows for improved
accessibility.

Breaking: Changing to a separate button requires it to be visible
unconditionally for the modal to be openable.
Places where the "question"-icon was previously not displayed, will
now show it. The previous check for node.info.url got removed in order
to have an open-button present.

---

Can be tested/ verified on https://render-guides-rendertest.ddev.site/PhpInline/Index.html.

<img width="551" height="81" alt="image" src="https://github.com/user-attachments/assets/d1750d67-0ae1-4702-a1e6-2c7c7fde1700" />
<img width="547" height="89" alt="image" src="https://github.com/user-attachments/assets/246fb762-30ce-4d75-b09f-4657452dadb0" />
<img width="530" height="601" alt="image" src="https://github.com/user-attachments/assets/8f7c4bea-a504-4919-abcc-4b47c5e18c04" />
