### PR TITLE
[BUGFIX] Regenerate code-php-short fixture for modal-button markup

### DIFF
--- a/tests/Integration/tests/code/code-php-short/expected/index.html
+++ b/tests/Integration/tests/code/code-php-short/expected/index.html
@@ -1,30 +1,34 @@
-        <!-- content start -->
+<!-- content start -->
                 <section class="section" id="php-short">
             <h1>PHP Short<a class="headerlink" href="#php-short" data-bs-toggle="modal" data-bs-target="#linkReferenceModal"  title="Reference this headline">&nbsp;<i class="fa-solid fa-link"></i></a></h1>
-            
+
 
 <ul>
     <li><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="FooBar"
-          data-shortdescription="PHP class or interface"
-          data-details="PHP classes in this namespace are commonly used as examples. Replace with your own vendor and namespace on implementation. "
-          data-morelink=""          data-bs-html="true"
     >
-        Foo<wbr>Bar</code></li>
+        Foo<wbr>Bar
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="FooBar"
+                data-shortdescription="PHP class or interface"
+                data-details="PHP classes in this namespace are commonly used as examples. Replace with your own vendor and namespace on implementation. "                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code></li>
     <li><code class="code-inline"
           translate="no"
-          data-bs-toggle="modal"
-          data-bs-target="#generalModal"
-          data-code="Something"
-          data-shortdescription="PHP class or interface"
-          data-details="This is a fully-qualified class or interface name,
-            try searching for \Foo\Bar\Something in the internet."
-          data-morelink=""          data-bs-html="true"
     >
-        Something</code></li>
+        Something
+        <button class="btn btn-light"
+                aria-label="Open modal for code and class information"
+                data-bs-toggle="modal"
+                data-bs-target="#generalModal"
+                data-code="Something"
+                data-shortdescription="PHP class or interface"
+                data-details="This is a fully-qualified class or interface name,
+            try searching for \Foo\Bar\Something in the internet."                data-bs-html="true"
+        ><i class="fa-regular fa-circle-question"></i></button></code></li>
 </ul>
 
     </section>


### PR DESCRIPTION
## Problem

Integration tests on `main` fail since 50146a4bfb22b05da02dcfc0da938e2d05cd2e47:

```
1) ...IntegrationTest::testHtmlIntegrationBetweenMarkers with data set "code-php-short"
Failed asserting that two strings are equal.
```

Every open PR inherits this failure via the merge ref (e.g. #1291, #1292).

## Cause

#1294 added the `code-php-short` test with expected output generated before #1305 changed `code.html.twig` (information modal now opened via a dedicated button; `data-morelink` only emitted for a non-empty URL). Both PRs were green individually and merged past each other today.

## Fix

Regenerate the fixture via `make integration-baseline` — only `tests/Integration/tests/code/code-php-short/expected/index.html` changes. The `php-short` rendering itself is unaffected: names remain stripped of the leading backslash (`FooBar`, `Something`).

Integration suite local result: `Tests: 115, Assertions: 1150` — no failures.
