### PR TITLE
[TASK] Add merge_group trigger for merge queue

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -5,11 +5,18 @@ on: # yamllint disable-line rule:truthy
   push:
     branches:
       - "main"
+  # Required for the merge queue on "main": without this trigger, queued
+  # merges never receive their required status checks and time out.
+  merge_group: null
 
 env:
   DEFAULT_PHP_VERSION: "8.2"
   RUN_ENVIRONMENT: "local"
 
+# The job names below ("Tests (8.x)", "Quality", ...) are configured as
+# required status checks for the merge queue on "main". Renaming a job or
+# changing how its checks are reported requires updating the branch ruleset
+# in the same change, or the merge queue will block all merges.
 jobs:
   tests:
     name : Tests


### PR DESCRIPTION
## What

Adds the `merge_group` event trigger to the Main workflow and documents that its job names are the merge queue's required-check contexts.

## Why

Follow-up to the team decision to trial a merge queue on this repository (and only this one). Background: #1294 was merged with checks that predated #1305's template change, breaking `main` until #1324 — the class of failure a merge queue prevents by re-running checks against current `main` before each merge.

Without this trigger, checks never run for queued merges and every merge group times out, so this must land **before** the queue is enabled.

## Next steps (after this PR merges)

1. Branch ruleset on `main`: merge queue (squash, all-entries-green) + the seven Main checks as required status checks; classic "require branches to be up to date" flag dropped as redundant.
2. Trial with a real PR and a Dependabot PR, results reported back to the team.

A decision record for the trial (scope: this repo only, not org-wide) is proposed in TYPO3-Documentation/.github.

## Note for #1196

The reusable-workflows migration rewrites this workflow's `on:` block and renames the reported check contexts. It must keep the `merge_group` trigger and update the ruleset's required-check contexts in the same merge window, otherwise the queue blocks all merges.