### PR TITLE
[DOCS] Document merge-queue workflow for contributors

### DIFF
--- a/Documentation/Developer/Contributing.rst
+++ b/Documentation/Developer/Contributing.rst
@@ -37,3 +37,18 @@ these checks are performed before any Git commit:
 
 Those Git hooks will also check your commit message for line length.
 
+Merging pull requests
+=====================
+
+Pull requests into ``main`` are merged through a `merge queue
+<https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/merging-a-pull-request-with-a-merge-queue>`__:
+instead of merging directly, use :guilabel:`Merge when ready`. The queue
+re-runs the required checks against the latest ``main`` before merging, so a
+pull request whose checks were green against an older ``main`` cannot break
+the branch. If the checks of a queued pull request fail, the pull request is
+removed from the queue and only that pull request is blocked.
+
+See `ADR-004
+<https://github.com/TYPO3-Documentation/.github/blob/main/Documentation/Decisions/ADR-004-MergeQueues.rst>`__
+for the decision and its scope.
+


### PR DESCRIPTION
Adds a "Merging pull requests" section to `Documentation/Developer/Contributing.rst`: pull requests into `main` merge through a merge queue ("Merge when ready"), what the queue does, and a link to the decision record (TYPO3-Documentation/.github#22, ADR-004).

**Merge timing:** the described behavior only becomes true once the merge queue is enabled — please merge this together with (or after) the settings flip that follows #1326. The ADR link points to a file that lands with TYPO3-Documentation/.github#22.