### PR TITLE
[TASK] Add version comments to SHA-pinned GitHub Actions

### DIFF
--- a/.github/workflows/deploy-azure-assets.yaml
+++ b/.github/workflows/deploy-azure-assets.yaml
@@ -18,7 +18,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Get the version
         id: get-version

--- a/.github/workflows/docker-test.yaml
+++ b/.github/workflows/docker-test.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: "Checkout"
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: "Prepare action (adjust configure-guides-step)"
         ##################################################################

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -24,7 +24,7 @@ jobs:
           - linux/amd64
           - linux/arm64
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Prepare image name
         run: |
@@ -35,7 +35,7 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -46,24 +46,24 @@ jobs:
             type=semver,pattern={{major}}
 
       - name: Log in to the Container registry
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Build and push
         id: build
         env:
           TYPO3AZUREEDGEURIVERSION: ${{ env.DOCKER_METADATA_OUTPUT_VERSION }}
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}
@@ -81,7 +81,7 @@ jobs:
           touch "/tmp/digests/${digest#sha256:}"
       -
         name: Upload digest
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: digests-${{ env.PLATFORM_NAME }}
           overwrite: true
@@ -101,18 +101,18 @@ jobs:
 
       -
         name: Download digests
-        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3
+        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
         with:
           pattern: digests-*
           merge-multiple: true
           path: /tmp/digests
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
       -
         name: Docker meta
         id: meta
-        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -122,7 +122,7 @@ jobs:
             type=raw,value=latest,enable=true
 
       - name: Log in to the Container registry
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/pr-auto-approve.yaml
+++ b/.github/workflows/pr-auto-approve.yaml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7
+        uses: dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7 # v2.3.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/pr-auto-merge.yaml
+++ b/.github/workflows/pr-auto-merge.yaml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7
+        uses: dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7 # v2.3.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/split-repositories.yaml
+++ b/.github/workflows/split-repositories.yaml
@@ -20,22 +20,22 @@ jobs:
     runs-on: "ubuntu-latest"
     name: "Publish Sub-split"
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: "0"
           persist-credentials: "false"
-      - uses: frankdejonge/use-github-token@15e6289d07c12b3b1603268a628bb74f2e9765f4
+      - uses: frankdejonge/use-github-token@15e6289d07c12b3b1603268a628bb74f2e9765f4 # 1.1.0
         with:
           authentication: "typo3-documentation-team:${{ secrets.BOT_TOKEN }}"
           user_name: "TYPO3 Documentation Team"
           user_email: "documentation-automation@typo3.com"
       - name: "Cache splitsh-lite"
         id: "splitsh-cache"
-        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: "./.splitsh"
           key: "${{ runner.os }}-splitsh-d-101"
-      - uses: frankdejonge/use-subsplit-publish@0001015147267203898034927e8cccad3a7a9aa7
+      - uses: frankdejonge/use-subsplit-publish@0001015147267203898034927e8cccad3a7a9aa7 # 1.1.0
         with:
           source-branch: "main"
           config-path: "./config.subsplit-publish.json"


### PR DESCRIPTION
First part of the #1184 split (as suggested by @linawolf there and agreed in the team chat).

Since #1184 was opened, all actions in these six workflows have already been SHA-pinned on `main` — what remains of the pinning half is the audit trail. This PR annotates every pinned SHA with its release tag, **without changing any version**:

| Action | Pinned SHA resolves to |
|---|---|
| actions/checkout | v6.0.2 |
| actions/cache | v5.0.3 |
| actions/upload-artifact | v7.0.0 |
| actions/download-artifact | v8.0.0 |
| dependabot/fetch-metadata | v2.3.0 |
| docker/build-push-action | v7.0.0 |
| docker/login-action | v4.0.0 |
| docker/metadata-action | v6.0.0 |
| docker/setup-buildx-action | v4.0.0 |
| docker/setup-qemu-action | v4.0.0 |
| frankdejonge/use-github-token | 1.1.0 |
| frankdejonge/use-subsplit-publish | 1.1.0 |

Each SHA→tag mapping was resolved via the GitHub API (`repos/<action>/tags`), so the comments are verified, not copied.

`main.yaml` is untouched — it belongs to #1196.

The second part (version updates with a per-action risk table, as requested by @sbuerk) follows as a separate PR stacked on this one.