### PR TITLE
[TASK] Update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/deploy-azure-assets.yaml
+++ b/.github/workflows/deploy-azure-assets.yaml
@@ -18,7 +18,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Get the version
         id: get-version

--- a/.github/workflows/docker-test.yaml
+++ b/.github/workflows/docker-test.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: "Checkout"
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: "Prepare action (adjust configure-guides-step)"
         ##################################################################

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -24,7 +24,7 @@ jobs:
           - linux/amd64
           - linux/arm64
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Prepare image name
         run: |
@@ -35,7 +35,7 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -46,24 +46,24 @@ jobs:
             type=semver,pattern={{major}}
 
       - name: Log in to the Container registry
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Build and push
         id: build
         env:
           TYPO3AZUREEDGEURIVERSION: ${{ env.DOCKER_METADATA_OUTPUT_VERSION }}
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}
@@ -81,7 +81,7 @@ jobs:
           touch "/tmp/digests/${digest#sha256:}"
       -
         name: Upload digest
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: digests-${{ env.PLATFORM_NAME }}
           overwrite: true
@@ -101,18 +101,18 @@ jobs:
 
       -
         name: Download digests
-        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: digests-*
           merge-multiple: true
           path: /tmp/digests
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
       -
         name: Docker meta
         id: meta
-        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -122,7 +122,7 @@ jobs:
             type=raw,value=latest,enable=true
 
       - name: Log in to the Container registry
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/pr-auto-approve.yaml
+++ b/.github/workflows/pr-auto-approve.yaml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7 # v2.3.0
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/pr-auto-merge.yaml
+++ b/.github/workflows/pr-auto-merge.yaml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7 # v2.3.0
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/split-repositories.yaml
+++ b/.github/workflows/split-repositories.yaml
@@ -20,7 +20,7 @@ jobs:
     runs-on: "ubuntu-latest"
     name: "Publish Sub-split"
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: "0"
           persist-credentials: "false"
@@ -31,7 +31,7 @@ jobs:
           user_email: "documentation-automation@typo3.com"
       - name: "Cache splitsh-lite"
         id: "splitsh-cache"
-        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: "./.splitsh"
           key: "${{ runner.os }}-splitsh-d-101"


### PR DESCRIPTION
Second part of the #1184 split — version updates only, stacked on #1328 so this diff shows nothing but version changes. GitHub retargets it to `main` automatically once #1328 merges (I'll rebase away the inherited commit then).

Every new SHA was resolved and cross-checked against the GitHub API for its tag. `main.yaml` is untouched (belongs to #1196) — note this leaves its three `actions/cache` pins at v5.0.3 until #1196 lands.

## Per-action risk assessment

| Action | From → To | Semver | Breaking / notable changes | Risk for our usage |
|---|---|---|---|---|
| [actions/checkout](https://github.com/actions/checkout/releases/tag/v7.0.0) | v6.0.2 → v7.0.0 | **major** | Blocks checking out fork PRs in `pull_request_target`/`workflow_run` contexts ([#2454](https://github.com/actions/checkout/pull/2454)); ESM migration | **None** — our only `pull_request_target` workflow (`pr-auto-merge.yaml`) has no checkout step; all checkout usages run on push/tag/PR events |
| [actions/cache](https://github.com/actions/cache/releases/tag/v6.0.0) | v5.0.3 → v6.1.0 | **major** | ESM migration ([#1760](https://github.com/actions/cache/pull/1760)); v6.1.0 adds read-only cache handling | **Low** — plain `path`+`key` usage in `split-repositories.yaml`, no interface change |
| [dependabot/fetch-metadata](https://github.com/dependabot/fetch-metadata/releases/tag/v3.0.0) | v2.3.0 → v3.1.0 | **major** | Declared breaking change: requires Node 24 runtime ([#671](https://github.com/dependabot/fetch-metadata/pull/671)) | **None** — `ubuntu-latest` provides Node 24; the `github-token` input and `update-type` output we use are unchanged |
| [docker/build-push-action](https://github.com/docker/build-push-action/compare/d08e5c3...53b7df9) | v7.0.0 → v7.3.0 | minor | — | Low |
| [docker/login-action](https://github.com/docker/login-action/compare/b45d80f...af1e73f) | v4.0.0 → v4.4.0 | minor | — | Low |
| [docker/metadata-action](https://github.com/docker/metadata-action/compare/030e881...dc80280) | v6.0.0 → v6.2.0 | minor | — | Low |
| [docker/setup-buildx-action](https://github.com/docker/setup-buildx-action/compare/4d04d5d...bb05f3f) | v4.0.0 → v4.2.0 | minor | — | Low |
| [docker/setup-qemu-action](https://github.com/docker/setup-qemu-action/compare/ce36039...96fe6ef) | v4.0.0 → v4.2.0 | minor | — | Low |
| [actions/upload-artifact](https://github.com/actions/upload-artifact/releases/tag/v7.0.1) | v7.0.0 → v7.0.1 | patch | docs + typespec runtime fix | None |
| [actions/download-artifact](https://github.com/actions/download-artifact/releases/tag/v8.0.1) | v8.0.0 → v8.0.1 | patch | CJK artifact-name support | None |

`frankdejonge/use-github-token` and `use-subsplit-publish` stay at 1.1.0 — that is their latest release. (Their Node 20 deprecation warning in `Publish Sub-split` cannot be fixed by any bump; upstream has no Node 24 build yet.)

## Verification limits

PR CI cannot exercise most of these workflows: `docker.yaml`, `deploy-azure-assets.yaml` run on tag/release only; `split-repositories.yaml` on push to `main`; `docker-test.yaml` only on `Dockerfile` changes; the two `pr-auto-*` workflows on Dependabot PRs. First real exercise is the next release/tag and the next Dependabot PR.

Follow-up worth considering (not in this PR): add a `github-actions` ecosystem to `.github/dependabot.yml` so these pins stay current automatically.