### PR TITLE
[TASK] Enable Dependabot updates for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,3 +32,14 @@ updates:
     labels:
       - "dependencies"
       - "npm"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "16:00"
+      timezone: "Europe/Berlin"
+    commit-message:
+      prefix: "[TASK]"
+    labels:
+      - "dependencies"
+      - "github-actions"


### PR DESCRIPTION
Adds a `github-actions` package ecosystem to `dependabot.yml`, using the same schedule and conventions as the existing composer and npm entries (daily 16:00 Europe/Berlin, `[TASK]` prefix, `dependencies` + ecosystem label — the `github-actions` label has been created).

## Why

Action versions in the workflows have only ever been updated by hand — `dependabot.yml` has covered composer and npm exclusively since it was created in #236, and the pins were last refreshed manually (#1194, then the #1184 → #1328/#1329 split). With this entry, Dependabot takes that over: it bumps SHA pins **and keeps the trailing `# vX.Y.Z` comments in sync** (see e.g. the actions bumps in TYPO3-Documentation/.github#19, same org).

Minor/patch action bumps then flow through the existing auto-approve/auto-merge workflows like composer/npm updates already do; majors wait for review.

## Coordination

- Trivial textual conflict with #1265, which also edits `dependabot.yml` (composer `ignore` key fix) — whichever lands second rebases.
- Best merged after #1328/#1329 so Dependabot starts from current, annotated pins rather than re-proposing the same bumps.