### PR TITLE
[BUGFIX] Update integration fixtures for escaped code role attributes

### DIFF
--- a/tests/Integration/tests-full/changelog/expected/Changelog/12.0/Breaking-87616-RemovedHookForAlteringPageLinks.html
+++ b/tests/Integration/tests-full/changelog/expected/Changelog/12.0/Breaking-87616-RemovedHookForAlteringPageLinks.html
@@ -215,7 +215,7 @@
                 data-code="$GLOBALS[&#039;TYPO3_CONF_VARS&#039;][&#039;SC_OPTIONS&#039;][&#039;typolinkProcessing&#039;][&#039;typolinkModifyParameterForPageLinks&#039;]"
                 data-shortdescription="Global PHP configuration"
                 data-details="The main configuration is achieved via a set of global
-                settings stored in a global array called $GLOBALS['TYPO3_CONF_VARS'].
+                settings stored in a global array called $GLOBALS[&#039;TYPO3_CONF_VARS&#039;].
                 They are commonly set in config/system/settings.php, config/system/additional.php,
                 or the ext_localconf.php file of an extension. "                    data-morelink="https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/Configuration/Typo3ConfVars/Index.html"                data-bs-html="true"
         ><i class="fa-regular fa-circle-question"></i></button></code>
@@ -229,7 +229,7 @@ has been removed in favor of a new PSR-14 event <code class="code-inline code-in
                 data-bs-target="#generalModal"
                 data-code="\TYPO3\CMS\Frontend\Event\ModifyPageLinkConfigurationEvent"
                 data-shortdescription="PHP class"
-                data-details="<code>final class ModifyPageLinkConfigurationEvent</code><br><em>A generic PSR 14 Event to allow modifying the incoming (and resolved) page when building a &quot;page link&quot;.</em>"                    data-morelink="https://api.typo3.org/main/classes/TYPO3-CMS-Frontend-Event-ModifyPageLinkConfigurationEvent.html"                    data-fqn="\TYPO3\CMS\Frontend\Event\ModifyPageLinkConfigurationEvent"                data-bs-html="true"
+                data-details="&lt;code&gt;final class ModifyPageLinkConfigurationEvent&lt;/code&gt;&lt;br&gt;&lt;em&gt;A generic PSR 14 Event to allow modifying the incoming (and resolved) page when building a &amp;quot;page link&amp;quot;.&lt;/em&gt;"                    data-morelink="https://api.typo3.org/main/classes/TYPO3-CMS-Frontend-Event-ModifyPageLinkConfigurationEvent.html"                    data-fqn="\TYPO3\CMS\Frontend\Event\ModifyPageLinkConfigurationEvent"                data-bs-html="true"
         ><i class="fa-regular fa-circle-question"></i></button></code>.</p>
 
             

--- a/tests/Integration/tests/typo3-file/expected/index.html
+++ b/tests/Integration/tests/typo3-file/expected/index.html
@@ -193,7 +193,7 @@ included for all pages.</p>
                 data-code="$GLOBALS[&#039;TYPO3_CONF_VARS&#039;][&#039;BE&#039;][&#039;lockBackendFile&#039;]"
                 data-shortdescription="Global PHP configuration"
                 data-details="The main configuration is achieved via a set of global
-                settings stored in a global array called $GLOBALS['TYPO3_CONF_VARS'].
+                settings stored in a global array called $GLOBALS[&#039;TYPO3_CONF_VARS&#039;].
                 They are commonly set in config/system/settings.php, config/system/additional.php,
                 or the ext_localconf.php file of an extension. "                    data-morelink="https://docs.typo3.org/m/typo3/reference-coreapi/14.3/en-us/Configuration/Typo3ConfVars/Index.html"                data-bs-html="true"
         ><i class="fa-regular fa-circle-question"></i></button></code></p>


### PR DESCRIPTION
`main` is red: the `Main` workflow fails on `Tests (8.2)` through `Tests (8.5)` since the three advisory merges this morning ([run 30148850398](https://github.com/TYPO3-Documentation/render-guides/actions/runs/30148850398)). `Quality`, `typo3-docs-theme JS tests` and `Validate monorepo structure` are green.

## Cause

ab24ff76 dropped the `|raw` filter in `packages/typo3-docs-theme/resources/template/inline/textroles/code.html.twig`:

```diff
-                data-shortdescription="{{ node.language|raw }}"
-                data-details="{{ node.helpText|raw }}"
+                data-shortdescription="{{ node.language }}"
+                data-details="{{ node.helpText }}"
```

Twig now escapes both values, so the rendered HTML changed. Two integration fixtures still carry the pre-escape output:

- `tests/Integration/tests/typo3-file/expected/index.html`
- `tests/Integration/tests-full/changelog/expected/Changelog/12.0/Breaking-87616-RemovedHookForAlteringPageLinks.html`

Three attribute values in total. A scan of all 138 `expected/*.html` files for `data-details` / `data-shortdescription` values containing `<`, `>` or `'` returns exactly these three, so the fixture set is fully covered.

## Change

The three values are updated to the escaped output, byte-identical to what the renderer produces. No template, no JS, no test code.

The escaping does not change what the modal JS receives: the values are read through `element.dataset`, which decodes the entities, and the modal escapes them again via `htmlEscape()` before assignment. Dropping `|raw` closes the attribute-breakout path — a `"` in `helpText` previously terminated the attribute.

## Verification

```
make test-integration ENV=local   Tests: 115, Assertions: 1150, Skipped: 2   OK
make test-unit ENV=local          OK (83 tests, 183 assertions)
```

Run on PHP 8.5.8 against `origin/main` (a22f55b9) plus this commit. `Quality` was already green on a22f55b9 and this change touches only two HTML fixtures.

## Follow-up, not in this PR

`data-details` carries markup from api.typo3.org (`<code>`, `<br>`, `<em>`) and pre-encoded entities (`&quot;`). Since ab24ff76 the modal escapes that content, so it now renders as literal text — the tooltip shows `<code>final class …</code>` and `&quot;` instead of formatted output. Restoring the formatting means sanitizing rather than escaping (like `resources/js/utils/sanitizeHtml.js` added in a22f55b9 for the search modal) and needs its own review.