### PR TITLE
Update Dependabot config to ignore PHPUnit 11.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,7 @@
 # https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 
 version: 2
+
 updates:
   - package-ecosystem: "composer"
     directory: "/"
@@ -10,16 +11,17 @@ updates:
       timezone: "Europe/Berlin"
     allow:
       - dependency-type: "development"
+    ignore:
+      - dependency-name: "phpunit/phpunit"
+        versions:
+          - "11.*" # Ignore PHPUnit 11.x versions
     versioning-strategy: "increase"
     commit-message:
       prefix: "[TASK]"
     labels:
       - "dependencies"
       - "composer"
-    ignored-updates:
-      - match:
-          dependency-name: "phpunit/phpunit"
-          versions: ["11.*"] # Ignore PHPUnit 11.x versions
+
   - package-ecosystem: "npm"
     directory: "/packages/typo3-docs-theme/"
     schedule:
@@ -32,6 +34,7 @@ updates:
     labels:
       - "dependencies"
       - "npm"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Corrected syntax for ignore rule for PHPUnit 11.x versions in Dependabot configuration.